### PR TITLE
BugFix - setGuidFor currently uses numberCache instead of stringCache

### DIFF
--- a/src/metal/set-guid-for.js
+++ b/src/metal/set-guid-for.js
@@ -50,7 +50,7 @@ function setGuidFor(obj) {
         id = stringCache[obj];
 
         if (!id) {
-          id = numberCache[obj] = `st${uuid()}`;
+          id = stringCache[obj] = `st${uuid()}`;
         }
 
         break;


### PR DESCRIPTION
BugFix .. setGuidFor currently uses numberCache instead of stringCache when sent item is an object