### PR TITLE
Adding protection to the log wrapping.

### DIFF
--- a/ci/deps
+++ b/ci/deps
@@ -35,4 +35,8 @@ fi
 
 ln -s $versioned_node_modules_path node_modules
 
+# See: https://github.com/npm/npm/issues/11283
+npm set progress=false
+
+# Install deps
 npm install

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,21 +1,21 @@
 import CoreObject from './metal/core-object';
 
 function wrapConsole(logCommand) {
-  let logMethod;
-
-  /* eslint-disable no-console */
-  try {
-    logMethod = Function.prototype.bind.call(console[logCommand], console);
-  } catch (e) {
-    logMethod = Function.prototype.bind.call(console.log, console);
-  }
-  /* eslint-enable no-console */
+  const logMethod = function () {
+    /* eslint-disable no-console */
+    if (console[logCommand]) {
+      console[logCommand](...arguments);
+    } else {
+      console.log(...arguments);
+    }
+    /* eslint-enable no-console */
+  };
 
   return function () {
-    const args = Array.prototype.slice.call(arguments);
+    const args = [...arguments];
 
     args.unshift('[JS-BUY-SDK]: ');
-    logMethod.apply(console, args);
+    logMethod(...args);
   };
 }
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,13 +1,21 @@
 import CoreObject from './metal/core-object';
 
 function wrapConsole(logCommand) {
+  let logMethod;
+
+  /* eslint-disable no-console */
+  try {
+    logMethod = Function.prototype.bind.call(console[logCommand], console);
+  } catch (e) {
+    logMethod = Function.prototype.bind.call(console.log, console);
+  }
+  /* eslint-enable no-console */
+
   return function () {
     const args = Array.prototype.slice.call(arguments);
 
     args.unshift('[JS-BUY-SDK]: ');
-    /* eslint-disable no-console */
-    console[logCommand](...args);
-    /* eslint-enable no-console */
+    logMethod.apply(console, args);
   };
 }
 
@@ -19,12 +27,12 @@ const Logger = CoreObject.extend({
    * @class Logger
    * @constructor
    */
-  constructor() {
-  },
+  constructor() { },
   debug: wrapConsole('debug'),
   info: wrapConsole('info'),
   warn: wrapConsole('warn'),
   error: wrapConsole('error')
 });
 
+export { wrapConsole };
 export default new Logger();

--- a/tests/unit/api/config-test.js
+++ b/tests/unit/api/config-test.js
@@ -2,6 +2,7 @@
 
 import { module, test } from 'qunit';
 import Config from 'shopify-buy/config';
+import logger from 'shopify-buy/logger';
 
 module('Unit | Config');
 
@@ -46,13 +47,12 @@ test('it should convert myShopifyDomain to domain', function (assert) {
 });
 
 test('it should output a deprecation warning when using myShopifyDomain', function (assert) {
-  assert.expect(4);
+  assert.expect(3);
 
-  /* eslint-disable no-console */
-  const oldLog = console.warn;
+  const oldLog = logger.warn;
   let output = [];
 
-  console.warn = function () {
+  logger.warn = function () {
     output = Array.prototype.slice.call(arguments);
   };
 
@@ -62,12 +62,10 @@ test('it should output a deprecation warning when using myShopifyDomain', functi
     appId: 6
   });
 
-  assert.equal(output.length, 3, 'logging should have a tag for config');
-  assert.equal(output[0], '[JS-BUY-SDK]: ', 'the deprecation warning should be tagged');
-  assert.equal(output[1], 'Config - ', 'the deprecation warning should say it\'s from config');
-  assert.notEqual(output[2].indexOf('deprecated'), -1, 'the deprecation warning should describe the problem');
-  console.warn = oldLog;
-  /* eslint-enable no-console */
+  assert.equal(output.length, 2, 'logging should have a tag for config');
+  assert.equal(output[0], 'Config - ', 'the deprecation warning should say it\'s from config');
+  assert.notEqual(output[1].indexOf('deprecated'), -1, 'the deprecation warning should describe the problem');
+  logger.warn = oldLog;
 });
 
 test('it should set domain', function (assert) {

--- a/tests/unit/api/logger-test.js
+++ b/tests/unit/api/logger-test.js
@@ -1,26 +1,42 @@
-/* eslint no-new: 0 */
-
+/* eslint no-new: 0, no-console: 0,  */
 import { module, test } from 'qunit';
 import logger from 'shopify-buy/logger';
+import { wrapConsole } from 'shopify-buy/logger';
 
 const testOutput = 'test output';
+let oldLog;
 
-module('Unit | Logger');
+module('Unit | Logger', {
+  before() {
+    oldLog = console.log;
+  },
+  after() {
+    console.log = oldLog;
+  }
+});
+
+test('it should wrap a valid console method', function (assert) {
+  assert.expect(2);
+  console.log = function () {
+    assert.equal(arguments[0], '[JS-BUY-SDK]: ', 'console.log should be tagged');
+    assert.equal(arguments[1], testOutput, 'console.log should be wrapped');
+  };
+  wrapConsole('log')(testOutput);
+});
+
+test('it should fallback to console.log if the method is not defined', function (assert) {
+  assert.expect(2);
+  console.log = function () {
+    assert.equal(arguments[0], '[JS-BUY-SDK]: ', 'console.log should be tagged');
+    assert.equal(arguments[1], testOutput, 'console.log should be wrapped');
+  };
+  wrapConsole('output')(testOutput);
+});
 
 ['debug', 'info', 'warn', 'error'].forEach(method => {
   test(`it should wrap ${method}`, function (assert) {
-    assert.expect(2);
-
-    /* eslint-disable no-console */
-    const oldLog = console[method];
-
-    console[method] = function () {
-      assert.equal(arguments[0], '[JS-BUY-SDK]: ', `console.${method} should be tagged`);
-      assert.equal(arguments[1], testOutput, `console.${method} should be wrapped`);
-    };
-
+    assert.expect(1);
     logger[method](testOutput);
-    console[method] = oldLog;
-    /* eslint-enable no-console */
+    assert.ok(true, `${method} should not throw an error`);
   });
 });


### PR DESCRIPTION
In IE9, apply cannot be called on console.log or any console method so I have wrapped the console methods in a function prototype from suggestion by @minasmart. I also added a try catch to catch if the method is undefined. It will fall back to console.log if the method being called is undefined.

cc @minasmart @tessalt 