### PR TITLE
[FEATURE] Do an end-to-end selenium test of the cart example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,9 @@ logs
 *.log
 npm-debug.log*
 
-# Dependency directory
+# Dependencies
 node_modules
+selenium-standalone.jar
 
 # Intermediate files
 tmp
@@ -13,6 +14,7 @@ tmp
 dist
 .dist-test
 tests.xml
+WDIO.*.xml
 lib
 
 # Decrypted secrets

--- a/ci/deps
+++ b/ci/deps
@@ -20,6 +20,9 @@ MESSAGE
 curl -k -L -o phantomjs.tar.bz2 https://s3.amazonaws.com/travis-phantomjs/phantomjs-${PHANTOMJS_VERSION}-ubuntu-12.04.tar.bz2
 tar -jxf phantomjs.tar.bz2
 
+# Grab selenium standalone
+curl -k -L -o selenium-standalone.jar http://goo.gl/IHP6Qw
+
 versioned_node_modules_path="node_modules_${CIRCLE_NODE_INDEX}"
 
 if [ ! -d "${versioned_node_modules_path}" ]; then

--- a/ci/test
+++ b/ci/test
@@ -17,7 +17,9 @@ echo <<MESSAGE
 MESSAGE
 
 npm run test-ci
+npm run test-examples
 
 mkdir -p $CIRCLE_TEST_REPORTS/xunit
 
-mv tests.xml $CIRCLE_TEST_REPORTS/xunit/tests.xml
+mv tests.xml $CIRCLE_TEST_REPORTS/xunit/
+mv WDIO.*.xml $CIRCLE_TEST_REPORTS/xunit/

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 # In order to test all node versions, Set up circle with a parallelism value of 5
 
 machine:
+  node:
+    version: v5.5.0
   environment:
     NODE_012_VERSION: v0.12.0
     NODE_4_VERSION: v4.2.2

--- a/examples/cart/specs/test-case.js
+++ b/examples/cart/specs/test-case.js
@@ -1,0 +1,56 @@
+/* global require, describe, beforeEach, it, browser */
+
+const assert = require('assert');
+
+describe('it loads', function () {
+
+  beforeEach(function () {
+    browser.url('http://localhost:4200/examples/cart');
+    browser.waitForText('.product-title', '6 Panel – Aztec');
+  });
+
+  it('should have the right title', function () {
+    assert.equal(browser.getTitle(), 'JS Buy SDK Example -- Cart 001');
+  });
+
+  it('it should render a product', function () {
+    assert.equal(browser.getAttribute('.variant-image', 'src'), 'https://cdn.shopify.com/s/files/1/1019/0495/products/i5.jpg?v=1446943528');
+    assert.equal(browser.getText('.variant-title'), 'Black');
+    assert.equal(browser.getText('.variant-price'), '$32.00');
+    assert.equal(browser.getValue('select[name=Color]'), 'Black');
+  });
+});
+
+describe('it behaves', function () {
+
+  beforeEach(function () {
+    browser.url('http://localhost:4200/examples/cart');
+    browser.waitForText('.product-title', '6 Panel – Aztec');
+  });
+
+  it('updates the variant by changing the select value', function () {
+    assert.equal(browser.getAttribute('.variant-image', 'src'), 'https://cdn.shopify.com/s/files/1/1019/0495/products/i5.jpg?v=1446943528');
+    assert.equal(browser.getText('.variant-title'), 'Black');
+    assert.equal(browser.getValue('select[name=Color]'), 'Black');
+
+    browser.selectByVisibleText('select[name=Color]', 'Red');
+
+    assert.equal(browser.getAttribute('.variant-image', 'src'), 'https://cdn.shopify.com/s/files/1/1019/0495/products/i6.jpg?v=1446943530');
+    assert.equal(browser.getText('.variant-title'), 'Red');
+    assert.equal(browser.getValue('select[name=Color]'), 'Red');
+  });
+
+  it('adds an item to the cart by clicking add to cart', function () {
+    browser.click('.buy-button');
+
+    assert.equal(browser.getText('.cart-item__title'), '6 Panel – Aztec');
+    assert.equal(browser.getText('.cart-item__variant-title'), 'Black');
+  });
+
+  it('takes us to checkout', function () {
+    browser.click('.buy-button');
+    browser.click('#checkout');
+
+    assert.equal(browser.getTitle(), 'Embeds - Checkout');
+  });
+});

--- a/examples/cart/wdio.conf.js
+++ b/examples/cart/wdio.conf.js
@@ -1,0 +1,32 @@
+/* global exports */
+
+exports.config = {
+  specs: [
+    './examples/cart/specs/**/*.js'
+  ],
+  exclude: [
+  ],
+  maxInstances: 10,
+  capabilities: [{
+    maxInstances: 5,
+    browserName: 'phantomjs'
+  }],
+  reporters: ['dot', 'junit'],
+  reporterOptions: {
+    junit: {
+      outputDir: './'
+    }
+  },
+  sync: true,
+  logLevel: 'error',
+  coloredLogs: true,
+  screenshotPath: './errorShots/',
+  baseUrl: 'http://localhost:4200/examples/cart',
+  waitforTimeout: 30000,
+  connectionRetryTimeout: 90000,
+  connectionRetryCount: 3,
+  framework: 'mocha',
+  mochaOpts: {
+    ui: 'bdd'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "broccoli serve",
     "examples": "env EXAMPLES=1 broccoli serve",
     "test": "node ./scripts/test",
+    "test-examples": "node scripts/test-examples",
     "test-ci": "./scripts/ci"
   },
   "author": "Shopify Inc.",
@@ -49,12 +50,17 @@
     "js-string-escape": "1.0.0",
     "loader.js": "3.5.0",
     "mime-types": "2.1.10",
+    "mocha": "2.5.3",
     "nodegit": "0.13.0",
     "pretender": "0.10.1",
     "qunitjs": "1.20.0",
     "route-recognizer": "0.1.9",
     "rsvp": "3.1.0",
     "testem": "0.9.11",
+    "wdio-dot-reporter": "0.0.5",
+    "wdio-junit-reporter": "0.1.0",
+    "wdio-mocha-framework": "^0.3.1",
+    "webdriverio": "4.0.9",
     "whatwg-fetch": "0.10.1",
     "yuidocjs": "0.10.0"
   }

--- a/scripts/test-examples
+++ b/scripts/test-examples
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/* eslint-env node */
+/* eslint no-var: 0, prefer-template: 0 */
+/* globals require process */
+
+var childProcess = require('child_process');
+var path = require('path');
+var npm = require('global-npm');
+var pkg = require('../package.json');
+var npmDo = require('./util/npm-do');
+
+require('./util/work-from-root')();
+
+function log(who, what) {
+  process.stdout.write('[' + who + '] ' + what);
+}
+
+function runTests() {
+  return new Promise(function (resolve, reject) {
+    npmDo('wdio', [path.join('examples', 'cart', 'wdio.conf.js')], function (status) {
+      if (status === 0) {
+        resolve(status);
+      } else {
+        reject(status);
+      }
+    });
+  });
+}
+
+function bootSelenium() {
+  return new Promise(function (resolve, reject) {
+    var resolved = false;
+    var selenium = childProcess.exec('java -jar selenium-standalone.jar');
+
+    // Selenium outputs everything on STDERR because it's hateful
+    selenium.stderr.on('data', function (data) {
+      if (data.toString().match(/Selenium Server is up and running/) && !resolved) {
+        resolved = true;
+        resolve(selenium);
+      } else if (!resolved) {
+        log('selenium', data);
+      }
+    });
+
+    selenium.on('close', function (status) {
+      if (!resolved) {
+        log('selenium-failure', status + '\n');
+        reject(status);
+      }
+    });
+  });
+}
+
+function bootBroccoli() {
+  return new Promise(function (resolve, reject) {
+    npm.load(pkg, function () {
+      var resolved = false;
+      var broccoliBin = path.join(npm.bin, 'broccoli');
+      var examplesEnv = JSON.parse(JSON.stringify(process.env));
+
+      examplesEnv.EXAMPLES = 1;
+
+      var broccoli = childProcess.exec('node ' + broccoliBin + ' serve', { env: examplesEnv });
+
+      broccoli.stdout.on('data', function (data) {
+        log('broccoli', data);
+
+        if (data.match(/Serving on http/) && !resolved) {
+          resolved = true;
+          resolve(broccoli);
+        }
+      });
+
+      broccoli.stderr.on('data', function (data) {
+        log('broccoli-error', data);
+      });
+
+      broccoli.on('close', function (status) {
+        if (!resolved) {
+          log('broccoli-failure', status + '\n');
+          reject(status);
+        }
+      });
+    });
+  });
+}
+
+var waitToDie;
+
+Promise.all([bootBroccoli(), bootSelenium()]).then(function (processes) {
+  var broccoli = processes[0];
+  var selenium = processes[1];
+
+  waitToDie = function () {
+    return new Promise(function (resolve) {
+      var broccoliDead = false;
+      var seleniumDead = false;
+      var resolved = false;
+
+      function maybeResolveDead() {
+        if (broccoliDead && seleniumDead && !resolved) {
+          resolved = true;
+          resolve();
+        }
+      }
+
+      broccoli.on('close', function () {
+        broccoliDead = true;
+
+        maybeResolveDead(broccoli);
+      });
+      broccoli.on('exit', function () {
+        broccoliDead = true;
+
+        maybeResolveDead();
+      });
+      selenium.on('close', function () {
+        seleniumDead = true;
+
+        maybeResolveDead();
+      });
+      selenium.on('exit', function () {
+        seleniumDead = true;
+
+        maybeResolveDead();
+      });
+
+      broccoli.kill();
+      selenium.kill();
+    });
+  };
+
+  function exitAfterTests(status) {
+    var timer = setTimeout(function () {
+      process.exit();
+    }, 5000);
+
+    waitToDie().then(function () {
+      clearTimeout(timer);
+      process.exit(status);
+    });
+  }
+
+  return runTests().then(exitAfterTests).catch(exitAfterTests);
+}).catch(function (error) {
+  log('global-failure', error + '\n');
+  if (waitToDie) {
+    waitToDie().then(function () {
+      process.exit(1);
+    });
+  } else {
+    process.exit(1);
+  }
+});


### PR DESCRIPTION
Title says it all. This should give us early warnings if our API breaks, or if
we've somehow made ourselves incompatible with it. Nothing is stubbed. This
relies on the current build and the live shopify API of the `embed` shop to run
tests.

__NOTE:__ Expects `selenium-standalone.jar` to live in the root directory. This
dependency is managed on CI, but if you want to run it yourself, you'll have to
download it. I'm open on recommendations on how to document this.