### PR TITLE
Complete fix for copy to clipboard

### DIFF
--- a/assets/scripts/docs.js
+++ b/assets/scripts/docs.js
@@ -40,16 +40,21 @@ $(function() {
     generateApiClassNavItems();
   }
 
-  var clipboard = new Clipboard('[data-clipboard-text]');
-  clipboard.on('success', function(e) {
-    var previousText = $(e.trigger).text();
-    $(e.trigger).text('Copied!');
-    setTimeout(function() {
-      $(e.trigger).text(previousText);
-    }, 2000);
-  });
-  clipboard.on('error', function(e) {
-    $(e.trigger).text('Press ⌘-C now to copy');
-  });
+  if(document.queryCommandSupported('copy')) {
+    var clipboard = new Clipboard('[data-clipboard-text]');
+    clipboard.on('success', function(e) {
+      var previousText = $(e.trigger).text();
+      $(e.trigger).text('Copied!');
+      setTimeout(function() {
+        $(e.trigger).text(previousText);
+      }, 2000);
+    });
+    clipboard.on('error', function(e) {
+      $(e.trigger).text('Press ⌘-C now to copy');
+    });
+  }
+  else {
+    $('[data-clipboard-text]').hide();
+  }
 
 });


### PR DESCRIPTION
Turns out I didn't commit everything I had for https://github.com/Shopify/js-buy-sdk/pull/80 - it's currently not functional in iOS, and we shouldn't be showing the copy button if it's never going to work for them. This hides the button if copying to clipboard isn't supported at all. 

@harismahmood89 @tessalt 