### PR TITLE
read version from package.json

### DIFF
--- a/scripts/deploy
+++ b/scripts/deploy
@@ -4,7 +4,7 @@ var AWS = require('aws-sdk');
 var fs = require('fs');
 var path = require('path');
 var mime = require('mime-types');
-var exec = require('child_process').exec;
+var tag = require('../package.json').version;
 var DEFAULT_CONTENT_TYPE = 'application/octet-stream';
 var S3_DIR = 'js-buy-sdk';
 var DEFAULT_CACHE_CONTROL = "public, max-age=86400";
@@ -31,13 +31,7 @@ var Uploader = function () {
   this.secrets = new Secrets();
   this.secrets.load();
   this.s3 = new AWS.S3();
-  this.tag = this.getPkgVersion();
   this.distAssets = fs.readdirSync(DIST_DIR);
-};
-
-Uploader.prototype.getPkgVersion = function () {
-  var pkg = fs.readFileSync('./package.json')
-  return JSON.parse(pkg).version;
 };
 
 Uploader.prototype.uploadFile = function(localPath, s3Path) {
@@ -61,7 +55,7 @@ Uploader.prototype.uploadFile = function(localPath, s3Path) {
 Uploader.prototype.uploadDistAssets = function () {
   this.distAssets.forEach(function (file) {
     if (file.indexOf(FILENAME_FILTER) > -1) {
-      this.uploadFile(path.join(DIST_DIR, file), this.s3PathForFile(file, this.tag));
+      this.uploadFile(path.join(DIST_DIR, file), this.s3PathForFile(file, tag));
       this.uploadFile(path.join(DIST_DIR, file), this.s3PathForFile(file, 'latest'));
     }
   }.bind(this));

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -31,7 +31,13 @@ var Uploader = function () {
   this.secrets = new Secrets();
   this.secrets.load();
   this.s3 = new AWS.S3();
+  this.tag = this.getPkgVersion();
   this.distAssets = fs.readdirSync(DIST_DIR);
+};
+
+Uploader.prototype.getPkgVersion = function () {
+  var pkg = fs.readFileSync('./package.json')
+  return JSON.parse(pkg).version;
 };
 
 Uploader.prototype.uploadFile = function(localPath, s3Path) {
@@ -53,24 +59,12 @@ Uploader.prototype.uploadFile = function(localPath, s3Path) {
 };
 
 Uploader.prototype.uploadDistAssets = function () {
-  this.getCurrentTag(function (tag) {
-    this.distAssets.forEach(function (file) {
-      if (file.indexOf(FILENAME_FILTER) > -1) {
-        this.uploadFile(path.join(DIST_DIR, file), this.s3PathForFile(file, tag));
-        this.uploadFile(path.join(DIST_DIR, file), this.s3PathForFile(file, 'latest'));
-      }
-    }.bind(this));
-  }.bind(this));
-};
-
-Uploader.prototype.getCurrentTag = function (cb) {
-  exec('git describe --always --tag --abbrev=0', (err, stdout) => {
-    if (err) {
-      console.error(err);
-      cb();
+  this.distAssets.forEach(function (file) {
+    if (file.indexOf(FILENAME_FILTER) > -1) {
+      this.uploadFile(path.join(DIST_DIR, file), this.s3PathForFile(file, this.tag));
+      this.uploadFile(path.join(DIST_DIR, file), this.s3PathForFile(file, 'latest'));
     }
-    cb(stdout.trim());
-  });
+  }.bind(this));
 };
 
 Uploader.prototype.s3PathForFile = function (localPath, tag) {

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -54,7 +54,7 @@ Uploader.prototype.uploadFile = function(localPath, s3Path) {
 
 Uploader.prototype.uploadDistAssets = function () {
   this.distAssets.forEach(function (file) {
-    if (file.indexOf(FILENAME_FILTER) > -1) {
+    if (file.includes(FILENAME_FILTER)) {
       this.uploadFile(path.join(DIST_DIR, file), this.s3PathForFile(file, tag));
       this.uploadFile(path.join(DIST_DIR, file), this.s3PathForFile(file, 'latest'));
     }


### PR DESCRIPTION
rather than calling `exec` to get git tag, get version number for cdn scripts from package.json. I think this is a better approach but I'm also slightly suspicious about what my original motives were for not doing this the first time around. @minasmart @yomexzo @richgilbank 