### PR TITLE
Change reference entry point to ShopifyBuy

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -7,7 +7,7 @@
     <a class="docs-nav__link {% if page.url == '/guide/' %}active{% endif %}" href="{{ '/guide' | prepend: site.baseurl }}">Guide</a>
   </li>
   <li class="nav-item--reference">
-    <a class="docs-nav__link {% if page.url contains '/api/' %}active{% endif %}" href="{{ '/api/classes/CartModel.html' | prepend: site.baseurl }}">Reference</a>
+    <a class="docs-nav__link {% if page.url contains '/api/' %}active{% endif %}" href="{{ '/api/classes/ShopifyBuy.html' | prepend: site.baseurl }}">Reference</a>
   </li>
   <li>
     <a class="docs-nav__link {% if page.url == '/examples/' %}active{% endif %}" href="{{ '/examples' | prepend: site.baseurl }}">Examples</a>


### PR DESCRIPTION
We should be jumping into the entry point for the SDK by default instead of the Cart Model. 

Please review @tessalt @harismahmood89 