### PR TITLE
Made sure btoa is loaded in nodejs environment when testing listings adapter

### DIFF
--- a/tests/unit/adapters/listings-adapter-test.js
+++ b/tests/unit/adapters/listings-adapter-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import ListingsAdapter from 'shopify-buy/adapters/listings-adapter';
 import version from 'shopify-buy/version';
 import Promise from 'promise';
+import 'shopify-buy/isomorphic-btoa';
 
 let adapter;
 


### PR DESCRIPTION
Because `btoa` is available in browsers, tests run smoothly in PhantomJS but breaks when attempt is made to run the `listings-adapter` test in Node.

This imports `isomorphic-btoa` which ensures `btoa` is available in both environments.