### PR TITLE
[FEATURE] create a `fetchRecentCart` method

### DIFF
--- a/src/models/reference-model.js
+++ b/src/models/reference-model.js
@@ -4,8 +4,8 @@ import { GUID_KEY } from '../metal/set-guid-for';
 const ReferenceModel = BaseModel.extend({
 
   /**
-    * Class for cart model
-    * @class CartModel
+    * Class for reference model
+    * @class ReferenceModel
     * @constructor
   */
   constructor(attrs) {
@@ -17,7 +17,7 @@ const ReferenceModel = BaseModel.extend({
   },
 
   /**
-    * get ID for current cart
+    * get the ID for current reference (not what it refers to, but its own unique identifier)
     * @property id
     * @type {String}
   */

--- a/src/models/reference-model.js
+++ b/src/models/reference-model.js
@@ -1,0 +1,39 @@
+import BaseModel from './base-model';
+import { GUID_KEY } from '../metal/set-guid-for';
+
+const ReferenceModel = BaseModel.extend({
+
+  /**
+    * Class for cart model
+    * @class CartModel
+    * @constructor
+  */
+  constructor(attrs) {
+    if (Object.keys(attrs).indexOf('referenceId') < 0) {
+      throw new Error('Missing key referenceId of reference. References to null are not allowed');
+    }
+
+    this.super(...arguments);
+  },
+
+  /**
+    * get ID for current cart
+    * @property id
+    * @type {String}
+  */
+  get id() {
+    return this.attrs[GUID_KEY];
+  },
+
+  get referenceId() {
+    return this.attrs.referenceId;
+  },
+  set referenceId(value) {
+    this.attrs.referenceId = value;
+
+    return value;
+  }
+
+});
+
+export default ReferenceModel;

--- a/src/serializers/reference-serializer.js
+++ b/src/serializers/reference-serializer.js
@@ -1,0 +1,27 @@
+import CoreObject from '../metal/core-object';
+import assign from '../metal/assign';
+import ReferenceModel from '../models/reference-model';
+
+const ReferenceSerializer = CoreObject.extend({
+  constructor(config) {
+    this.config = config;
+  },
+
+  modelForType(/* type */) {
+    return ReferenceModel;
+  },
+
+  deserializeSingle(type, singlePayload = {}, metaAttrs = {}) {
+    const Model = this.modelForType(type);
+
+    return new Model(singlePayload, metaAttrs);
+  },
+
+  serialize(type, model) {
+    const attrs = assign({}, model.attrs);
+
+    return attrs;
+  }
+});
+
+export default ReferenceSerializer;

--- a/src/shop-client.js
+++ b/src/shop-client.js
@@ -1,9 +1,11 @@
 import ListingsSerializer from './serializers/listings-serializer';
 import ListingsAdapter from './adapters/listings-adapter';
 import CartSerializer from './serializers/cart-serializer';
+import ReferenceSerializer from './serializers/reference-serializer';
 import LocalStorageAdapter from './adapters/local-storage-adapter';
 import CoreObject from './metal/core-object';
 import assign from './metal/assign';
+import { GUID_KEY } from './metal/set-guid-for';
 
 /**
  * @module shopify-buy
@@ -47,13 +49,15 @@ const ShopClient = CoreObject.extend({
     this.serializers = {
       products: ListingsSerializer,
       collections: ListingsSerializer,
-      carts: CartSerializer
+      carts: CartSerializer,
+      references: ReferenceSerializer
     };
 
     this.adapters = {
       products: ListingsAdapter,
       collections: ListingsAdapter,
-      carts: LocalStorageAdapter
+      carts: LocalStorageAdapter,
+      references: LocalStorageAdapter
     };
   },
 
@@ -401,7 +405,28 @@ const ShopClient = CoreObject.extend({
    *   @param {String|Number} [query.limit=50] the number of collections to retrieve per page
    * @return {Promise|Array} The collection models.
    */
-  fetchQueryCollections: fetchFactory('query', 'collections')
+  fetchQueryCollections: fetchFactory('query', 'collections'),
+
+
+  fetchRecentCart() {
+    return this.fetch('references', `${this.config.myShopifyDomain}.recent-cart`).then(reference => {
+      const cartId = reference.referenceId;
+
+      return this.fetchCart(cartId);
+    }).catch(() => {
+      return this.createCart().then(cart => {
+        const refAttrs = {
+          referenceId: cart.id
+        };
+
+        refAttrs[GUID_KEY] = `${this.config.myShopifyDomain}.recent-cart`;
+
+        this.create('references', refAttrs);
+
+        return cart;
+      });
+    });
+  }
 });
 
 export default ShopClient;

--- a/src/shop-client.js
+++ b/src/shop-client.js
@@ -408,6 +408,21 @@ const ShopClient = CoreObject.extend({
   fetchQueryCollections: fetchFactory('query', 'collections'),
 
 
+  /**
+   * This method looks up a reference in localStorage to the most recent cart.
+   * If one is not found, creates one. If the cart the reference points to
+   * doesn't exist, create one and store the new reference.
+   *
+   * ```javascript
+   * client.fetchRecentCart().then(cart => {
+   *  // do stuff with the cart
+   * });
+   * ```
+   *
+   * @method fetchRecentCart
+   * @public
+   * @return {Promise|CartModel} The cart.
+   */
   fetchRecentCart() {
     return this.fetch('references', `${this.config.myShopifyDomain}.recent-cart`).then(reference => {
       const cartId = reference.referenceId;

--- a/tests/integration/shop-client-recent-cart-test.js
+++ b/tests/integration/shop-client-recent-cart-test.js
@@ -1,0 +1,137 @@
+import { module, test } from 'qunit';
+// import { step, resetStep } from 'shopify-buy/tests/helpers/assert-step';
+import ShopClient from 'shopify-buy/shop-client';
+import Config from 'shopify-buy/config';
+import { GUID_KEY } from 'shopify-buy/metal/set-guid-for';
+import CartModel from 'shopify-buy/models/cart-model';
+
+const configAttrs = {
+  myShopifyDomain: 'buckets-o-stuff',
+  apiKey: 'abc123',
+  appId: 6
+};
+
+
+const config = new Config(configAttrs);
+
+let shopClient;
+let fakeLocalStorage;
+
+const { getItem, setItem, removeItem } = localStorage;
+
+module('Integration | ShopClient#fetchRecentCart', {
+  setup() {
+    shopClient = new ShopClient(config);
+    fakeLocalStorage = {};
+    // resetStep();
+
+    localStorage.getItem = function (key) {
+      return JSON.stringify(fakeLocalStorage[key]);
+    };
+    localStorage.setItem = function (key, value) {
+      fakeLocalStorage[key] = JSON.parse(value);
+    };
+    localStorage.removeItem = function (key) {
+      delete fakeLocalStorage[key];
+    };
+  },
+  teardown() {
+    shopClient = null;
+    localStorage.getItem = getItem;
+    localStorage.setItem = setItem;
+    localStorage.removeItem = removeItem;
+  }
+});
+
+
+test('it resolves with an exisitng cart when a reference and corresponding cart exist', function (assert) {
+  assert.expect(1);
+
+  const done = assert.async();
+
+  const cartReferenceKey = `references.${config.myShopifyDomain}.recent-cart`;
+  const cartId = 'carts.shopify-buy.123';
+
+  const cartAttrs = {
+    cart: {
+      line_items: [{ variantId: 123 }]
+    }
+  };
+
+  fakeLocalStorage[cartReferenceKey] = {};
+  fakeLocalStorage[cartReferenceKey].referenceId = cartId.replace('carts.', '');
+  fakeLocalStorage[cartReferenceKey][GUID_KEY] = cartReferenceKey;
+  fakeLocalStorage[cartId] = cartAttrs;
+
+  shopClient.fetchRecentCart().then(cart => {
+    assert.deepEqual(cart.attrs, cartAttrs.cart);
+    done();
+  }).catch(() => {
+    assert.ok(false, 'promise should not reject');
+    done();
+  });
+});
+
+test('it resolves with a new cart when a no reference exists, persisting both the cart and reference', function (assert) {
+  assert.expect(6);
+
+  const done = assert.async();
+
+  assert.equal(Object.keys(fakeLocalStorage).length, 0);
+
+  shopClient.fetchRecentCart().then(cart => {
+    assert.equal(Object.keys(fakeLocalStorage).length, 2);
+
+    assert.ok(cart);
+    assert.ok(CartModel.prototype.isPrototypeOf(cart));
+
+    assert.equal(Object.keys(fakeLocalStorage).filter(key => {
+      return key.match(/^references\./);
+    }).length, 1);
+
+    assert.equal(Object.keys(fakeLocalStorage).filter(key => {
+      return key.match(/^carts\./);
+    }).length, 1);
+
+    done();
+  }).catch(() => {
+    assert.ok(false, 'promise should not reject');
+    done();
+  });
+});
+
+test('it recovers from broken state when a reference exists to a non-existent cart', function (assert) {
+  assert.expect(6);
+
+  const done = assert.async();
+
+  const cartReferenceKey = `references.${config.myShopifyDomain}.recent-cart`;
+  const cartId = 'carts.shopify-buy.123';
+
+
+  fakeLocalStorage[cartReferenceKey] = {};
+  fakeLocalStorage[cartReferenceKey].referenceId = cartId.replace('carts.', '');
+  fakeLocalStorage[cartReferenceKey][GUID_KEY] = cartReferenceKey;
+
+  assert.equal(Object.keys(fakeLocalStorage).length, 1);
+
+  shopClient.fetchRecentCart().then(cart => {
+    assert.equal(Object.keys(fakeLocalStorage).length, 2);
+
+    assert.ok(cart);
+    assert.ok(CartModel.prototype.isPrototypeOf(cart));
+
+    assert.equal(Object.keys(fakeLocalStorage).filter(key => {
+      return key.match(/^references\./);
+    }).length, 1);
+
+    assert.equal(Object.keys(fakeLocalStorage).filter(key => {
+      return key.match(/^carts\./);
+    }).length, 1);
+
+    done();
+  }).catch(() => {
+    assert.ok(false, 'promise should not reject');
+    done();
+  });
+});

--- a/tests/integration/shop-client-recent-cart-test.js
+++ b/tests/integration/shop-client-recent-cart-test.js
@@ -1,5 +1,4 @@
 import { module, test } from 'qunit';
-// import { step, resetStep } from 'shopify-buy/tests/helpers/assert-step';
 import ShopClient from 'shopify-buy/shop-client';
 import Config from 'shopify-buy/config';
 import { GUID_KEY } from 'shopify-buy/metal/set-guid-for';
@@ -23,7 +22,6 @@ module('Integration | ShopClient#fetchRecentCart', {
   setup() {
     shopClient = new ShopClient(config);
     fakeLocalStorage = {};
-    // resetStep();
 
     localStorage.getItem = function (key) {
       return JSON.stringify(fakeLocalStorage[key]);

--- a/tests/unit/models/reference-model.js
+++ b/tests/unit/models/reference-model.js
@@ -1,0 +1,45 @@
+import { module, test } from 'qunit';
+import BaseModel from 'shopify-buy/models/base-model';
+import ReferenceModel from 'shopify-buy/models/reference-model';
+
+module('Unit | ReferenceModel');
+
+test('it extends from BaseModel', function (assert) {
+  const model = new ReferenceModel({ referenceId: 'whatever' });
+
+  assert.ok(BaseModel.prototype.isPrototypeOf(model));
+});
+
+test('it attaches attrs to `.attrs`', function (assert) {
+  const attrs = { someAttr: 'some-attr', referenceId: 'whatever' };
+  const model = new ReferenceModel(attrs);
+
+  assert.deepEqual(model.attrs, attrs);
+});
+
+test('it attaches metaAttrs to the root', function (assert) {
+  const metaAttrs = { someAttr: 'some-attr' };
+  const model = new ReferenceModel({ referenceId: 'whatever' }, metaAttrs);
+
+  assert.equal(model.someAttr, metaAttrs.someAttr);
+});
+
+test('it throws when a reference id is missing', function (assert) {
+  assert.throws(function () {
+    /* eslint no-unused-vars: 0 */
+    const model = new ReferenceModel({});
+  }, 'missing referenceId param throws');
+});
+
+test('it attaches proxies referenceId to attrs', function (assert) {
+  const referenceId = 'whatever';
+  const model = new ReferenceModel({ referenceId });
+
+  assert.equal(model.referenceId, referenceId);
+
+  const newId = 'some-value';
+
+  model.referenceId = newId;
+
+  assert.equal(model.referenceId, newId);
+});

--- a/tests/unit/serializers/reference-serializer.js
+++ b/tests/unit/serializers/reference-serializer.js
@@ -1,0 +1,70 @@
+import { module, test } from 'qunit';
+import ReferenceSerializer from 'shopify-buy/serializers/reference-serializer';
+import ReferenceModel from 'shopify-buy/models/reference-model';
+
+let serializer;
+
+const config = {};
+
+module('Unit | ReferenceSerializer', {
+  setup() {
+    serializer = new ReferenceSerializer(config);
+  },
+  teardown() {
+    serializer = null;
+  }
+});
+
+
+const referenceFixture = {
+  referenceId: 'some-reference'
+};
+
+test('it returns ReferenceModel for reference type', function (assert) {
+  assert.expect(1);
+
+  assert.equal(serializer.modelForType('references'), ReferenceModel);
+});
+
+test('it transforms a single item payload into a reference object.', function (assert) {
+  assert.expect(2);
+
+  const model = serializer.deserializeSingle('references', referenceFixture);
+
+  assert.notOk(Array.isArray(model), 'should not be an array');
+  assert.deepEqual(model.attrs, referenceFixture);
+});
+
+test('it attaches a reference of the passed serializer to the model on #deserializeSingle', function (assert) {
+  assert.expect(1);
+
+  const model = serializer.deserializeSingle('references', referenceFixture, { serializer });
+
+  assert.deepEqual(model.serializer, serializer);
+});
+
+test('it attaches a reference of the passed shopClient to the model on #deserializeSingle', function (assert) {
+  assert.expect(1);
+
+  const shopClient = 'some-shop-client';
+
+  const model = serializer.deserializeSingle('references', referenceFixture, { shopClient });
+
+  assert.equal(model.shopClient, shopClient);
+});
+
+test('it transforms a model into a payload on #serialize using the root key', function (assert) {
+  const model = new ReferenceModel(referenceFixture);
+
+  const payload = serializer.serialize('references', model);
+
+  assert.deepEqual(payload, model.attrs);
+});
+
+test('it attaches a reference to the config', function (assert) {
+  assert.expect(1);
+
+  const model = serializer.deserializeSingle('references', referenceFixture, {});
+
+  assert.equal(model.config, config);
+});


### PR DESCRIPTION
Includes specs and integration tests. Also introduces a `ReferenceModel`
which is essentially a user-identifiable singleton bookmark to a thing.
It's assumed the consumer of a reference instance knows what it points to.

The meat of the new behaviour is defined here: https://github.com/Shopify/js-buy-sdk/blob/feature-recent-carts/src/shop-client.js#L401-L418