### PR TITLE
Added custom domain and deprecating myShopifyDomain in config

### DIFF
--- a/src/adapters/listings-adapter.js
+++ b/src/adapters/listings-adapter.js
@@ -14,9 +14,9 @@ const ListingsAdapter = CoreObject.extend({
   },
 
   get baseUrl() {
-    const { myShopifyDomain, appId } = this.config;
+    const { domain, appId } = this.config;
 
-    return `https://${myShopifyDomain}.myshopify.com/api/apps/${appId}`;
+    return `https://${domain}/api/apps/${appId}`;
   },
 
   get headers() {

--- a/src/config.js
+++ b/src/config.js
@@ -15,7 +15,7 @@ const Config = CoreObject.extend({
    * @param {String} attrs.appId The app whose listings the client will be
    * using. If you are just modifying a buy button, the buy-button's app id is
    * 6. Otherwise, obtain the app id of the app you're modifying or extending.
-   * @param {String} attrs.myShopifyDomain You shop's `myshopify.com` domain.
+   * @param {String} attrs.domain Your shop's full domain.
    */
   constructor(attrs) {
     Object.keys(this.deprecatedProperties).forEach(key => {
@@ -105,6 +105,16 @@ const Config = CoreObject.extend({
    * @public
    */
   domain: ''
+
+  /**
+   * The subdomain of myshopify.io that all the api requests will go to
+   * @attribute myShopifyDomain
+   * @default ''
+   * @type String
+   * @public
+   * @deprecated Use `config.domain` instead.
+   */
+  myShopifyDomain: ''
 });
 
 export default Config;

--- a/src/config.js
+++ b/src/config.js
@@ -17,6 +17,14 @@ const Config = CoreObject.extend({
    * @param {String} attrs.myShopifyDomain You shop's `myshopify.com` domain.
    */
   constructor(attrs) {
+    Object.keys(this.deprecatedProperties).forEach(key => {
+      const transformName = this.deprecatedProperties[key];
+      const transform = this[transformName];
+
+      if (attrs.hasOwnProperty(key)) {
+        transform(attrs[key], attrs);
+      }
+    });
     this.requiredProperties.forEach(key => {
       if (!attrs.hasOwnProperty(key)) {
         throw new Error(`new Config() requires the option '${key}'`);
@@ -27,8 +35,37 @@ const Config = CoreObject.extend({
   },
 
   /**
-   * The apiKey for authenticating against shopify. This is your api client's
-   * public api token. Not the shared secret. Set during initialation.
+   * An object with keys for deprecated properties and values as functions that
+   * will transform the value into a usable value.
+   * @attribute deprecatedProperties
+   * @default { myShopifyDomain: this.transformMyShopifyDomain }
+   * @type Object
+   * @private
+   */
+  deprecatedProperties: {
+    myShopifyDomain: 'transformMyShopifyDomain'
+  },
+
+  /**
+   * Transform the myShopifyDomain config to a domain config.
+   * @method transformMyShopifyDomain
+   * @static
+   * @private
+   * @param {String} subdomain The original subdomain on myshopify.com
+   * @param {Object} attrs. The config attributes to be transformed to a
+   * non-deprecated state.
+   * @return {Object} the transformed config attributes.
+   */
+  transformMyShopifyDomain(subdomain, attrs) {
+    console.warn('Config - ',
+       `myShopifyDomain is deprecated,
+       please use domain and provide the whole myshopify.com domain.`);
+    attrs.domain = `${subdomain}.myshopify.com`;
+    delete attrs.myShopifyDomain;
+  },
+
+  /**
+   * Properties that must be set on initializations
    * @attribute requiredProperties
    * @default ['apiKey', 'appId', 'myShopifyDomain']
    * @type Array
@@ -37,7 +74,7 @@ const Config = CoreObject.extend({
   requiredProperties: [
     'apiKey',
     'appId',
-    'myShopifyDomain'
+    'domain'
   ],
 
 
@@ -60,12 +97,13 @@ const Config = CoreObject.extend({
   appId: '',
 
   /**
-   * @attribute myShopifyDomain
+   * The domain that all the api requests will go to
+   * @attribute domain
    * @default ''
    * @type String
    * @public
    */
-  myShopifyDomain: ''
+  domain: ''
 });
 
 export default Config;

--- a/src/config.js
+++ b/src/config.js
@@ -37,7 +37,8 @@ const Config = CoreObject.extend({
 
   /**
    * An object with keys for deprecated properties and values as functions that
-   * will transform the value into a usable value.
+   * will transform the value into a usable value. A depracation transform should
+   * have the value signature function(deprecated_value, config_to_be_transformed)
    * @attribute deprecatedProperties
    * @default { myShopifyDomain: this.transformMyShopifyDomain }
    * @type Object
@@ -59,8 +60,7 @@ const Config = CoreObject.extend({
    */
   transformMyShopifyDomain(subdomain, attrs) {
     logger.warn('Config - ',
-       `myShopifyDomain is deprecated,
-       please use domain and provide the whole myshopify.com domain.`);
+       'myShopifyDomain is deprecated, please use domain and provide the full shop domain.');
     attrs.domain = `${subdomain}.myshopify.com`;
     delete attrs.myShopifyDomain;
   },

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,5 @@
 import CoreObject from './metal/core-object';
+import logger from './logger';
 
 /**
  * @module shopify-buy
@@ -57,7 +58,7 @@ const Config = CoreObject.extend({
    * @return {Object} the transformed config attributes.
    */
   transformMyShopifyDomain(subdomain, attrs) {
-    console.warn('Config - ',
+    logger.warn('Config - ',
        `myShopifyDomain is deprecated,
        please use domain and provide the whole myshopify.com domain.`);
     attrs.domain = `${subdomain}.myshopify.com`;

--- a/src/config.js
+++ b/src/config.js
@@ -15,7 +15,7 @@ const Config = CoreObject.extend({
    * @param {String} attrs.appId The app whose listings the client will be
    * using. If you are just modifying a buy button, the buy-button's app id is
    * 6. Otherwise, obtain the app id of the app you're modifying or extending.
-   * @param {String} attrs.domain Your shop's full domain.
+   * @param {String} attrs.domain Your shop's full domain. (i.e. `craftedgoods.myshopify.com`)
    */
   constructor(attrs) {
     Object.keys(this.deprecatedProperties).forEach(key => {

--- a/src/config.js
+++ b/src/config.js
@@ -62,7 +62,6 @@ const Config = CoreObject.extend({
     logger.warn('Config - ',
        'myShopifyDomain is deprecated, please use domain and provide the full shop domain.');
     attrs.domain = `${subdomain}.myshopify.com`;
-    delete attrs.myShopifyDomain;
   },
 
   /**
@@ -104,7 +103,7 @@ const Config = CoreObject.extend({
    * @type String
    * @public
    */
-  domain: ''
+  domain: '',
 
   /**
    * The subdomain of myshopify.io that all the api requests will go to

--- a/src/config.js
+++ b/src/config.js
@@ -19,10 +19,10 @@ const Config = CoreObject.extend({
    */
   constructor(attrs) {
     Object.keys(this.deprecatedProperties).forEach(key => {
-      const transformName = this.deprecatedProperties[key];
-      const transform = this[transformName];
-
       if (attrs.hasOwnProperty(key)) {
+        const transformName = this.deprecatedProperties[key];
+        const transform = this[transformName];
+
         transform(attrs[key], attrs);
       }
     });

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,5 +1,17 @@
 import CoreObject from './metal/core-object';
 
+function wrapConsole(logCommand) {
+  return function () {
+    const args = Array.prototype.slice.call(arguments);
+
+    args.unshift('[JS-BUY-SDK]: ');
+    /* eslint-disable no-console */
+    console[logCommand](...args);
+    /* eslint-enable no-console */
+  };
+}
+
+
 const Logger = CoreObject.extend({
   /**
    * Wrapper around the console log so in the future we can have better dev output.
@@ -9,37 +21,10 @@ const Logger = CoreObject.extend({
    */
   constructor() {
   },
-
-  /* eslint-disable no-console */
-  log() {
-    console.log(...this.tagLog(...arguments));
-  },
-
-  debug() {
-    console.debug(...this.tagLog(...arguments));
-  },
-
-  info() {
-    console.info(...this.tagLog(...arguments));
-  },
-
-  warn() {
-    console.warn(...this.tagLog(...arguments));
-  },
-
-  error() {
-    console.error(...this.tagLog(...arguments));
-  },
-
-  tagLog() {
-    const args = Array.prototype.slice.call(arguments);
-
-    args.unshift('[JS-BUY-SDK]: ');
-
-    return args;
-  }
-  /* eslint-enable no-console */
-
+  debug: wrapConsole('debug'),
+  info: wrapConsole('info'),
+  warn: wrapConsole('warn'),
+  error: wrapConsole('error')
 });
 
 export default new Logger();

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,45 @@
+import CoreObject from './metal/core-object';
+
+const Logger = CoreObject.extend({
+  /**
+   * Wrapper around the console log so in the future we can have better dev output.
+   * Also allows us to disable output in production.
+   * @class Logger
+   * @constructor
+   */
+  constructor() {
+  },
+
+  /* eslint-disable no-console */
+  log() {
+    console.log(...this.tagLog(...arguments));
+  },
+
+  debug() {
+    console.debug(...this.tagLog(...arguments));
+  },
+
+  info() {
+    console.info(...this.tagLog(...arguments));
+  },
+
+  warn() {
+    console.warn(...this.tagLog(...arguments));
+  },
+
+  error() {
+    console.error(...this.tagLog(...arguments));
+  },
+
+  tagLog() {
+    const args = Array.prototype.slice.call(arguments);
+
+    args.unshift('[JS-BUY-SDK]: ');
+
+    return args;
+  }
+  /* eslint-enable no-console */
+
+});
+
+export default new Logger();

--- a/src/models/cart-model.js
+++ b/src/models/cart-model.js
@@ -82,7 +82,7 @@ const CartModel = BaseModel.extend({
   */
   get checkoutUrl() {
     const config = this.config;
-    const baseUrl = `https://${config.myShopifyDomain}.myshopify.com/cart`;
+    const baseUrl = `https://${config.domain}/cart`;
 
     const variantPath = this.lineItems.map(item => {
       return `${item.variant_id}:${item.quantity}`;

--- a/src/models/product-variant-model.js
+++ b/src/models/product-variant-model.js
@@ -148,7 +148,7 @@ const ProductVariantModel = BaseModel.extend({
   */
   checkoutUrl(quantity = 1) {
     const config = this.config;
-    const baseUrl = `https://${config.myShopifyDomain}.myshopify.com/cart`;
+    const baseUrl = `https://${config.domain}/cart`;
 
     const variantPath = `${this.id}:${parseInt(quantity, 10)}`;
 

--- a/src/shop-client.js
+++ b/src/shop-client.js
@@ -426,7 +426,7 @@ const ShopClient = CoreObject.extend({
    * @return {Promise|CartModel} The cart.
    */
   fetchRecentCart() {
-    return this.fetch('references', `${this.config.myShopifyDomain}.recent-cart`).then(reference => {
+    return this.fetch('references', `${this.config.domain}.recent-cart`).then(reference => {
       const cartId = reference.referenceId;
 
       return this.fetchCart(cartId);
@@ -436,7 +436,7 @@ const ShopClient = CoreObject.extend({
           referenceId: cart.id
         };
 
-        refAttrs[GUID_KEY] = `${this.config.myShopifyDomain}.recent-cart`;
+        refAttrs[GUID_KEY] = `${this.config.domain}.recent-cart`;
 
         this.create('references', refAttrs);
 

--- a/src/shopify.js
+++ b/src/shopify.js
@@ -28,7 +28,8 @@ const Shopify = {
    * const client = ShopifyBuy.buildClient({
    *   apiKey: 'abc123',
    *   appId: 123456,
-   *   myShopifyDomain: 'myshop'
+   *   myShopifyDomain: 'myshop',
+   *   domain: 'myshop.myshopify.com'
    * });
    * ```
    *
@@ -41,8 +42,9 @@ const Shopify = {
    * @param {String} configAttrs.appId The app whose listings the client will be
    * using. If you are just modifying a buy button, the buy-button's app id is
    * 6. Otherwise, obtain the app id of the app you're modifying or extending.
-   * @param {String} configAttrs.myShopifyDomain You shop's `myshopify.com`
+   * @param {String} configAttrs.myShopifyDomain [DEPRACATED] You shop's `myshopify.com`
    * domain.
+   * @param {String} configAttrs.domain You shop's full `myshopify.com` domain.
    * @return {ShopClient} a client for the shop using your api credentials.
    */
   buildClient(configAttrs = {}) {

--- a/src/shopify.js
+++ b/src/shopify.js
@@ -42,8 +42,6 @@ const Shopify = {
    * @param {String} configAttrs.appId The app whose listings the client will be
    * using. If you are just modifying a buy button, the buy-button's app id is
    * 6. Otherwise, obtain the app id of the app you're modifying or extending.
-   * @param {String} configAttrs.myShopifyDomain [DEPRACATED] You shop's `myshopify.com`
-   * domain.
    * @param {String} configAttrs.domain You shop's full `myshopify.com` domain.
    * @return {ShopClient} a client for the shop using your api credentials.
    */

--- a/tests/integration/shop-client-cart-test.js
+++ b/tests/integration/shop-client-cart-test.js
@@ -152,7 +152,7 @@ test('it has a checkout url reflecting the line items in the cart', function (as
     quantity: 1,
     variant_id: 12345
   };
-  const baseUrl = `https://${config.myShopifyDomain}.myshopify.com/cart`;
+  const baseUrl = `https://${config.domain}/cart`;
   const lineItemPath = `${lineItem.variant_id}:${lineItem.quantity}`;
   const query = `api_key=${config.apiKey}`;
 

--- a/tests/integration/shop-client-fetch-collection-test.js
+++ b/tests/integration/shop-client-fetch-collection-test.js
@@ -5,14 +5,14 @@ import Pretender from 'pretender';
 import { singleCollectionFixture, multipleCollectionsFixture } from '../fixtures/collection-fixture';
 
 const configAttrs = {
-  myShopifyDomain: 'buckets-o-stuff',
+  domain: 'buckets-o-stuff.myshopify.com',
   apiKey: 1,
   appId: 6
 };
 
 const config = new Config(configAttrs);
 
-const baseUrl = `https://${configAttrs.myShopifyDomain}.myshopify.com/api/apps/${configAttrs.appId}`;
+const baseUrl = `https://${configAttrs.domain}/api/apps/${configAttrs.appId}`;
 
 function apiUrl(path) {
   return `${baseUrl}${path}`;

--- a/tests/integration/shop-client-fetch-product-test.js
+++ b/tests/integration/shop-client-fetch-product-test.js
@@ -5,14 +5,14 @@ import Pretender from 'pretender';
 import { singleProductFixture, multipleProductsFixture } from '../fixtures/product-fixture';
 
 const configAttrs = {
-  myShopifyDomain: 'buckets-o-stuff',
+  domain: 'buckets-o-stuff.myshopify.com',
   apiKey: 1,
   appId: 6
 };
 
 const config = new Config(configAttrs);
 
-const baseUrl = `https://${configAttrs.myShopifyDomain}.myshopify.com/api/apps/${configAttrs.appId}`;
+const baseUrl = `https://${configAttrs.domain}/api/apps/${configAttrs.appId}`;
 
 function apiUrl(path) {
   return `${baseUrl}${path}`;

--- a/tests/integration/shop-client-recent-cart-test.js
+++ b/tests/integration/shop-client-recent-cart-test.js
@@ -5,7 +5,7 @@ import { GUID_KEY } from 'shopify-buy/metal/set-guid-for';
 import CartModel from 'shopify-buy/models/cart-model';
 
 const configAttrs = {
-  myShopifyDomain: 'buckets-o-stuff',
+  domain: 'buckets-o-stuff.myshopify.com',
   apiKey: 'abc123',
   appId: 6
 };
@@ -47,7 +47,7 @@ test('it resolves with an exisitng cart when a reference and corresponding cart 
 
   const done = assert.async();
 
-  const cartReferenceKey = `references.${config.myShopifyDomain}.recent-cart`;
+  const cartReferenceKey = `references.${config.domain}.recent-cart`;
   const cartId = 'carts.shopify-buy.123';
 
   const cartAttrs = {
@@ -106,7 +106,7 @@ test('it recovers from broken state when a reference exists to a non-existent ca
 
   const done = assert.async();
 
-  const cartReferenceKey = `references.${config.myShopifyDomain}.recent-cart`;
+  const cartReferenceKey = `references.${config.domain}.recent-cart`;
   const cartId = 'carts.shopify-buy.123';
 
   const cartRef = {
@@ -144,7 +144,7 @@ test('it properly transforms line items LineItem instances when fetched', functi
 
   const done = assert.async();
 
-  const cartReferenceKey = `references.${config.myShopifyDomain}.recent-cart`;
+  const cartReferenceKey = `references.${config.domain}.recent-cart`;
   const cartId = 'carts.shopify-buy.123';
 
   const cartAttrs = {

--- a/tests/unit/adapters/listings-adapter-test.js
+++ b/tests/unit/adapters/listings-adapter-test.js
@@ -6,8 +6,8 @@ import Promise from 'promise';
 let adapter;
 
 const appId = 6;
-const myShopifyDomain = 'buckets-o-stuff';
-const baseUrl = `https://${myShopifyDomain}.myshopify.com/api/apps/${appId}`;
+const domain = 'buckets-o-stuff.myshopify.com';
+const baseUrl = `https://${domain}/api/apps/${appId}`;
 const apiKey = 'abc123def456ghi';
 const base64ApiKey = btoa(apiKey);
 
@@ -29,7 +29,7 @@ module('Unit | ListingsAdapter', {
 test('it builds an appropriate baseUrl based on configured values', function (assert) {
   assert.expect(1);
 
-  adapter.config = { myShopifyDomain, appId };
+  adapter.config = { domain, appId };
 
   assert.equal(adapter.baseUrl, baseUrl);
 });
@@ -50,7 +50,7 @@ test('it builds auth headers using the base64 encoded api key', function (assert
 test('it builds the url for all collections', function (assert) {
   assert.expect(1);
 
-  adapter.config = { myShopifyDomain, appId };
+  adapter.config = { domain, appId };
 
   assert.equal(adapter.buildUrl('multiple', 'collections'), `${baseUrl}/collection_listings`);
 });
@@ -60,7 +60,7 @@ test('it builds the url for a single product', function (assert) {
 
   const id = 123;
 
-  adapter.config = { myShopifyDomain, appId };
+  adapter.config = { domain, appId };
 
   assert.equal(adapter.buildUrl('single', 'products', id), `${baseUrl}/product_listings/${id}`);
 });
@@ -71,7 +71,7 @@ test('it builds the url for a query', function (assert) {
   const id = 134;
   const page = 88;
 
-  adapter.config = { myShopifyDomain, appId };
+  adapter.config = { domain, appId };
 
   const expectedUrl = `${baseUrl}/product_listings?collection_id=${id}&page=${page}`;
 
@@ -81,7 +81,7 @@ test('it builds the url for a query', function (assert) {
 test('it sends a GET, the correct url, and auth headers for fetchMultiple to #ajax', function (assert) {
   assert.expect(3);
 
-  adapter.config = { myShopifyDomain, appId, apiKey };
+  adapter.config = { domain, appId, apiKey };
 
   adapter.ajax = function (method, url, opts) {
     assert.equal(method, 'GET');
@@ -104,7 +104,7 @@ test('it sends a GET, the correct url, and auth headers for fetchSingle to #ajax
 
   const id = 123;
 
-  adapter.config = { myShopifyDomain, appId, apiKey };
+  adapter.config = { domain, appId, apiKey };
 
   adapter.ajax = function (method, url, opts) {
     assert.equal(method, 'GET');
@@ -128,7 +128,7 @@ test('it sends a GET, the correct url, and auth headers for fetchMultiple with q
   const ids = [123, 456, 789];
   const page = 88;
 
-  adapter.config = { myShopifyDomain, appId, apiKey };
+  adapter.config = { domain, appId, apiKey };
 
   adapter.ajax = function (method, url, opts) {
     // Should resolve with a promise

--- a/tests/unit/api/config-deprecation-test.js
+++ b/tests/unit/api/config-deprecation-test.js
@@ -1,0 +1,90 @@
+/* eslint no-new: 0 */
+
+import { module, test } from 'qunit';
+import Config from 'shopify-buy/config';
+
+module('Unit | Config');
+
+const DeprecationKlass = Config.extend({
+  constructor() {
+    this.super(...arguments);
+  },
+  deprecatedProperties: {
+    dprop1: 'transformProp1',
+    dprop2: 'transformProp2',
+    dprop3: 'transformProp3'
+  },
+  requiredProperties: [
+    'endProp1',
+    'endProp2',
+    'endProp3',
+    'endProp4',
+    'endProp5'
+  ],
+  transformProp1(value, attrs) {
+    const initial = value.split(':');
+
+    attrs.endProp1 = initial[0];
+    attrs.endProp4 = initial[1];
+  },
+  transformProp2(value, attrs) {
+    attrs.endProp2 = 'z';
+  },
+  transformProp3(value, attrs) {
+    attrs.endProp3 += attrs.dprop3;
+  },
+  endProp1: '',
+  endProp2: '',
+  endProp3: '',
+  endProp4: '',
+  endProp5: ''
+});
+
+test('it should not touch non deprecated properties', function (assert) {
+  assert.expect(5);
+
+  const dklass = new DeprecationKlass({
+    endProp1: 'a',
+    endProp2: 'b',
+    endProp3: 'c',
+    endProp4: 'd',
+    endProp5: 'e'
+  });
+
+  assert.equal(dklass.endProp1, 'a', 'property should equal the value passed');
+  assert.equal(dklass.endProp2, 'b', 'property should equal the value passed');
+  assert.equal(dklass.endProp3, 'c', 'property should equal the value passed');
+  assert.equal(dklass.endProp4, 'd', 'property should equal the value passed');
+  assert.equal(dklass.endProp5, 'e', 'property should equal the value passed');
+});
+
+test('it should allow multiple deprecation transformations', function (assert) {
+  assert.expect(5);
+
+  const dklass = new DeprecationKlass({
+    dprop1: 'test:one',
+    dprop2: 'you wont see this',
+    dprop3: 'at',
+    endProp3: 'c',
+    endProp5: 'e'
+  });
+
+  assert.equal(dklass.endProp1, 'test', 'property should equal the transformed value');
+  assert.equal(dklass.endProp2, 'z', 'property should equal the transformed value');
+  assert.equal(dklass.endProp3, 'cat', 'property should equal the transformed value');
+  assert.equal(dklass.endProp4, 'one', 'property should equal the transformed value');
+  assert.equal(dklass.endProp5, 'e', 'property should equal the value passed');
+});
+
+test('it throws an error with some but not all params defined even with transformations', function (assert) {
+  assert.expect(1);
+
+  assert.throws(function () {
+    new DeprecationKlass({
+      dprop1: 'test:one',
+      dprop2: 'you wont see this',
+      dprop3: 'at',
+      endProp3: 'c'
+    });
+  }, 'some but not all required params should produce an error');
+});

--- a/tests/unit/api/config-test.js
+++ b/tests/unit/api/config-test.js
@@ -32,3 +32,52 @@ test('it doesn\'t throw when all required params are specified', function (asser
 
   assert.ok(config);
 });
+
+test('it should convert myShopifyDomain to domain', function (assert) {
+  assert.expect(1);
+
+  const config = new Config({
+    myShopifyDomain: 'krundle',
+    apiKey: 123,
+    appId: 6
+  });
+
+  assert.equal(config.domain, 'krundle.myshopify.com', 'domain should be myshopify.com domain');
+});
+
+test('it output a deprecation warning when using myShopifyDomain', function (assert) {
+  assert.expect(4);
+
+  /* eslint-disable no-console */
+  const oldLog = console.warn;
+  let output = [];
+
+  console.warn = function () {
+    output = Array.prototype.slice.call(arguments);
+  };
+
+  new Config({
+    myShopifyDomain: 'krundle',
+    apiKey: 123,
+    appId: 6
+  });
+
+  assert.equal(output.length, 3, 'logging should have a tag for config');
+  assert.equal(output[0], '[JS-BUY-SDK]: ', 'the deprecation warning should be tagged');
+  assert.equal(output[1], 'Config - ', 'the deprecation warning should say it\'s from config');
+  assert.notEqual(output[2].indexOf('deprecated'), -1, 'the deprecation warning should describe the problem');
+  console.warn = oldLog;
+  /* eslint-enable no-console */
+});
+
+test('it should set domain', function (assert) {
+  assert.expect(1);
+
+  const config = new Config({
+    domain: 'krundle.com',
+    apiKey: 123,
+    appId: 6
+  });
+
+  assert.equal(config.domain, 'krundle.com', 'domain should be krundle.com domain');
+});

--- a/tests/unit/api/config-test.js
+++ b/tests/unit/api/config-test.js
@@ -45,7 +45,7 @@ test('it should convert myShopifyDomain to domain', function (assert) {
   assert.equal(config.domain, 'krundle.myshopify.com', 'domain should be myshopify.com domain');
 });
 
-test('it output a deprecation warning when using myShopifyDomain', function (assert) {
+test('it should output a deprecation warning when using myShopifyDomain', function (assert) {
   assert.expect(4);
 
   /* eslint-disable no-console */

--- a/tests/unit/api/logger-test.js
+++ b/tests/unit/api/logger-test.js
@@ -1,0 +1,27 @@
+/* eslint no-new: 0 */
+
+import { module, test } from 'qunit';
+import logger from 'shopify-buy/logger';
+
+const testOutput = 'test output';
+
+module('Unit | Logger');
+
+['log', 'debug', 'info', 'warn', 'error'].forEach(method => {
+  test(`it should wrap ${method}`, function (assert) {
+    assert.expect(2);
+
+    /* eslint-disable no-console */
+    const oldLog = console[method];
+
+    console[method] = function () {
+      assert.equal(arguments[0], '[JS-BUY-SDK]: ', `console.${method} should be tagged`);
+      assert.equal(arguments[1], testOutput, `console.${method} should be wrapped`);
+    };
+
+    logger[method](testOutput);
+    console[method] = oldLog;
+    /* eslint-enable no-console */
+  });
+});
+

--- a/tests/unit/api/logger-test.js
+++ b/tests/unit/api/logger-test.js
@@ -7,7 +7,7 @@ const testOutput = 'test output';
 
 module('Unit | Logger');
 
-['log', 'debug', 'info', 'warn', 'error'].forEach(method => {
+['debug', 'info', 'warn', 'error'].forEach(method => {
   test(`it should wrap ${method}`, function (assert) {
     assert.expect(2);
 
@@ -24,4 +24,3 @@ module('Unit | Logger');
     /* eslint-enable no-console */
   });
 });
-

--- a/tests/unit/api/shop-client-test.js
+++ b/tests/unit/api/shop-client-test.js
@@ -7,7 +7,7 @@ import CartModel from 'shopify-buy/models/cart-model';
 import { GUID_KEY } from 'shopify-buy/metal/set-guid-for';
 
 const configAttrs = {
-  myShopifyDomain: 'buckets-o-stuff',
+  domain: 'buckets-o-stuff.myshopify.com',
   apiKey: 123,
   appId: 6
 };
@@ -588,7 +588,7 @@ test('it fetches a reference, then a cart on #fetchRecentCart when one exists', 
     if (type === 'references') {
       step(1, 'fetches a reference', assert);
 
-      assert.equal(idOrQuery, `${config.myShopifyDomain}.recent-cart`);
+      assert.equal(idOrQuery, `${config.domain}.recent-cart`);
 
       return new Promise(resolve => {
         resolve({ referenceId: cartId });
@@ -632,7 +632,7 @@ test('it fetches a reference and creates a cart on #fetchRecentCart when one doe
     if (type === 'references') {
       step(1, 'fetches a reference', assert);
 
-      assert.equal(idOrQuery, `${config.myShopifyDomain}.recent-cart`);
+      assert.equal(idOrQuery, `${config.domain}.recent-cart`);
 
       return new Promise((resolve, reject) => {
         reject({});
@@ -656,7 +656,7 @@ test('it fetches a reference and creates a cart on #fetchRecentCart when one doe
       });
     } else if (type === 'references') {
       step(3, 'it creates a reference with the cart id', assert);
-      assert.equal(attrs[GUID_KEY], `${config.myShopifyDomain}.recent-cart`);
+      assert.equal(attrs[GUID_KEY], `${config.domain}.recent-cart`);
       assert.equal(attrs.referenceId, cartModel.id);
 
       return new Promise(resolve => {
@@ -726,7 +726,7 @@ test('it fetches a reference and creates a cart on #fetchRecentCart with broken 
     } else if (type === 'references') {
       step(4, 'it saves a new reference to the cart', assert);
 
-      assert.equal(attrs[GUID_KEY], `${config.myShopifyDomain}.recent-cart`);
+      assert.equal(attrs[GUID_KEY], `${config.domain}.recent-cart`);
       assert.equal(attrs.referenceId, cartModel.id);
 
       return new Promise(resolve => {

--- a/tests/unit/models/cart-model-test.js
+++ b/tests/unit/models/cart-model-test.js
@@ -12,7 +12,7 @@ let shopClient;
 const { getItem, setItem, removeItem } = localStorage;
 const storage = {};
 const config = {
-  myShopifyDomain: 'buckets-o-stuff',
+  domain: 'buckets-o-stuff.myshopify.com',
   apiKey: 'abc123'
 };
 
@@ -274,7 +274,7 @@ test('it generates checkout permalinks', function (assert) {
 
   const done = assert.async();
 
-  const baseUrl = `https://${config.myShopifyDomain}.myshopify.com/cart`;
+  const baseUrl = `https://${config.domain}/cart`;
   const variantId = model.lineItems[0].variant_id;
   const quantity = model.lineItems[0].quantity;
   const query = `api_key=${config.apiKey}`;
@@ -303,7 +303,7 @@ test('it detects google analytics and appends the cross-domain linker param', fu
 
   const done = assert.async();
 
-  const baseUrl = `https://${config.myShopifyDomain}.myshopify.com/cart`;
+  const baseUrl = `https://${config.domain}/cart`;
   const variantId = model.lineItems[0].variant_id;
   const quantity = model.lineItems[0].quantity;
   const query = `api_key=${config.apiKey}`;

--- a/tests/unit/models/product-variant-test.js
+++ b/tests/unit/models/product-variant-test.js
@@ -50,7 +50,7 @@ const baseAttrs = {
 };
 
 const config = {
-  myShopifyDomain: 'buckets-o-stuff',
+  domain: 'buckets-o-stuff.myshopify.com',
   apiKey: 'abc123'
 };
 
@@ -157,7 +157,7 @@ test('image variants should be empty when there\'s not image', function (assert)
 test('it generates checkout permalinks from passed quantity', function (assert) {
   assert.expect(4);
 
-  const baseUrl = `https://${config.myShopifyDomain}.myshopify.com/cart`;
+  const baseUrl = `https://${config.domain}/cart`;
   const query = `api_key=${config.apiKey}`;
 
   assert.equal(model.checkoutUrl(), `${baseUrl}/${model.id}:1?${query}`, 'defaults to 1');


### PR DESCRIPTION
Changed client config to accept a `domain` config as well as deprecated `myShopifyDomain` to allow for completely custom domains. I added a deprecated transforms flow so that myShopifyDomain would be transformed to a domain config and issue a warning. This allows requiredProperties to act as it did before the change.

Added a logger that tags logs with `[JS-BUY-SDK]` so that when we issue deprecation warnings, it is clear where it comes from. It is pretty basic right now and is not much more than a wrapper around `console`. 

**cc** @tessalt @minasmart 