### PR TITLE
[FIX] Bump version of broccoli-lint-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,8 @@
     "node-fetch": "1.3.3"
   },
   "devDependencies": {
-    "aws-sdk": "2.2.44",
     "Base64": "0.3.0",
-    "broccoli-sass": "0.7.0",
+    "aws-sdk": "2.2.44",
     "babel-eslint": "5.0.0",
     "babel-preset-es2015": "6.6.0",
     "babel-register": "6.7.2",
@@ -32,10 +31,11 @@
     "broccoli-concat": "2.2.0",
     "broccoli-env": "0.0.1",
     "broccoli-funnel": "1.0.1",
-    "broccoli-lint-eslint": "2.2.0",
+    "broccoli-lint-eslint": "2.2.1",
     "broccoli-merge-trees": "1.1.1",
     "broccoli-plugin": "1.2.1",
     "broccoli-sane-watcher": "1.1.4",
+    "broccoli-sass": "0.7.0",
     "broccoli-static-compiler": "0.2.2",
     "broccoli-uglify-js": "0.1.3",
     "broccoli-uglify-sourcemap": "1.1.1",


### PR DESCRIPTION
2.2.0 is broken on windows. 2.2.1 includes a fix.

This issue was first identified in #97. @petetnt pointed me to the
breaking change and fix:
https://github.com/Shopify/js-buy-sdk/issues/97#issuecomment-216923217