### PR TITLE
[FIX] Don't include sourcemaps in prod.

### DIFF
--- a/build-lib/lib.js
+++ b/build-lib/lib.js
@@ -34,39 +34,46 @@ module.exports = function (pathConfig, env) {
     header: ';(function () {',
     headerFiles: ['loader.js'],
     inputFiles: ['**/*.js'],
-    footer: `window.ShopifyBuy = require('shopify-buy/shopify').default;
-    }());`,
-    outputFile: `${pkg.name}.globals.js`
+    footer: `
+window.ShopifyBuy = require('shopify-buy/shopify').default;
+}());`,
+    outputFile: `${pkg.name}.globals.js`,
+    sourceMapConfig: { enabled: (env !== 'production') }
   });
 
   if (env === 'production') {
     const amdOutput = concat(amdTree, {
       inputFiles: ['**/*.js'],
-      outputFile: `${pkg.name}.amd.js`
+      outputFile: `${pkg.name}.amd.js`,
+      sourceMapConfig: { enabled: false }
     });
 
     const polyFilledAmdOutput = concat(mergeTrees([amdOutput, polyfillTree]), {
       headerFiles: ['polyfills.js'],
       inputFiles: `${pkg.name}.amd.js`,
-      outputFile: `${pkg.name}.polyfilled.amd.js`
+      outputFile: `${pkg.name}.polyfilled.amd.js`,
+      sourceMapConfig: { enabled: false }
     });
 
     const polyFilledGlobalsOutput = concat(mergeTrees([globalsOutput, polyfillTree]), {
       headerFiles: ['polyfills.js'],
       inputFiles: `${pkg.name}.globals.js`,
-      outputFile: `${pkg.name}.polyfilled.globals.js`
+      outputFile: `${pkg.name}.polyfilled.globals.js`,
+      sourceMapConfig: { enabled: false }
     });
 
     const commonTree = sourceTree(pathConfig, 'common');
     const commonOutput = concat(commonTree, {
       inputFiles: ['**/*.js'],
-      outputFile: `${pkg.name}.common.js`
+      outputFile: `${pkg.name}.common.js`,
+      sourceMapConfig: { enabled: false }
     });
 
     const polyFilledCommonOutput = concat(mergeTrees([commonOutput, polyfillTree]), {
       headerFiles: ['polyfills.js'],
       inputFiles: `${pkg.name}.common.js`,
-      outputFile: `${pkg.name}.polyfilled.common.js`
+      outputFile: `${pkg.name}.polyfilled.common.js`,
+      sourceMapConfig: { enabled: false }
     });
 
     const nodeLibOutput = funnel(commonTree, {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "broccoli-asset-rev": "2.4.1",
     "broccoli-babel-transpiler": "5.5.0",
     "broccoli-cli": "1.0.0",
-    "broccoli-concat": "2.0.4",
+    "broccoli-concat": "2.2.0",
     "broccoli-env": "0.0.1",
     "broccoli-funnel": "1.0.1",
     "broccoli-lint-eslint": "1.2.0",


### PR DESCRIPTION
I'm not sure why, but sourcemaps with the prod flag set get appended as
whole files rather than URLs. This is probably a bug in broccoli-concat,
but this fixes the issue for now.
