### PR TITLE
Simplify the build loop process.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,24 +1,25 @@
 /* global require, module */
 
-if (process.version < 'v4.0.0') {
-  require('babel-register')({
-    ignore: function (fileName) {
-      var whitelistedPackages = [
-        'broccoli-lint-eslint'
-      ].join('|');
+require('babel-register')({
+  ignore: function (fileName) {
+    var whitelistedPackages = [
+      'broccoli-lint-eslint'
+    ].join('|');
 
-      if (fileName.match(new RegExp(whitelistedPackages))) {
-        return false;
-      } else if (fileName.match(/node_modules/)) {
-        return true;
-      }
-
+    if (fileName.match(new RegExp(whitelistedPackages))) {
       return false;
-    },
-    presets: [
-      require('babel-preset-es2015')
-    ]
-  });
-}
+    } else if (fileName.match(/node_modules/)) {
+      return true;
+    }
+
+    return false;
+  },
+  presets: [
+    require('babel-preset-es2015')
+  ],
+  plugins: [
+    'transform-object-assign'
+  ]
+});
 
 module.exports = require('./js-buy-sdk-build');

--- a/build-lib/lib.js
+++ b/build-lib/lib.js
@@ -27,112 +27,64 @@ function sourceTree(pathConfig, moduleType) {
 }
 
 module.exports = function (pathConfig, env) {
-  let tree;
-
-  const amdTree = sourceTree(pathConfig, 'amd');
   const polyfillTree = polyfills(env);
   const loaderTree = loader();
 
-  const globalsOutput = concat(mergeTrees([amdTree, loaderTree]), {
-    header: ';(function () {',
-    headerFiles: ['loader.js'],
-    inputFiles: ['**/*.js'],
-    footer: `
-window.ShopifyBuy = require('shopify-buy/shopify').default;
-})();`,
-    outputFile: `${pkg.name}.globals.js`,
-    sourceMapConfig: { enabled: false }
+  const trees = [{
+    name: 'amd',
+    moduleType: 'amd',
+    additionalTrees: [],
+    concatOptions: {}
+  }, {
+    name: 'commonjs',
+    moduleType: 'commonjs',
+    additionalTrees: [],
+    concatOptions: {}
+  }, {
+    name: 'globals',
+    moduleType: 'amd',
+    additionalTrees: [loaderTree],
+    concatOptions: {
+      header: ';(function () {',
+      headerFiles: ['loader.js'],
+      footer: `
+        window.ShopifyBuy = require('shopify-buy/shopify').default;
+        })();
+      `
+    }
+  }].map(config => {
+    const baseTree = sourceTree(pathConfig, config.moduleType);
+
+    const bareTree = concat(mergeTrees([baseTree].concat(config.additionalTrees)), Object.assign({
+      inputFiles: ['**/*.js'],
+      outputFile: `${pkg.name}.${config.name}.js`,
+      sourceMapConfig: { enabled: false }
+    }, config.concatOptions));
+
+    const polyfilledLibTree = concat(mergeTrees([polyfillTree, bareTree]), {
+      headerFiles: ['polyfills.js'],
+      inputFiles: `${pkg.name}.${config.name}.js`,
+      outputFile: `${pkg.name}.polyfilled.${config.name}.js`,
+      sourceMapConfig: { enabled: false }
+    });
+
+    return mergeTrees([bareTree, polyfilledLibTree]);
   });
 
-  if (env === 'production') {
-    const amdOutput = concat(amdTree, {
-      inputFiles: ['**/*.js'],
-      outputFile: `${pkg.name}.amd.js`,
-      sourceMapConfig: { enabled: false }
-    });
+  const nodeTree = funnel(sourceTree(pathConfig, 'commonjs'), {
+    srcDir: '.',
+    destDir: './node-lib'
+  });
 
-    const polyFilledAmdOutput = concat(mergeTrees([amdOutput, polyfillTree]), {
-      headerFiles: ['polyfills.js'],
-      inputFiles: `${pkg.name}.amd.js`,
-      outputFile: `${pkg.name}.polyfilled.amd.js`,
-      sourceMapConfig: { enabled: false }
-    });
-
-    const polyFilledGlobalsOutput = concat(mergeTrees([globalsOutput, polyfillTree]), {
-      headerFiles: ['polyfills.js'],
-      inputFiles: `${pkg.name}.globals.js`,
-      outputFile: `${pkg.name}.polyfilled.globals.js`,
-      sourceMapConfig: { enabled: false }
-    });
-
-    const commonTree = sourceTree(pathConfig, 'commonjs');
-    const commonOutput = concat(commonTree, {
-      inputFiles: ['**/*.js'],
-      outputFile: `${pkg.name}.common.js`,
-      sourceMapConfig: { enabled: false }
-    });
-
-    const polyFilledCommonOutput = concat(mergeTrees([commonOutput, polyfillTree]), {
-      headerFiles: ['polyfills.js'],
-      inputFiles: `${pkg.name}.common.js`,
-      outputFile: `${pkg.name}.polyfilled.common.js`,
-      sourceMapConfig: { enabled: false }
-    });
-
-    const nodeLibOutput = funnel(commonTree, {
-      srcDir: '.',
-      destDir: './node-lib'
-    });
-
-    tree = mergeTrees([
-      polyfillTree,
-      amdOutput,
-      polyFilledAmdOutput,
-      globalsOutput,
-      polyFilledGlobalsOutput,
-      commonOutput,
-      polyFilledCommonOutput
-    ]);
-
-    const minifiedTree = uglifyJavaScript(funnel(tree, {
+  if (env.production) {
+    trees.push(uglifyJavaScript(funnel(trees, {
       getDestinationPath: function (path) {
         return path.replace(/\.js/, '.min.js');
       }
-    }));
-
-    const concatenatedScripts = new Licenser([
-      new Versioner([
-        mergeTrees([
-          tree,
-          minifiedTree
-        ])
-      ], { templateString: '{{versionString}}' })
-    ]);
-
-    tree = mergeTrees([concatenatedScripts, nodeLibOutput]);
-  } else {
-    const amdOutput = concat(mergeTrees([amdTree, loaderTree]), {
-      headerFiles: ['loader.js'],
-      inputFiles: ['**/*.js'],
-      outputFile: `${pkg.name}.amd.js`
-    });
-
-    const polyFilledGlobalsOutput = concat(mergeTrees([globalsOutput, polyfillTree]), {
-      headerFiles: ['polyfills.js'],
-      inputFiles: `${pkg.name}.globals.js`,
-      outputFile: `${pkg.name}.polyfilled.globals.js`,
-      sourceMapConfig: { enabled: false }
-    });
-
-    tree = new Versioner([
-      mergeTrees([
-        amdOutput,
-        polyfillTree,
-        globalsOutput,
-        polyFilledGlobalsOutput
-      ])
-    ], { templateString: '{{versionString}}' });
+    })));
   }
 
-  return tree;
+  return mergeTrees([nodeTree, loaderTree, polyfillTree, new Licenser([
+    new Versioner(trees, { templateString: '{{versionString}}' })
+  ])]);
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel-eslint": "5.0.0",
     "babel-plugin-transform-es2015-modules-amd": "6.8.0",
     "babel-plugin-transform-es2015-modules-commonjs": "6.8.0",
+    "babel-plugin-transform-object-assign": "6.8.0",
     "babel-preset-es2015": "6.9.0",
     "babel-register": "6.9.0",
     "broccoli": "0.16.9",

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,6 +10,7 @@
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
 
+  <script src="/loader.js"></script>
   <script src="/shopify-buy.amd.js"></script>
   <script src="/sdk-testing.js"></script>
   <script src="/polyfills.js"></script>

--- a/tests/unit/api/version-test.js
+++ b/tests/unit/api/version-test.js
@@ -9,5 +9,5 @@ test('it exists', function (assert) {
   assert.expect(2);
 
   assert.equal(typeof version, 'string');
-  assert.ok(version.match(/v\d\.\d\.\d-[a-f0-9]{6}/), 'a version string of the format vX.Y.Z-abc123 exists');
+  assert.ok(version.match(/v\d\.\d\.\d-[a-f0-9]{6}/), `a version string of the format vX.Y.Z-abc123 exists. Found ${version}`);
 });


### PR DESCRIPTION
This PR takes a lot of what was statically coded, and turns it into data. The
biggest invisible change is that now we're building all the things all the time,
instead of only building some things during dev, and all the things an build.

This also pulls the AMD loader out of the dev built artifact, and makes it something that must be explicitly loaded into the test environment.