### PR TITLE
Added `ProductVariantModel.imageVariants` getter

### DIFF
--- a/src/models/product-variant-model.js
+++ b/src/models/product-variant-model.js
@@ -105,7 +105,7 @@ const ProductVariantModel = BaseModel.extend({
   /**
     * Image variants for product variant
     * @property imageVariant
-    * @type {Object}
+    * @type {Array}
   */
   get imageVariants() {
     const src = this.image.src;

--- a/src/models/product-variant-model.js
+++ b/src/models/product-variant-model.js
@@ -111,7 +111,8 @@ const ProductVariantModel = BaseModel.extend({
   get imageVariants() {
     const src = this.image.src;
     const extensionIndex = src.lastIndexOf('.');
-    const srcParts = [src.slice(0, extensionIndex), src.slice(extensionIndex)];
+    const pathAndBasename = src.slice(0, extensionIndex);
+    const extension = src.slice(extensionIndex);
     const variants = [
       { name: 'pico', dimension: '16x16' },
       { name: 'icon', dimension: '32x32' },
@@ -126,7 +127,7 @@ const ProductVariantModel = BaseModel.extend({
     ];
 
     variants.forEach(variant => {
-      variant.src = `${srcParts[0]}_${variant.name}${srcParts[1]}`;
+      variant.src = `${pathAndBasename}_${variant.name}${extension}`;
     });
 
     return variants;

--- a/src/models/product-variant-model.js
+++ b/src/models/product-variant-model.js
@@ -110,6 +110,7 @@ const ProductVariantModel = BaseModel.extend({
   get imageVariants() {
     const src = this.image.src;
     const extensionIndex = src.lastIndexOf('.');
+    const srcParts = [src.slice(0, extensionIndex), src.slice(extensionIndex)];
     const variants = [
       { name: 'pico', dimension: '16x16' },
       { name: 'icon', dimension: '32x32' },
@@ -123,11 +124,12 @@ const ProductVariantModel = BaseModel.extend({
       { name: '2048x2048', dimension: '2048x2048' }
     ];
 
-    return variants.map(variant => {
-      variant.src = `${src.slice(0, extensionIndex)}_${variant.name}${src.slice(extensionIndex)}`;
-
-      return variant;
+    variants.forEach((variant, index) => {
+      variant.src = `${srcParts[0]}_${variant.name}${srcParts[1]}`;
+      variants[index] = variant;
     });
+
+    return variants;
   },
 
   /**

--- a/src/models/product-variant-model.js
+++ b/src/models/product-variant-model.js
@@ -125,8 +125,8 @@ const ProductVariantModel = BaseModel.extend({
       { name: '2048x2048', dimension: '2048x2048' }
     ];
 
-    variants.forEach((variant, index) => {
-      variants[index].src = `${srcParts[0]}_${variant.name}${srcParts[1]}`;
+    variants.forEach(variant => {
+      variant.src = `${srcParts[0]}_${variant.name}${srcParts[1]}`;
     });
 
     return variants;

--- a/src/models/product-variant-model.js
+++ b/src/models/product-variant-model.js
@@ -103,6 +103,34 @@ const ProductVariantModel = BaseModel.extend({
   },
 
   /**
+    * Image variants for product variant
+    * @property imageVariant
+    * @type {Object}
+  */
+  get imageVariants() {
+    const src = this.image.src;
+    const extensionIndex = src.lastIndexOf('.');
+    const variants = [
+      { name: 'pico', dimension: '16x16' },
+      { name: 'icon', dimension: '32x32' },
+      { name: 'thumb', dimension: '50x50' },
+      { name: 'small', dimension: '100x100' },
+      { name: 'compact', dimension: '160x160' },
+      { name: 'medium', dimension: '240x240' },
+      { name: 'large', dimension: '480x480' },
+      { name: 'grande', dimension: '600x600' },
+      { name: '1024x1024', dimension: '1024x1024' },
+      { name: '2048x2048', dimension: '2048x2048' }
+    ];
+
+    return variants.map(variant => {
+      variant.src = `${src.slice(0, extensionIndex)}_${variant.name}${src.slice(extensionIndex)}`;
+
+      return variant;
+    });
+  },
+
+  /**
     * Checkout URL for purchasing variant with quantity.
     * @method checkoutUrl
     * @param {Number} [quantity = 1] quantity of variant

--- a/src/models/product-variant-model.js
+++ b/src/models/product-variant-model.js
@@ -103,7 +103,8 @@ const ProductVariantModel = BaseModel.extend({
   },
 
   /**
-    * Image variants for product variant
+    * Image variants available for a variant, ex [ {"name":"pico","dimension":"16x16","src":"https://cdn.shopify.com/image-two_pico.jpg"} ]
+    * See https://help.shopify.com/themes/liquid/filters/url-filters#size-parameters for list of available variants.
     * @property imageVariant
     * @type {Array}
   */

--- a/src/models/product-variant-model.js
+++ b/src/models/product-variant-model.js
@@ -126,8 +126,7 @@ const ProductVariantModel = BaseModel.extend({
     ];
 
     variants.forEach((variant, index) => {
-      variant.src = `${srcParts[0]}_${variant.name}${srcParts[1]}`;
-      variants[index] = variant;
+      variants[index].src = `${srcParts[0]}_${variant.name}${srcParts[1]}`;
     });
 
     return variants;

--- a/src/models/product-variant-model.js
+++ b/src/models/product-variant-model.js
@@ -104,7 +104,7 @@ const ProductVariantModel = BaseModel.extend({
 
   /**
     * Image variants available for a variant, ex [ {"name":"pico","dimension":"16x16","src":"https://cdn.shopify.com/image-two_pico.jpg"} ]
-    * See https://help.shopify.com/themes/liquid/filters/url-filters#size-parameters for list of available variants.
+    * See <a href="https://help.shopify.com/themes/liquid/filters/url-filters#size-parameters"> for list of available variants.</a>
     * @property imageVariant
     * @type {Array}
   */

--- a/tests/unit/models/product-variant-test.js
+++ b/tests/unit/models/product-variant-test.js
@@ -49,59 +49,6 @@ const baseAttrs = {
   }
 };
 
-const expectedImageVariants = [
-  {
-    name: 'pico',
-    dimension: '16x16',
-    src: 'https://cdn.shopify.com/image-two_pico.jpg'
-  },
-  {
-    name: 'icon',
-    dimension: '32x32',
-    src: 'https://cdn.shopify.com/image-two_icon.jpg'
-  },
-  {
-    name: 'thumb',
-    dimension: '50x50',
-    src: 'https://cdn.shopify.com/image-two_thumb.jpg'
-  },
-  {
-    name: 'small',
-    dimension: '100x100',
-    src: 'https://cdn.shopify.com/image-two_small.jpg'
-  },
-  {
-    name: 'compact',
-    dimension: '160x160',
-    src: 'https://cdn.shopify.com/image-two_compact.jpg'
-  },
-  {
-    name: 'medium',
-    dimension: '240x240',
-    src: 'https://cdn.shopify.com/image-two_medium.jpg'
-  },
-  {
-    name: 'large',
-    dimension: '480x480',
-    src: 'https://cdn.shopify.com/image-two_large.jpg'
-  },
-  {
-    name: 'grande',
-    dimension: '600x600',
-    src: 'https://cdn.shopify.com/image-two_grande.jpg'
-  },
-  {
-    name: '1024x1024',
-    dimension: '1024x1024',
-    src: 'https://cdn.shopify.com/image-two_1024x1024.jpg'
-  },
-  {
-    name: '2048x2048',
-    dimension: '2048x2048',
-    src: 'https://cdn.shopify.com/image-two_2048x2048.jpg'
-  }
-];
-
 const config = {
   myShopifyDomain: 'buckets-o-stuff',
   apiKey: 'abc123'
@@ -134,6 +81,58 @@ test('it proxies to a composite of product and variant state', function (assert)
 
 test('it returns the image variants for the variant', function (assert) {
   assert.expect(1);
+  const expectedImageVariants = [
+    {
+      name: 'pico',
+      dimension: '16x16',
+      src: 'https://cdn.shopify.com/image-two_pico.jpg'
+    },
+    {
+      name: 'icon',
+      dimension: '32x32',
+      src: 'https://cdn.shopify.com/image-two_icon.jpg'
+    },
+    {
+      name: 'thumb',
+      dimension: '50x50',
+      src: 'https://cdn.shopify.com/image-two_thumb.jpg'
+    },
+    {
+      name: 'small',
+      dimension: '100x100',
+      src: 'https://cdn.shopify.com/image-two_small.jpg'
+    },
+    {
+      name: 'compact',
+      dimension: '160x160',
+      src: 'https://cdn.shopify.com/image-two_compact.jpg'
+    },
+    {
+      name: 'medium',
+      dimension: '240x240',
+      src: 'https://cdn.shopify.com/image-two_medium.jpg'
+    },
+    {
+      name: 'large',
+      dimension: '480x480',
+      src: 'https://cdn.shopify.com/image-two_large.jpg'
+    },
+    {
+      name: 'grande',
+      dimension: '600x600',
+      src: 'https://cdn.shopify.com/image-two_grande.jpg'
+    },
+    {
+      name: '1024x1024',
+      dimension: '1024x1024',
+      src: 'https://cdn.shopify.com/image-two_1024x1024.jpg'
+    },
+    {
+      name: '2048x2048',
+      dimension: '2048x2048',
+      src: 'https://cdn.shopify.com/image-two_2048x2048.jpg'
+    }
+  ];
 
   assert.deepEqual(model.imageVariants, expectedImageVariants);
 });

--- a/tests/unit/models/product-variant-test.js
+++ b/tests/unit/models/product-variant-test.js
@@ -49,6 +49,59 @@ const baseAttrs = {
   }
 };
 
+const expectedImageVariants = [
+  {
+    name: 'pico',
+    dimension: '16x16',
+    src: 'https://cdn.shopify.com/image-two_pico.jpg'
+  },
+  {
+    name: 'icon',
+    dimension: '32x32',
+    src: 'https://cdn.shopify.com/image-two_icon.jpg'
+  },
+  {
+    name: 'thumb',
+    dimension: '50x50',
+    src: 'https://cdn.shopify.com/image-two_thumb.jpg'
+  },
+  {
+    name: 'small',
+    dimension: '100x100',
+    src: 'https://cdn.shopify.com/image-two_small.jpg'
+  },
+  {
+    name: 'compact',
+    dimension: '160x160',
+    src: 'https://cdn.shopify.com/image-two_compact.jpg'
+  },
+  {
+    name: 'medium',
+    dimension: '240x240',
+    src: 'https://cdn.shopify.com/image-two_medium.jpg'
+  },
+  {
+    name: 'large',
+    dimension: '480x480',
+    src: 'https://cdn.shopify.com/image-two_large.jpg'
+  },
+  {
+    name: 'grande',
+    dimension: '600x600',
+    src: 'https://cdn.shopify.com/image-two_grande.jpg'
+  },
+  {
+    name: '1024x1024',
+    dimension: '1024x1024',
+    src: 'https://cdn.shopify.com/image-two_1024x1024.jpg'
+  },
+  {
+    name: '2048x2048',
+    dimension: '2048x2048',
+    src: 'https://cdn.shopify.com/image-two_2048x2048.jpg'
+  }
+];
+
 const config = {
   myShopifyDomain: 'buckets-o-stuff',
   apiKey: 'abc123'
@@ -77,6 +130,12 @@ test('it proxies to a composite of product and variant state', function (assert)
   assert.equal(model.price, baseAttrs.variant.price);
   assert.equal(model.grams, baseAttrs.variant.grams);
   assert.deepEqual(model.optionValues, baseAttrs.variant.option_values);
+});
+
+test('it returns the image variants for the variant', function (assert) {
+  assert.expect(1);
+
+  assert.deepEqual(model.imageVariants, expectedImageVariants);
 });
 
 test('it returns the image for the variant', function (assert) {


### PR DESCRIPTION
Fixes #10 and it's part of the v0.2.0 list at #51.

Format is gotten from Shopify/shopify#71114

@minasmart, @harismahmood89, @tessalt 
