### PR TITLE
Adding the readme for the examples section

### DIFF
--- a/examples/cart/README.md
+++ b/examples/cart/README.md
@@ -1,0 +1,10 @@
+### JS Buy SDK Examples
+
+To run this example locally, you must first install the SDK's
+dependencies and start a server to serve these files from:
+
+```bash
+npm install && npm run examples
+```
+
+Once it's running, open your browser to `http://localhost:4200/examples/cart/` to view the example.

--- a/examples/cart/README.md
+++ b/examples/cart/README.md
@@ -8,3 +8,7 @@ npm install && npm run examples
 ```
 
 Once it's running, open your browser to `http://localhost:4200/examples/cart/` to view the example.
+The example works in Internet Explorer 9+, Safari 5.1+, iOS 6.1+,
+Android 4.0+ and modern (current - 1) Chrome, Firefox and Opera.
+
+Building the example requires Node.js 4.x+ and NPM 3.x+.


### PR DESCRIPTION
Adds a readme to the cart example directory since it wasn't documented anywhere previously: https://ecommerce.shopify.com/c/shopify-apis-and-technology/t/cart-example-not-working-334493

I think this is the right place to put this, but open to suggestions @tessalt @harismahmood89 