### PR TITLE
[FIX] Don't coerce the subtotal to a string during reduce

### DIFF
--- a/src/models/cart-model.js
+++ b/src/models/cart-model.js
@@ -49,9 +49,11 @@ const CartModel = BaseModel.extend({
     * @type {String}
   */
   get subtotal() {
-    return this.lineItems.reduce((runningTotal, lineItem) => {
-      return (runningTotal + parseFloat(lineItem.line_price)).toFixed(2);
+    const subtotal = this.lineItems.reduce((runningTotal, lineItem) => {
+      return (runningTotal + parseFloat(lineItem.line_price));
     }, 0);
+
+    return subtotal.toFixed(2);
   },
 
   /**


### PR DESCRIPTION
Reduce was coercing the accumulator into a string, but reduce expected an float. Don't coerce into a string until we return.
