### PR TITLE
[FIX] version and link node modules.

### DIFF
--- a/ci/deps
+++ b/ci/deps
@@ -20,4 +20,16 @@ MESSAGE
 curl -k -L -o phantomjs.tar.bz2 https://s3.amazonaws.com/travis-phantomjs/phantomjs-${PHANTOMJS_VERSION}-ubuntu-12.04.tar.bz2
 tar -jxf phantomjs.tar.bz2
 
+versioned_node_modules_path="node_modules_${CIRCLE_NODE_INDEX}"
+
+if [ ! -d "${versioned_node_modules_path}" ]; then
+  mkdir $versioned_node_modules_path
+fi
+
+if [ -L node_modules ]; then
+  rm node_modules
+fi
+
+ln -s $versioned_node_modules_path node_modules
+
 npm install

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,11 @@ machine:
     PHANTOMJS_VERSION: 2.0.0
 
 dependencies:
+  cache_directories:
+      - "node_modules_0"
+      - "node_modules_1"
+      - "node_modules_2"
+      - "node_modules_3"
   pre:
     - ./ci/setup-node:
         parallel: true


### PR DESCRIPTION
Circle caches dependencies from VM 0. This means that statically compiled
modules in node_modules from whatever node version is being tested on VM 0 get
distributed to every other node version when caches are distributed. This
creates a versioned `node_modules_X` directory, and symlinks `node_modules` to
it.