### PR TITLE
[FIX] Handle variants that don't exist

### DIFF
--- a/src/models/product-model.js
+++ b/src/models/product-model.js
@@ -122,7 +122,7 @@ const ProductModel = BaseModel.extend({
 
     return this.variants.filter(variant => {
       return variant.title === variantTitle;
-    })[0];
+    })[0] || null;
   },
 
   /**
@@ -131,6 +131,10 @@ const ProductModel = BaseModel.extend({
     * @type {Object}
   */
   get selectedVariantImage() {
+    if (!this.selectedVariant) {
+      return null;
+    }
+
     return this.selectedVariant.image;
   }
 });

--- a/tests/unit/models/product-model-test.js
+++ b/tests/unit/models/product-model-test.js
@@ -95,3 +95,27 @@ test('it attaches a reference to the config on variants', function (assert) {
     assert.equal(variant.config, config);
   });
 });
+
+test('it returns null variant when there is no matching variant based on the selections', function (assert) {
+  assert.expect(1);
+
+  model.options[0].values.push('beans');
+  model.options[1].values.push('beans');
+
+  model.options[0].selected = 'beans';
+  model.options[1].selected = 'beans';
+
+  assert.equal(model.selectedVariant, null);
+});
+
+test('it returns a null image when there is no selected variant', function (assert) {
+  assert.expect(1);
+
+  model.options[0].values.push('beans');
+  model.options[1].values.push('beans');
+
+  model.options[0].selected = 'beans';
+  model.options[1].selected = 'beans';
+
+  assert.equal(model.selectedVariantImage, null);
+});


### PR DESCRIPTION
Instead of blowing up, guard for a variant that doesn't exist and return null variants and null images