### PR TITLE
Fixed documentation on `cart.addVariants()`. Fixes #110

### DIFF
--- a/api/classes/CartModel.html
+++ b/api/classes/CartModel.html
@@ -120,7 +120,7 @@ layout: api
 	</div>
 
 	<div class="description"><p>Add items to cart. Updates cart's <code>lineItems</code></p>
-<pre class="code prettyprint"><code class="language-javascript">cart.addVariants({id: 123, quantity: 1}).then(cart =&gt; {
+<pre class="code prettyprint"><code class="language-javascript">cart.addVariants({variant: variantObject, quantity: 1}).then(cart =&gt; {
   // do things with the updated cart.
 });
 </code></pre>

--- a/api/data.json
+++ b/api/data.json
@@ -331,7 +331,7 @@
         {
             "file": "src/models/cart-model.js",
             "line": 82,
-            "description": "Add items to cart. Updates cart's `lineItems`\n```javascript\ncart.addVariants({id: 123, quantity: 1}).then(cart => {\n  // do things with the updated cart.\n});\n```",
+            "description": "Add items to cart. Updates cart's `lineItems`\n```javascript\ncart.addVariants({variant: variantObject, quantity: 1}).then(cart => {\n  // do things with the updated cart.\n});\n```",
             "itemtype": "method",
             "name": "addVariants",
             "params": [

--- a/guide/index.md
+++ b/guide/index.md
@@ -75,7 +75,7 @@ variant ID that already exists in the cart, that line item's quantity will be in
 > Note: `addVariants` accepts a variable number of arguments, each of which must be an object containing an id and quantity.
 
 ```js
-cart.addVariants({id: 123, quantity: 1}).then(function (cart) {
+cart.addVariants({variant: variantObject, quantity: 1}).then(function (cart) {
   // do something with updated cart
 });
 ```
@@ -135,7 +135,7 @@ The product's `selectedVariant` property will now reflect the variant matching t
 
 ```js
 cart.addVariants({
-  id: product.selectedVariant.id,
+  variant: product.selectedVariant,
   quantity: 1
 }).then(function (cart) {
   cart = cart;


### PR DESCRIPTION
changed `cart.addVariants({id: 123, quantity: 1})` to `cart.addVariants({variant: variantObject, quantity: 1})` on `gh-pages`

cc ,, @minasmart @harismahmood89 