### PR TITLE
Typo

### DIFF
--- a/src/models/cart-model.js
+++ b/src/models/cart-model.js
@@ -175,7 +175,7 @@ const CartModel = BaseModel.extend({
   /**
     * Update line item quantity
     * ```javascript
-    * cart.updateLineItem(123, 2}).then(cart => {
+    * cart.updateLineItem(123, 2).then(cart => {
     *   // do things with the updated cart.
     * });
     * ```


### PR DESCRIPTION
Removes an extra `}` from the docs, as pointed out via email.

@harismahmood89 @tessalt 