### PR TITLE
Support selection of different variant scaled images.

### DIFF
--- a/src/models/product-variant-model.js
+++ b/src/models/product-variant-model.js
@@ -91,11 +91,37 @@ const ProductVariantModel = BaseModel.extend({
     * @type {Object}
   */
   get image() {
-    const id = this.id;
-    const images = this.attrs.product.images;
+    return this.scaledImage();
+  },
 
-    const primaryImage = images[0];
-    const variantImage = images.filter(image => {
+  /**
+    * Gets image corresponding to a specific size.
+    * Available sizes are listed at https://help.shopify.com/themes/liquid/filters/url-filters#size-parameters
+    * @method scaledImage
+    * @param {String} [size = 'master'] Desired size. Defaults to `master` when available and to product image when unavailable.
+    * @public
+    * @return {String} Checkout URL
+  */
+  scaledImage(size = 'master') {
+    const id = this.id;
+    const productImages = this.attrs.product.images;
+
+    if (this.attrs.variant.image) {
+      const candidates = this.attrs.variant.image.imageVariants.filter(element => {
+        return element.name === size || element.name === 'master';
+      });
+
+      if (candidates.length === 1) {
+        return candidates[0];
+      } else if (candidates[0].name === size) {
+        return candidates[0];
+      }
+
+      return candidates[1];
+    }
+
+    const primaryImage = productImages[0];
+    const variantImage = productImages.filter(image => {
       return image.variant_ids.indexOf(id) !== -1;
     })[0];
 

--- a/src/models/product-variant-model.js
+++ b/src/models/product-variant-model.js
@@ -95,25 +95,25 @@ const ProductVariantModel = BaseModel.extend({
   },
 
   /**
-    * Gets image corresponding to a specific size.
-    * Available sizes are listed at https://help.shopify.com/themes/liquid/filters/url-filters#size-parameters
+    * Gets image corresponding to a specific scale.
+    * Available scales are listed at https://help.shopify.com/themes/liquid/filters/url-filters#size-parameters
     * @method scaledImage
-    * @param {String} [size = 'master'] Desired size. Defaults to `master` when available and to product image when unavailable.
+    * @param {String} [scale = 'master'] Desired scale. Defaults to `master` when available and to product image when unavailable.
     * @public
     * @return {String} Checkout URL
   */
-  scaledImage(size = 'master') {
+  scaledImage(scale = 'master') {
     const id = this.id;
     const productImages = this.attrs.product.images;
 
     if (this.attrs.variant.image) {
       const candidates = this.attrs.variant.image.imageVariants.filter(element => {
-        return element.name === size || element.name === 'master';
+        return element.name === scale || element.name === 'master';
       });
 
       if (candidates.length === 1) {
         return candidates[0];
-      } else if (candidates[0].name === size) {
+      } else if (candidates[0].name === scale) {
         return candidates[0];
       }
 

--- a/tests/fixtures/product-fixture.js
+++ b/tests/fixtures/product-fixture.js
@@ -66,6 +66,7 @@ export const singleProductFixture = {
             value: 'Tons'
           }
         ],
+        image: null,
         price: '4.04',
         compare_at_price: null,
         grams: 1000,
@@ -90,6 +91,7 @@ export const singleProductFixture = {
             value: 'Less than tons'
           }
         ],
+        image: null,
         price: '4.01',
         compare_at_price: null,
         grams: 1000,
@@ -114,6 +116,7 @@ export const singleProductFixture = {
             value: 'Tons'
           }
         ],
+        image: null,
         price: '5.12',
         compare_at_price: null,
         grams: 1000,
@@ -138,6 +141,20 @@ export const singleProductFixture = {
             value: 'Less than tons'
           }
         ],
+        image: {
+          imageVariants: [
+            {
+              name: 'thumb',
+              dimensions: '50x50',
+              src: 'https://cdn.shopify.com/image-two_thumb.jpg'
+            },
+            {
+              name: 'small',
+              dimensions: '100x100',
+              src: 'https://cdn.shopify.com/image-two_small.jpg'
+            }
+          ]
+        },
         price: '3.00',
         compare_at_price: null,
         grams: 1000,

--- a/tests/fixtures/product-fixture.js
+++ b/tests/fixtures/product-fixture.js
@@ -141,20 +141,7 @@ export const singleProductFixture = {
             value: 'Less than tons'
           }
         ],
-        image: {
-          imageVariants: [
-            {
-              name: 'thumb',
-              dimensions: '50x50',
-              src: 'https://cdn.shopify.com/image-two_thumb.jpg'
-            },
-            {
-              name: 'small',
-              dimensions: '100x100',
-              src: 'https://cdn.shopify.com/image-two_small.jpg'
-            }
-          ]
-        },
+        image: null,
         price: '3.00',
         compare_at_price: null,
         grams: 1000,

--- a/tests/unit/models/product-variant-test.js
+++ b/tests/unit/models/product-variant-test.js
@@ -98,18 +98,21 @@ test('it proxies to a composite of product and variant state', function (assert)
   assert.deepEqual(model.optionValues, baseAttrs.variant.option_values);
 });
 
-test('it returns the image for the variant', function (assert) {
-  assert.expect(2);
+test('it returns the appropriate image for the variant', function (assert) {
+  assert.expect(8);
 
-  assert.deepEqual(model.image, baseAttrs.variant.image.imageVariants[2], 'should return the `master` when no type is specified');
-  assert.deepEqual(model.image('small'), baseAttrs.variant.image.imageVariants[1], 'should return the `small` image');
-  assert.deepEqual(model.image('stupid-name'), baseAttrs.variant.image.imageVariants[2], 'should return `master` image for invalid type');
+  assert.deepEqual(model.scaledImage(), baseAttrs.variant.image.imageVariants[2], 'return the `master` when no type is specified');
+  assert.deepEqual(model.scaledImage('small'), baseAttrs.variant.image.imageVariants[1], 'return the `small` image');
+  assert.deepEqual(model.scaledImage('stupid-name'), baseAttrs.variant.image.imageVariants[2], 'return `master` image for invalid type');
+  assert.deepEqual(model.image, baseAttrs.variant.image.imageVariants[2], 'behave like `scaledImage()` for valid variant level images');
 
   model.attrs.variant.image = null;
-  assert.deepEqual(model.image, baseAttrs.product.images[1], 'should return product level image for variant');
+  assert.deepEqual(model.scaledImage(), baseAttrs.product.images[1], 'return product level image for variant');
+  assert.deepEqual(model.image, baseAttrs.product.images[1], 'behave like `scaledImage()` for product level images');
 
   model.attrs.variant.id = 'abc123';
-  assert.deepEqual(model.image, baseAttrs.product.images[0], 'should return product default image when no id matches');
+  assert.deepEqual(model.scaledImage(), baseAttrs.product.images[0], 'return product default image when no id matches');
+  assert.deepEqual(model.image, baseAttrs.product.images[0], 'behave like `scaledImage()` for invalid id and top level images');
 });
 
 test('it generates checkout permalinks from passed quantity', function (assert) {

--- a/tests/unit/models/product-variant-test.js
+++ b/tests/unit/models/product-variant-test.js
@@ -45,7 +45,26 @@ const baseAttrs = {
         name: 'Enthusiasm',
         value: 'Less than tons'
       }
-    ]
+    ],
+    image: {
+      imageVariants: [
+        {
+          name: 'thumb',
+          dimensions: '50x50',
+          src: 'https://cdn.shopify.com/image-two_thumb.jpg'
+        },
+        {
+          name: 'small',
+          dimensions: '100x100',
+          src: 'https://cdn.shopify.com/image-two_small.jpg'
+        },
+        {
+          name: 'master',
+          dimensions: '100x100',
+          src: 'https://cdn.shopify.com/image-two_small.jpg'
+        }
+      ]
+    }
   }
 };
 
@@ -82,11 +101,15 @@ test('it proxies to a composite of product and variant state', function (assert)
 test('it returns the image for the variant', function (assert) {
   assert.expect(2);
 
-  assert.deepEqual(model.image, baseAttrs.product.images[1]);
+  assert.deepEqual(model.image, baseAttrs.variant.image.imageVariants[2], 'should return the `master` when no type is specified');
+  assert.deepEqual(model.image('small'), baseAttrs.variant.image.imageVariants[1], 'should return the `small` image');
+  assert.deepEqual(model.image('stupid-name'), baseAttrs.variant.image.imageVariants[2], 'should return `master` image for invalid type');
+
+  model.attrs.variant.image = null;
+  assert.deepEqual(model.image, baseAttrs.product.images[1], 'should return product level image for variant');
 
   model.attrs.variant.id = 'abc123';
-
-  assert.deepEqual(model.image, baseAttrs.product.images[0], 'the first image is default when no id matches');
+  assert.deepEqual(model.image, baseAttrs.product.images[0], 'should return product default image when no id matches');
 });
 
 test('it generates checkout permalinks from passed quantity', function (assert) {


### PR DESCRIPTION
### Details
`ProductVariantModel.scaledImage()` is implemented, which is now called/used by `ProductVariantModel.image` getter.

The currently proposed schema to get the variant scaled images looks like the below
```
  product: {
    variant: {
      image: {
        imageVariants: [
          {
            name: 'thumb',
            dimensions: '50x50',
            src: 'https://cdn.shopify.com/image-two_thumb.jpg'
          }
        ]
      }
    }
```
### Assumptions
- This PR assumes current data source does not have an `image` key on the product variant data. In which case, the `ProductVariantModel.image` getter would work like it currently does.
- It also assumes that the `master` image variant will always be included when the data source has `image.imageVariants`

references - #10, #51, Shopify/shopify#71114

### Suggestion
To access the scaled images, we'd use `product.variant.image.imageVariants[]`. Since we know each variant would only have one image with different scales, i think we can change it to `product.variant.images[]`

@minasmart @lreeves 