### PR TITLE
Remove node 0.10 from ci

### DIFF
--- a/ci/setup-node
+++ b/ci/setup-node
@@ -9,15 +9,12 @@ setup_node () {
 
 case $CIRCLE_NODE_INDEX in
   0)
-    setup_node $NODE_010_VERSION
-    ;;
-  1)
     setup_node $NODE_012_VERSION
     ;;
-  2)
+  1)
     setup_node $IOJS_VERSION
     ;;
-  3)
+  2)
     setup_node $NODE_4_VERSION
     ;;
   *)

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,6 @@
 
 machine:
   environment:
-    NODE_010_VERSION: v0.10.34
     NODE_012_VERSION: v0.12.0
     IOJS_VERSION: iojs-v1.3.0
     NODE_4_VERSION: v4.2.2


### PR DESCRIPTION
Since we build on prepublish, no need to test all of the build rigging on CI. We can add this back in once we have proper node tests that install the module and consume it.