### PR TITLE
Tested NO_IMAGE_URI for non-emptiness instead

### DIFF
--- a/tests/unit/models/product-model-test.js
+++ b/tests/unit/models/product-model-test.js
@@ -100,7 +100,7 @@ test('it returns Shopify admin\'s no image URI', function (assert) {
   assert.expect(2);
 
   assert.ok(typeof NO_IMAGE_URI === 'string', 'NO_IMAGE_URI must be a string');
-  assert.ok(NO_IMAGE_URI.length !== 0, 'NO_IMAGE_URI must NOT be empty');
+  assert.ok(NO_IMAGE_URI.length, 'NO_IMAGE_URI must NOT be empty');
 });
 
 test('it returns null variant when there is no matching variant based on the selections', function (assert) {

--- a/tests/unit/models/product-model-test.js
+++ b/tests/unit/models/product-model-test.js
@@ -97,9 +97,10 @@ test('it attaches a reference to the config on variants', function (assert) {
 });
 
 test('it returns Shopify admin\'s no image URI', function (assert) {
-  assert.expect(1);
+  assert.expect(2);
 
-  assert.equal(true, typeof NO_IMAGE_URI === 'string' && NO_IMAGE_URI.length !== 0, 'NO_IMAGE_URI must be a non-empty string');
+  assert.ok(typeof NO_IMAGE_URI === 'string', 'NO_IMAGE_URI must be a string');
+  assert.ok(NO_IMAGE_URI.length !== 0, 'NO_IMAGE_URI must NOT be empty');
 });
 
 test('it returns null variant when there is no matching variant based on the selections', function (assert) {

--- a/tests/unit/models/product-model-test.js
+++ b/tests/unit/models/product-model-test.js
@@ -99,7 +99,7 @@ test('it attaches a reference to the config on variants', function (assert) {
 test('it returns Shopify admin\'s no image URI', function (assert) {
   assert.expect(1);
 
-  assert.equal(NO_IMAGE_URI, 'https://widgets.shopifyapps.com/assets/no-image.svg');
+  assert.equal(true, typeof NO_IMAGE_URI === 'string' && NO_IMAGE_URI.length !== 0, 'NO_IMAGE_URI must be a non-empty string');
 });
 
 test('it returns null variant when there is no matching variant based on the selections', function (assert) {


### PR DESCRIPTION
Implements the comment I missed on #127.

👀 @minasmart, @tessalt 