### PR TITLE
[FIX] Cart line item serialization and deserialization

### DIFF
--- a/src/models/cart-line-item-model.js
+++ b/src/models/cart-line-item-model.js
@@ -1,0 +1,70 @@
+import BaseModel from './base-model';
+import { GUID_KEY } from '../metal/set-guid-for';
+
+const CartLineItem = BaseModel.extend({
+  constructor() {
+    this.super(...arguments);
+  },
+
+  get id() {
+    return this[GUID_KEY];
+  },
+
+  get variant_id() {
+    return this.attrs.variant_id;
+  },
+
+  get product_id() {
+    return this.attrs.product_id;
+  },
+
+  get image() {
+    return this.attrs.image;
+  },
+
+  get title() {
+    return this.attrs.title;
+  },
+
+  get quantity() {
+    return this.attrs.quantity;
+  },
+
+  set quantity(value) {
+    this.attrs.quantity = value;
+
+    return value;
+  },
+
+  get properties() {
+    return this.attrs.properties || {};
+  },
+
+  set properties(value) {
+    this.attrs.properties = value || {};
+
+    return value;
+  },
+
+  get variant_title() {
+    return this.attrs.variant_title;
+  },
+
+  get price() {
+    return this.attrs.price;
+  },
+
+  get compare_at_price() {
+    return this.attrs.compare_at_price;
+  },
+
+  get line_price() {
+    return (this.quantity * parseFloat(this.price)).toFixed(2);
+  },
+
+  get grams() {
+    return this.attrs.grams;
+  }
+});
+
+export default CartLineItem;

--- a/src/models/cart-line-item-model.js
+++ b/src/models/cart-line-item-model.js
@@ -31,9 +31,18 @@ const CartLineItem = BaseModel.extend({
   },
 
   set quantity(value) {
-    this.attrs.quantity = value;
+    const parsedValue = parseInt(value, 10);
 
-    return value;
+    if (parsedValue < 0) {
+      throw new Error('Quantities must be positive');
+    } else if (parsedValue !== parseFloat(value)) {
+      /* incidentally, this covers all NaN values, because NaN !== Nan */
+      throw new Error('Quantities must be whole numbers');
+    }
+
+    this.attrs.quantity = parsedValue;
+
+    return this.attrs.quantity;
   },
 
   get properties() {

--- a/src/models/cart-model.js
+++ b/src/models/cart-model.js
@@ -1,4 +1,5 @@
 import BaseModel from './base-model';
+import CartLineItem from './cart-line-item-model';
 import assign from '../metal/assign';
 import setGuidFor from '../metal/set-guid-for';
 import { GUID_KEY } from '../metal/set-guid-for';
@@ -45,7 +46,9 @@ const CartModel = BaseModel.extend({
     * @type {Array}
   */
   get lineItems() {
-    return this.attrs.line_items || [];
+    return (this.attrs.line_items || []).map(item => {
+      return new CartLineItem(item);
+    });
   },
 
   /**
@@ -110,9 +113,6 @@ const CartModel = BaseModel.extend({
   addVariants() {
     const newLineItems = [...arguments].map(item => {
       const lineItem = {
-        get id() {
-          return this[GUID_KEY];
-        },
         image: item.variant.image,
         variant_id: item.variant.id,
         product_id: item.variant.productId,
@@ -122,9 +122,6 @@ const CartModel = BaseModel.extend({
         variant_title: item.variant.title,
         price: item.variant.price,
         compare_at_price: item.variant.compareAtPrice,
-        get line_price() {
-          return (this.quantity * parseFloat(this.price)).toFixed(2);
-        },
         grams: item.variant.grams
       };
 

--- a/src/models/cart-model.js
+++ b/src/models/cart-model.js
@@ -129,7 +129,7 @@ const CartModel = BaseModel.extend({
 
       return lineItem;
     });
-    const existingLineItems = this.lineItems;
+    const existingLineItems = this.attrs.line_items;
 
     existingLineItems.push(...newLineItems);
 

--- a/tests/unit/models/cart-line-item-model-test.js
+++ b/tests/unit/models/cart-line-item-model-test.js
@@ -1,0 +1,41 @@
+import { module, test } from 'qunit';
+import CartLineItemModel from 'shopify-buy/models/cart-line-item-model';
+import BaseModel from 'shopify-buy/models/base-model';
+
+let model;
+
+const lineItemFixture = {
+  id: 3,
+  image: 'http://google.com/image.png',
+  variant_id: 12345,
+  product_id: 45678,
+  title: 'Some Product',
+  quantity: 1,
+  properties: {},
+  variant_title: 'Red / Small',
+  price: '12.00',
+  compare_at_price: '',
+  line_price: '12.00',
+  grams: 4
+};
+
+module('Unit | CartLineItemModel', {
+  setup() {
+    model = new CartLineItemModel(lineItemFixture);
+  },
+
+  teardown() {
+    model = null;
+  }
+});
+
+test('it extends from BaseModel', function (assert) {
+  assert.expect(1);
+
+  assert.ok(BaseModel.prototype.isPrototypeOf(model));
+});
+
+test('it updates line_price based on changing quantity', function (assert) {
+  assert.expect(/* Add a value here */);
+});
+

--- a/tests/unit/models/cart-line-item-model-test.js
+++ b/tests/unit/models/cart-line-item-model-test.js
@@ -36,6 +36,14 @@ test('it extends from BaseModel', function (assert) {
 });
 
 test('it updates line_price based on changing quantity', function (assert) {
-  assert.expect(/* Add a value here */);
-});
+  assert.expect(6);
 
+  assert.equal(model.quantity, 1);
+  assert.equal(model.price, '12.00');
+  assert.equal(model.line_price, '12.00');
+
+  model.quantity = 2;
+  assert.equal(model.quantity, 2);
+  assert.equal(model.price, '12.00');
+  assert.equal(model.line_price, '24.00');
+});

--- a/tests/unit/models/cart-line-item-model-test.js
+++ b/tests/unit/models/cart-line-item-model-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import CartLineItemModel from 'shopify-buy/models/cart-line-item-model';
+import assign from 'shopify-buy/metal/assign';
 import BaseModel from 'shopify-buy/models/base-model';
 
 let model;
@@ -21,7 +22,7 @@ const lineItemFixture = {
 
 module('Unit | CartLineItemModel', {
   setup() {
-    model = new CartLineItemModel(lineItemFixture);
+    model = new CartLineItemModel(assign({}, lineItemFixture));
   },
 
   teardown() {
@@ -43,7 +44,71 @@ test('it updates line_price based on changing quantity', function (assert) {
   assert.equal(model.line_price, '12.00');
 
   model.quantity = 2;
+
   assert.equal(model.quantity, 2);
   assert.equal(model.price, '12.00');
   assert.equal(model.line_price, '24.00');
+});
+
+test('it updates line_price if quantity is a numeric string', function (assert) {
+  assert.expect(6);
+
+  assert.equal(model.quantity, 1);
+  assert.equal(model.price, '12.00');
+  assert.equal(model.line_price, '12.00');
+
+  model.quantity = '2';
+
+  assert.equal(model.quantity, 2, 'quantity gets cast to a number');
+  assert.equal(model.price, '12.00');
+  assert.equal(model.line_price, '24.00');
+});
+
+test('it rejects negative quantities', function (assert) {
+  assert.expect(1);
+
+  assert.throws(function () {
+    model.quantity = -1;
+  });
+});
+
+test('it rejects decimal quantities', function (assert) {
+  assert.expect(2);
+
+  assert.throws(function () {
+    model.quantity = 1.5;
+  });
+
+  assert.throws(function () {
+    model.quantity = '1.5';
+  });
+});
+
+test('it rejects things that are in no way numbers', function (assert) {
+  assert.expect(6);
+
+  assert.throws(function () {
+    model.quantity = '';
+  });
+
+  assert.throws(function () {
+    model.quantity = null;
+  });
+
+  assert.throws(function () {
+    model.quantity = true;
+  });
+
+  assert.throws(function () {
+    model.quantity = false;
+  });
+
+  assert.throws(function () {
+    model.quantity = NaN;
+  });
+
+  assert.throws(function () {
+    /* eslint no-undefined: 0 */
+    model.quantity = undefined;
+  });
 });

--- a/tests/unit/models/cart-model-test.js
+++ b/tests/unit/models/cart-model-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import CartModel from 'shopify-buy/models/cart-model';
 import BaseModel from 'shopify-buy/models/base-model';
+import CartLineItem from 'shopify-buy/models/cart-line-item-model';
 import assign from 'shopify-buy/metal/assign';
 import { cartFixture } from '../../fixtures/cart-fixture';
 import { singleProductFixture } from '../../fixtures/product-fixture';
@@ -53,10 +54,14 @@ test('it extends from BaseModel', function (assert) {
   assert.ok(BaseModel.prototype.isPrototypeOf(model));
 });
 
-test('it proxies `lineItems` to the underlying line items', function (assert) {
-  assert.expect(1);
+test('it transforms attrs.line_items into CartLineItem class instances', function (assert) {
+  assert.expect(1 + cartFixture.cart.line_items.length);
 
-  assert.deepEqual(model.lineItems, cartFixture.cart.line_items);
+  assert.deepEqual(model.lineItems.length, cartFixture.cart.line_items.length);
+
+  model.lineItems.forEach(item => {
+    assert.ok(CartLineItem.prototype.isPrototypeOf(item));
+  });
 });
 
 test('it proxies sub total from the underlying cart', function (assert) {


### PR DESCRIPTION
This is a redo of #104. Now with the added bonus of not dumping `CartLineItemModel` classes to local storage, and a test to make sure we don't intermingle internal state and decorated state.