### PR TITLE
Fix line item documentation for cart creation

### DIFF
--- a/guide/index.md
+++ b/guide/index.md
@@ -56,11 +56,11 @@ shopClient.createCart().then(function (cart) {
 });
 ```
 
-Variants can be passed in during initalization to create a non-empty cart with those variants.
+Line items can be passed in during initalization to create a non-empty cart with those variants.
 
 ```js
 var cart;
-shopClient.createCart({id: 123, quantity: 1}).then(function (cart) {
+shopClient.createCart({line_items: [{id: 123, quantity: 1}]}).then(function (cart) {
   cart = cart;
   // do something with cart
 });


### PR DESCRIPTION
Per https://github.com/Shopify/js-buy-sdk/issues/69, line items currently have to be passed in as an array of objects under the `line_items` key to `createCart`: https://github.com/Shopify/js-buy-sdk/blob/master/tests/integration/shop-client-cart-test.js#L20

Please review @tessalt @harismahmood89 