### PR TITLE
Cart Rework

### DIFF
--- a/examples/cart/index.html
+++ b/examples/cart/index.html
@@ -16,11 +16,11 @@
     <h2 class="variant-title"></h2>
     <h2 class="variant-price"></h2>
     <div class="variant-selectors"></div>
-    <button class="buy-button js-preventCartListener">Add To Cart</button>
+    <button class="buy-button js-prevent-cart-listener">Add To Cart</button>
   </div>
 
   <!-- .cart-tab start -->
-  <button class="btn btn--cart-tab js-preventCartListener">
+  <button class="btn btn--cart-tab js-prevent-cart-listener">
     <span class="btn__counter"></span>
     <svg xmlns="http://www.w3.org/2000/svg" class="icon-cart icon-cart--side" viewBox="0 0 25 25" enable-background="new 0 0 25 25"><g fill="#fff"><path d="M24.6 3.6c-.3-.4-.8-.6-1.3-.6h-18.4l-.1-.5c-.3-1.5-1.7-1.5-2.5-1.5h-1.3c-.6 0-1 .4-1 1s.4 1 1 1h1.8l3 13.6c.2 1.2 1.3 2.4 2.5 2.4h12.7c.6 0 1-.4 1-1s-.4-1-1-1h-12.7c-.2 0-.5-.4-.6-.8l-.2-1.2h12.6c1.3 0 2.3-1.4 2.5-2.4l2.4-7.4v-.2c.1-.5-.1-1-.4-1.4zm-4 8.5v.2c-.1.3-.4.8-.5.8h-13l-1.8-8.1h17.6l-2.3 7.1z"></path><circle cx="9" cy="22" r="2"></circle><circle cx="19" cy="22" r="2"></circle></g></svg>
   </button>

--- a/examples/cart/index.html
+++ b/examples/cart/index.html
@@ -16,8 +16,16 @@
     <h2 class="variant-title"></h2>
     <h2 class="variant-price"></h2>
     <div class="variant-selectors"></div>
-    <button class="buy-button btn">Add To Cart</button>
+    <button class="buy-button js-preventCartListener">Add To Cart</button>
   </div>
+
+  <!-- .cart-tab start -->
+  <button class="btn btn--cart-tab js-preventCartListener">
+    <span class="btn__counter"></span>
+    <svg xmlns="http://www.w3.org/2000/svg" class="icon-cart icon-cart--side" viewBox="0 0 25 25" enable-background="new 0 0 25 25"><g fill="#fff"><path d="M24.6 3.6c-.3-.4-.8-.6-1.3-.6h-18.4l-.1-.5c-.3-1.5-1.7-1.5-2.5-1.5h-1.3c-.6 0-1 .4-1 1s.4 1 1 1h1.8l3 13.6c.2 1.2 1.3 2.4 2.5 2.4h12.7c.6 0 1-.4 1-1s-.4-1-1-1h-12.7c-.2 0-.5-.4-.6-.8l-.2-1.2h12.6c1.3 0 2.3-1.4 2.5-2.4l2.4-7.4v-.2c.1-.5-.1-1-.4-1.4zm-4 8.5v.2c-.1.3-.4.8-.5.8h-13l-1.8-8.1h17.6l-2.3 7.1z"></path><circle cx="9" cy="22" r="2"></circle><circle cx="19" cy="22" r="2"></circle></g></svg>
+  </button>
+  <!-- .cart-tab end -->
+
 
   <!-- .cart begin -->
   <div class="cart">
@@ -60,16 +68,7 @@
   </div>
   <!-- .cart end -->
 
-
-  <!-- .cart-tab start -->
-  <button class="btn btn--cart-tab">
-    <span class="btn__counter"></span>
-    <svg xmlns="http://www.w3.org/2000/svg" class="icon-cart icon-cart--side" viewBox="0 0 25 25" enable-background="new 0 0 25 25"><g fill="#fff"><path d="M24.6 3.6c-.3-.4-.8-.6-1.3-.6h-18.4l-.1-.5c-.3-1.5-1.7-1.5-2.5-1.5h-1.3c-.6 0-1 .4-1 1s.4 1 1 1h1.8l3 13.6c.2 1.2 1.3 2.4 2.5 2.4h12.7c.6 0 1-.4 1-1s-.4-1-1-1h-12.7c-.2 0-.5-.4-.6-.8l-.2-1.2h12.6c1.3 0 2.3-1.4 2.5-2.4l2.4-7.4v-.2c.1-.5-.1-1-.4-1.4zm-4 8.5v.2c-.1.3-.4.8-.5.8h-13l-1.8-8.1h17.6l-2.3 7.1z"></path><circle cx="9" cy="22" r="2"></circle><circle cx="19" cy="22" r="2"></circle></g></svg>
-  </button>
-  <!-- .cart-tab end -->
-
-
-  <script id="cart-item-template" type="text/template">
+  <script id="CartItemTemplate" type="text/template">
     <div class="cart-item">
       <div class="cart-item__img"></div>
       <div class="cart-item__content">

--- a/examples/cart/index.js
+++ b/examples/cart/index.js
@@ -24,7 +24,7 @@ $(function() {
     });
   }
 
-
+  var previousFocusItem;
 
 
   /* Fetch product and init
@@ -52,7 +52,7 @@ $(function() {
 
     attachCheckoutButtonListeners();
 
-    closeCart();
+    bindEventListeners();
 
   });
 
@@ -119,13 +119,15 @@ $(function() {
       event.preventDefault();
       var id = product.selectedVariant.id;
       addVariantToCart(product.selectedVariant, 1);
+      setPreviousFocusItem(this);
+      $('#checkout').focus();
     });
   }
 
   /* Increase product variant quantity in cart
   ============================================================ */
   function attachQuantityIncrementListeners(product) {
-    $('.cart').on('click', '.quantity-increment', function() {
+    $('.cart').on('click', '.quantity-increment', function(evt) {
       var variantId = parseInt($(this).attr('data-variant-id'), 10);
       var variant = product.variants.filter(function (variant) {
         return (variant.id === variantId);
@@ -135,13 +137,14 @@ $(function() {
       $(this).attr('disabled', 'disabled');
 
       addVariantToCart(variant, 1);
+      evt.stopPropagation();
     });
   }
 
   /* Decrease product variant quantity in cart
   ============================================================ */
   function attachQuantityDecrementListeners(product) {
-    $('.cart').on('click', '.quantity-decrement', function() {
+    $('.cart').on('click', '.quantity-decrement', function(evt) {
       var variantId = parseInt($(this).attr('data-variant-id'), 10);
       var variant = product.variants.filter(function (variant) {
         return (variant.id === variantId);
@@ -151,6 +154,26 @@ $(function() {
       $(this).attr('disabled', 'disabled');
 
       addVariantToCart(variant, -1);
+      evt.stopPropagation();
+    });
+  }
+
+  /* Bind Event Listeners
+  ============================================================ */
+  function bindEventListeners() {
+    $('.cart .btn--close').on('click', closeCart);
+
+    $(document).on('click', function(evt) {
+      if((!$(evt.target).closest('.cart').length) && (!$(evt.target).closest('.js-preventCartListener').length)) {
+        closeCart();
+      }
+    });
+
+    var ESCAPE_KEYCODE = 27
+    $(document).on('keydown', function (evt) {
+      if (evt.which === ESCAPE_KEYCODE) {
+        closeCart();
+      }
     });
   }
 
@@ -163,11 +186,13 @@ $(function() {
   /* Close Cart
   ============================================================ */
   function closeCart() {
-    $('.cart .btn--close').click(function () {
-      $('.cart').removeClass('js-active');
-    });
+    $('.cart').removeClass('js-active');
+    $('.overlay').removeClass('js-active');
+    if (previousFocusItem) {
+      $(previousFocusItem).focus();
+      previousFocusItem = ''
+    }
   }
-
 
   /* Add 'quantity' amount of product 'variant' to cart
   ============================================================ */
@@ -189,8 +214,9 @@ $(function() {
     var $cartItemContainer = $('.cart-item-container');
     var totalPrice = 0;
 
+
     $cartItemContainer.empty();
-    var lineItemEmptyTemplate = $('#cart-item-template').html();
+    var lineItemEmptyTemplate = $('#CartItemTemplate').html();
     var $cartLineItems = cart.lineItems.map(function (lineItem, index) {
       var $lineItemTemplate = $(lineItemEmptyTemplate);
       var itemImage = lineItem.image.src;
@@ -252,8 +278,13 @@ $(function() {
     }
 
     $('.btn--cart-tab').click(function() {
+      setPreviousFocusItem(this);
       openCart();
     });
+  }
+
+  function setPreviousFocusItem(item) {
+    previousFocusItem = item;
   }
 
 });

--- a/examples/cart/index.js
+++ b/examples/cart/index.js
@@ -8,6 +8,7 @@ $(function() {
     appId: '6'
   });
 
+  var product;
   var cart;
   var cartLineItemCount;
   if(localStorage.getItem('lastCartId')) {
@@ -29,7 +30,8 @@ $(function() {
 
   /* Fetch product and init
   ============================================================ */
-  client.fetchProduct('3614436099').then(function (product) {
+  client.fetchProduct('3614436099').then(function (fetchedProduct) {
+    product = fetchedProduct;
     var selectedVariant = product.selectedVariant;
     var selectedVariantImage = product.selectedVariantImage;
     var currentOptions = product.options;
@@ -41,19 +43,9 @@ $(function() {
     updateVariantImage(selectedVariantImage);
     updateVariantTitle(selectedVariant);
     updateVariantPrice(selectedVariant);
-
-    attachBuyButtonListeners(product);
     attachOnVariantSelectListeners(product);
-
-    attachQuantityIncrementListeners(product);
-    attachQuantityDecrementListeners(product);
-
     updateCartTabButton();
-
-    attachCheckoutButtonListeners();
-
     bindEventListeners();
-
   });
 
   /* Generate DOM elements for variant selectors
@@ -67,6 +59,63 @@ $(function() {
 
     return elements;
   }
+
+
+  /* Bind Event Listeners
+  ============================================================ */
+  function bindEventListeners() {
+    /* cart close button listener */
+    $('.cart .btn--close').on('click', closeCart);
+
+    /* click away listener to close cart */
+    $(document).on('click', function(evt) {
+      if((!$(evt.target).closest('.cart').length) && (!$(evt.target).closest('.js-prevent-cart-listener').length)) {
+        closeCart();
+      }
+    });
+
+    /* escape key handler */
+    var ESCAPE_KEYCODE = 27;
+    $(document).on('keydown', function (evt) {
+      if (evt.which === ESCAPE_KEYCODE) {
+        if (previousFocusItem) {
+          $(previousFocusItem).focus();
+          previousFocusItem = ''
+        }
+        closeCart();
+      }
+    });
+
+    /* checkout button click listener */
+    $('.btn--cart-checkout').on('click', function () {
+      window.open(cart.checkoutUrl, '_self');
+    });
+
+    /* buy button click listener */
+    $('.buy-button').on('click', buyButtonClickHandler);
+
+    /* increment quantity click listener */
+    $('.cart').on('click', '.quantity-increment', function () {
+      var variantId = $(this).data('variant-id');
+      incrementQuantity(variantId);
+    });
+
+    /* decrement quantity click listener */
+    $('.cart').on('click', '.quantity-decrement', function() {
+      var variantId = $(this).data('variant-id');
+      decrementQuantity(variantId);
+    });
+
+    /* update quantity field listener */
+    $('.cart').on('keyup', '.cart-item__quantity', debounce(fieldQuantityHandler, 250));
+
+    /* cart tab click listener */
+    $('.btn--cart-tab').click(function() {
+      setPreviousFocusItem(this);
+      openCart();
+    });
+  }
+
 
   /* Variant option change handler
   ============================================================ */
@@ -114,63 +163,78 @@ $(function() {
 
   /* Attach and control listeners onto buy button
   ============================================================ */
-  function attachBuyButtonListeners(product) {
-    $('.buy-button').on('click', function (event) {
-      event.preventDefault();
-      var id = product.selectedVariant.id;
-      addOrUpdateVariant(product.selectedVariant, 1);
-      setPreviousFocusItem(this);
-      $('#checkout').focus();
-    });
+  function buyButtonClickHandler(evt) {
+    evt.preventDefault();
+    var id = product.selectedVariant.id;
+    var quantity;
+    var cartLineItem = findCartItemByVariantId(id);
+
+    quantity = cartLineItem ? cartLineItem.quantity + 1 : 1;
+
+    addOrUpdateVariant(product.selectedVariant, quantity);
+    setPreviousFocusItem(evt.target);
+    $('#checkout').focus();
   }
 
-  /* Increase product variant quantity in cart
+  /* Update product variant quantity in cart
   ============================================================ */
-  function attachQuantityIncrementListeners(product) {
-    $('.cart').on('click', '.quantity-increment', function(evt) {
-      var variantId = parseInt($(this).attr('data-variant-id'), 10);
-      var variant = product.variants.filter(function (variant) {
-        return (variant.id === variantId);
-      })[0];
-
-      addOrUpdateVariant(variant, 1);
-    });
+  function updateQuantity(fn, variantId) {
+    var variant = product.variants.filter(function (variant) {
+      return (variant.id === variantId);
+    })[0];
+    var quantity;
+    var cartLineItem = findCartItemByVariantId(variant.id);
+    if (cartLineItem) {
+      quantity = fn(cartLineItem.quantity);
+      updateVariantInCart(cartLineItem, quantity);
+    }
   }
 
-  /* Decrease product variant quantity in cart
+  /* Decrease quantity amount by 1
   ============================================================ */
-  function attachQuantityDecrementListeners(product) {
-    $('.cart').on('click', '.quantity-decrement', function(evt) {
-      var variantId = parseInt($(this).attr('data-variant-id'), 10);
-      var variant = product.variants.filter(function (variant) {
-        return (variant.id === variantId);
-      })[0];
-
-      addOrUpdateVariant(variant, -1);
-    });
+  function decrementQuantity(variantId) {
+    updateQuantity(function(quantity) {
+      return quantity - 1;
+    }, variantId);
   }
 
-  /* Bind Event Listeners
+  /* Increase quantity amount by 1
   ============================================================ */
-  function bindEventListeners() {
-    $('.cart .btn--close').on('click', closeCart);
+  function incrementQuantity(variantId) {
+    updateQuantity(function(quantity) {
+      return quantity + 1;
+    }, variantId);
+  }
 
-    $(document).on('click', function(evt) {
-      if((!$(evt.target).closest('.cart').length) && (!$(evt.target).closest('.js-preventCartListener').length)) {
-        closeCart();
-      }
-    });
+  /* Update producrt variant quantity in cart through input field
+  ============================================================ */
+  function fieldQuantityHandler(evt) {
+    var variantId = parseInt($(this).closest('.cart-item').attr('data-variant-id'), 10);
+    var variant = product.variants.filter(function (variant) {
+      return (variant.id === variantId);
+    })[0];
+    var cartLineItem = findCartItemByVariantId(variant.id);
+    var quantity = evt.target.value;
+    if (cartLineItem) {
+      updateVariantInCart(cartLineItem, quantity);
+    }
+  }
 
-    var ESCAPE_KEYCODE = 27
-    $(document).on('keydown', function (evt) {
-      if (evt.which === ESCAPE_KEYCODE) {
-        if (previousFocusItem) {
-          $(previousFocusItem).focus();
-          previousFocusItem = ''
-        }
-        closeCart();
-      }
-    });
+  /* Debounce taken from _.js
+  ============================================================ */
+  function debounce(func, wait, immediate) {
+    var timeout;
+    return function() {
+      var context = this, args = arguments;
+      var later = function() {
+        timeout = null;
+        if (!immediate) func.apply(context, args);
+      };
+      var callNow = immediate && !timeout;
+      clearTimeout(timeout);
+      timeout = setTimeout(later, wait);
+      if (callNow) func.apply(context, args);
+    }
   }
 
   /* Open Cart
@@ -186,16 +250,22 @@ $(function() {
     $('.overlay').removeClass('js-active');
   }
 
+  /* Find Cart Line Item By Variant Id
+  ============================================================ */
+  function findCartItemByVariantId(variantId) {
+    return cart.lineItems.filter(function (item) {
+      return (item.variant_id === variantId);
+    })[0];
+  }
+
   /* Determine action for variant adding/updating/removing
   ============================================================ */
   function addOrUpdateVariant(variant, quantity) {
     openCart();
-    var foundInCart = cart.lineItems.filter(function (item) {
-      return (item.variant_id === variant.id);
-    });
+    var cartLineItem = findCartItemByVariantId(variant.id);
 
-    if (foundInCart.length) {
-      updateVariantInCart(variant, quantity, foundInCart[0]);
+    if (cartLineItem) {
+      updateVariantInCart(cartLineItem, quantity);
     } else {
       addVariantToCart(variant, quantity);
     }
@@ -205,12 +275,13 @@ $(function() {
 
   /* Update details for item already in cart. Remove if necessary
   ============================================================ */
-  function updateVariantInCart(variant, quantity, cartLineItem) {
-    cart.addVariants({ variant: variant, quantity: quantity }).then(function() {
-      var $cartItem = $('.cart').find('.cart-item[data-variant-id="' + variant.id + '"]');
-
-      if (cartLineItem.quantity > 0) {
-        $cartItem.find('.cart-item__quantity').attr('value', cartLineItem.quantity);
+  function updateVariantInCart(cartLineItem, quantity) {
+    var variantId = cartLineItem.variant_id;
+    var cartLength = cart.lineItems.length;
+    cart.updateLineItem(cartLineItem.id, quantity).then(function(updatedCart) {
+      var $cartItem = $('.cart').find('.cart-item[data-variant-id="' + variantId + '"]');
+      if (updatedCart.lineItems.length >= cartLength) {
+        $cartItem.find('.cart-item__quantity').val(cartLineItem.quantity);
         $cartItem.find('.cart-item__price').text(formatAsMoney(cartLineItem.line_price));
       } else {
         $cartItem.addClass('js-hidden').bind('transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd', function() {
@@ -218,13 +289,15 @@ $(function() {
         });
       }
 
+      updateCartTabButton();
       updateTotalCartPricing();
-
+      if (updatedCart.lineItems.length < 1) {
+        closeCart();
+      }
     }).catch(function (errors) {
       console.log('Fail');
       console.error(errors);
     });
-
   }
 
   /* Add 'quantity' amount of product 'variant' to cart
@@ -252,6 +325,8 @@ $(function() {
     updateCartTabButton();
   }
 
+  /* Return required markup for single item rendering
+  ============================================================ */
   function renderCartItem(lineItem) {
     var lineItemEmptyTemplate = $('#CartItemTemplate').html();
     var $lineItemTemplate = $(lineItemEmptyTemplate);
@@ -275,7 +350,6 @@ $(function() {
     var $cartItemContainer = $('.cart-item-container');
     $cartItemContainer.empty();
     var lineItemEmptyTemplate = $('#CartItemTemplate').html();
-
     var $cartLineItems = cart.lineItems.map(function (lineItem, index) {
       return renderCartItem(lineItem);
     });
@@ -299,15 +373,6 @@ $(function() {
     return '$' + parseFloat(amount, 10).toFixed(2).replace(/(\d)(?=(\d{3})+\.)/g, "$1,").toString();
   }
 
-
-  /* Checkout listener
-  ============================================================ */
-  function attachCheckoutButtonListeners() {
-    $('.btn--cart-checkout').on('click', function () {
-      window.open(cart.checkoutUrl, '_self');
-    });
-  }
-
   /* Update cart tab button
   ============================================================ */
   function updateCartTabButton() {
@@ -321,13 +386,10 @@ $(function() {
       $('.btn--cart-tab').removeClass('js-active');
       $('.cart').removeClass('js-active');
     }
-
-    $('.btn--cart-tab').click(function() {
-      setPreviousFocusItem(this);
-      openCart();
-    });
   }
 
+  /* Set previously focused item for escape handler
+  ============================================================ */
   function setPreviousFocusItem(item) {
     previousFocusItem = item;
   }

--- a/examples/cart/styles/_cart.scss
+++ b/examples/cart/styles/_cart.scss
@@ -73,7 +73,6 @@
   perspective-origin: 50% 0px;
 }
 
-
 .cart-item {
   margin-bottom: 20px;
   overflow: hidden;
@@ -113,7 +112,6 @@
 .cart-item__content {
   width: 100%;
   padding-left: 75px;
-  // padding-top: 5px;
 }
 
 .cart-item__content-row {


### PR DESCRIPTION
Built on from #82.

Any changes to the line items would call a complete re-render of the cart DOM causing a couple of issues. This has been reworked to update the cart DOM's state instead of re-rendering it entirely.

- `renderCartItem()` renders a single line item. This function is called when adding a single item, or recursively when rendering the entire cart on page load.
- `updateVariantInCart()` is used to update an already existing item in the cart. Updates the `quantity` and `price` values.
- `variantToCartHandler()` determines whether to call the update or render function.
- `evt.stopPropagation()` is no longer required in the increment and decrement functions to prevent bubbling.
- Small tweaks for esc key handler.