### PR TITLE
update version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify-buy",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "The JS Buy SDK is a lightweight library that allows you to build ecommerce into any website. It is based on Shopify's API and provides the ability to retrieve products and collections from your shop, add products to a cart, and checkout.",
   "main": "lib/shopify.js",
   "repository": "git@github.com:Shopify/js-buy-sdk.git",


### PR DESCRIPTION
I thought 1.6 was the latest but looks like that went out to npm in april. Bumping to 0.1.7. 

@Shopify/buy-button 