### PR TITLE
add npm install to shipit task

### DIFF
--- a/shipit.yml
+++ b/shipit.yml
@@ -1,4 +1,5 @@
 deploy:
   override:
+    - npm install
     - ejson decrypt config/secrets.ejson > config/secrets.json
-    - scripts/deploy 
+    - scripts/deploy


### PR DESCRIPTION
adds npm install task, which will build the library so it can be deployed. @richgilbank @minasmart 
