### PR TITLE
prefix s3 path with js-buy-sdk

### DIFF
--- a/scripts/deploy
+++ b/scripts/deploy
@@ -68,7 +68,7 @@ Uploader.prototype.getCurrentTag = function (cb) {
       console.error(err);
       cb();
     }
-    cb(stdout);
+    cb(stdout.trim());
   });
 };
 


### PR DESCRIPTION
results in url at http://sdks.shopifycdn.com/js-buy-sdk

strips whitespace from whatever gets returned from `git describe --always --tag --abbrev=0`

@richgilbank @wvanbergen 
