### PR TITLE
productVariant.checkoutUrl Object

### DIFF
--- a/src/models/product-variant-model.js
+++ b/src/models/product-variant-model.js
@@ -105,15 +105,22 @@ const ProductVariantModel = BaseModel.extend({
   /**
     * Checkout URL for purchasing variant with quantity.
     * @method checkoutUrl
-    * @param {Number} [quantity = 1] quantity of variant
+    * @param {Object} [{quantity: 1}] an options object, contains quantity by
+    * default.
     * @public
     * @return {String} Checkout URL
   */
-  checkoutUrl(quantity = 1) {
+  checkoutUrl(opts = { quantity: 1 }) {
+
+    if (Object.keys(opts).length === 0) {
+      opts.quantity = 1;
+    }
+
     const config = this.config;
     const baseUrl = `https://${config.myShopifyDomain}.myshopify.com/cart`;
 
-    const variantPath = `${this.id}:${parseInt(quantity, 10)}`;
+    const quantity = parseInt(opts.quantity, 10);
+    const variantPath = `${this.id}:${quantity}`;
 
     const query = `api_key=${config.apiKey}`;
 

--- a/tests/unit/models/product-variant-test.js
+++ b/tests/unit/models/product-variant-test.js
@@ -90,13 +90,18 @@ test('it returns the image for the variant', function (assert) {
 });
 
 test('it generates checkout permalinks from passed quantity', function (assert) {
-  assert.expect(4);
+  assert.expect(5);
 
   const baseUrl = `https://${config.myShopifyDomain}.myshopify.com/cart`;
   const query = `api_key=${config.apiKey}`;
+  const opts = {};
 
   assert.equal(model.checkoutUrl(), `${baseUrl}/${model.id}:1?${query}`, 'defaults to 1');
-  assert.equal(model.checkoutUrl(27), `${baseUrl}/${model.id}:27?${query}`, 'respects passed quantity');
-  assert.equal(model.checkoutUrl('3'), `${baseUrl}/${model.id}:3?${query}`, 'works with strings');
-  assert.equal(model.checkoutUrl(5.5), `${baseUrl}/${model.id}:5?${query}`, 'trims decimals');
+  assert.equal(model.checkoutUrl(opts), `${baseUrl}/${model.id}:1?${query}`, 'defaults to 1 when passed an empty object');
+  opts.quantity = 27;
+  assert.equal(model.checkoutUrl(opts), `${baseUrl}/${model.id}:27?${query}`, 'respects passed quantity');
+  opts.quantity = '3';
+  assert.equal(model.checkoutUrl(opts), `${baseUrl}/${model.id}:3?${query}`, 'works with strings');
+  opts.quantity = 5.5;
+  assert.equal(model.checkoutUrl(opts), `${baseUrl}/${model.id}:5?${query}`, 'trims decimals');
 });


### PR DESCRIPTION
Addresses #73

I do realize this is a documentation update issue, however the changes within this PR address a code solution. If you hate it, throw it out! 

checkoutUrl now takes an object as a parameter.
object has a default `quantity` of 1.

Tests were updated to add an addition test case, as well as allow for object input.