### PR TITLE
[FEATURE] Add a licenser to the production build

### DIFF
--- a/build-lib/lib.js
+++ b/build-lib/lib.js
@@ -11,6 +11,7 @@ const pkg = require('../package.json');
 const polyfills = require('./polyfills');
 const loader = require('./loader');
 const babelConfig = require('./util/babel-config');
+const Licenser = require('./licenser');
 
 
 function sourceTree(pathConfig, moduleType) {
@@ -97,8 +98,9 @@ window.ShopifyBuy = require('shopify-buy/shopify').default;
       }
     }));
 
-    tree = mergeTrees([tree, minifiedTree, nodeLibOutput]);
+    const concatenatedScripts = new Licenser([mergeTrees([tree, minifiedTree])]);
 
+    tree = mergeTrees([concatenatedScripts, nodeLibOutput]);
   } else {
     const amdOutput = concat(mergeTrees([amdTree, loaderTree]), {
       headerFiles: ['loader.js'],

--- a/build-lib/licenser.js
+++ b/build-lib/licenser.js
@@ -1,0 +1,43 @@
+/* global require, module, fs */
+
+const Plugin = require('broccoli-plugin');
+const path = require('path');
+const fs = require('fs');
+
+const LICENSE = fs.readFileSync(path.join(__dirname, '..', 'LICENSE.txt'));
+
+function Licenser(inputNodes, options) {
+  const defaultedOptions = options || {};
+
+  Plugin.call(this, inputNodes, {
+    annotation: defaultedOptions.annotation
+  });
+
+  this.options = defaultedOptions;
+}
+
+Licenser.prototype = Object.create(Plugin.prototype);
+Licenser.prototype.constructor = Licenser;
+
+Licenser.prototype.build = function () {
+
+  const files = this.inputPaths.reduce((fileAcc, dir) => {
+    const list = fs.readdirSync(dir).map(fileName => {
+      return path.join(dir, fileName);
+    });
+
+    return fileAcc.concat(list);
+  }, []).filter(fileName => {
+    return fileName.match(/^.+\.js$/);
+  });
+
+  files.forEach(fileName => {
+    const inputBuffer = fs.readFileSync(path.join(fileName));
+
+    const outputBuffer = `/*\n${LICENSE}*/\n\n${inputBuffer}`;
+
+    fs.writeFileSync(path.join(this.outputPath, path.basename(fileName)), outputBuffer);
+  });
+};
+
+module.exports = Licenser;


### PR DESCRIPTION
Addresses #65. Prepends the contents of `LICENSE.txt` to all build files in production