### PR TITLE
Graph Query Helpers

### DIFF
--- a/graph/generator.js
+++ b/graph/generator.js
@@ -161,7 +161,7 @@ function exportBundle(types) {
 ${declaration}
 ${assignments}
 
-export default ${moduleName}`;
+export default Object.freeze(${moduleName})`;
 
   return types.concat({
     path: `${moduleName}.js`,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "6.8.0",
     "babel-plugin-transform-runtime": "6.9.0",
     "babel-preset-es2015": "6.9.0",
+    "babel-preset-es2015-rollup": "1.1.1",
     "babel-preset-stage-2": "6.11.0",
     "babel-register": "6.9.0",
     "babel-runtime": "6.11.6",

--- a/src/graph-helpers/fields.js
+++ b/src/graph-helpers/fields.js
@@ -1,0 +1,5 @@
+import join from './join';
+
+export default function fields(schema) {
+  return join(...schema.fields);
+}

--- a/src/graph-helpers/join.js
+++ b/src/graph-helpers/join.js
@@ -1,0 +1,3 @@
+export default function join(...fields) {
+  return fields.join(', ');
+}

--- a/src/graph-helpers/query.js
+++ b/src/graph-helpers/query.js
@@ -1,0 +1,10 @@
+import QueryRoot from 'graph/query-root';
+import relationship from './relationship';
+
+export default function query(/* resource, [requestArgs], [callback] */) {
+  const args = [...arguments];
+
+  args.unshift(QueryRoot);
+
+  return `query { ${relationship(...args)} }`;
+}

--- a/src/graph-helpers/raw-relationship.js
+++ b/src/graph-helpers/raw-relationship.js
@@ -1,4 +1,5 @@
 import graphSchema from 'graph/schema';
+import join from './join';
 
 function formatArgPair(key, hash) {
   return `${key}: ${hash[key]}`;
@@ -9,7 +10,7 @@ function formatArgs(argumentHash) {
     return formatArgPair(key, argumentHash);
   });
 
-  return `(${formattedArgs.join(', ')})`;
+  return `(${join(formattedArgs)})`;
 }
 
 export function parseArgs(args) {
@@ -49,5 +50,9 @@ export default function rawRelationship(/* schema, relationshipKey, requestArgsH
     body = '';
   }
 
-  return [relationshipKey, requestArgs, body].join(' ').trim();
+  const parts = [relationshipKey, requestArgs, body].filter(part => {
+    return part.length > 0;
+  });
+
+  return parts.join(' ').trim();
 }

--- a/src/graph-helpers/raw-relationship.js
+++ b/src/graph-helpers/raw-relationship.js
@@ -1,0 +1,53 @@
+import graphSchema from 'graph/schema';
+
+function formatArgPair(key, hash) {
+  return `${key}: ${hash[key]}`;
+}
+
+function formatArgs(argumentHash) {
+  const formattedArgs = Object.keys(argumentHash).map(key => {
+    return formatArgPair(key, argumentHash);
+  });
+
+  return `(${formattedArgs.join(', ')})`;
+}
+
+export function parseArgs(args) {
+  const schema = args[0];
+  const relationshipKey = args[1];
+
+  let requestArgsHash, bodyCallback;
+
+  if (typeof args[2] === 'function') {
+    bodyCallback = args[2];
+  } else {
+    requestArgsHash = args[2];
+    bodyCallback = args[3];
+  }
+
+  return [schema, relationshipKey, requestArgsHash, bodyCallback];
+}
+
+export default function rawRelationship(/* schema, relationshipKey, requestArgsHash, bodyCallback */) {
+  const [schema, relationshipKey, requestArgsHash, bodyCallback] = parseArgs(arguments);
+
+  const relationshipModuleName = schema.relationships[relationshipKey].schemaModule;
+  const relationshipSchema = graphSchema[relationshipModuleName];
+
+  let requestArgs;
+  let body;
+
+  if (requestArgsHash) {
+    requestArgs = formatArgs(requestArgsHash);
+  } else {
+    requestArgs = '';
+  }
+
+  if (bodyCallback) {
+    body = `{ ${bodyCallback(relationshipSchema)} }`;
+  } else {
+    body = '';
+  }
+
+  return [relationshipKey, requestArgs, body].join(' ').trim();
+}

--- a/src/graph-helpers/relationship.js
+++ b/src/graph-helpers/relationship.js
@@ -1,0 +1,39 @@
+import relationship from './raw-relationship';
+import { parseArgs } from './raw-relationship';
+import fields from './fields';
+import join from './join';
+
+function wrapCallback(callbackFunction) {
+  return function (schema) {
+    if (schema.name.match(/Connection$/)) {
+      const pageInfo = relationship(schema, 'pageInfo', pageInfoSchema => {
+        return fields(pageInfoSchema);
+      });
+      const edge = relationship(schema, 'edges', edgeSchema => {
+        const edgeFields = fields(edgeSchema);
+        const node = relationship(edgeSchema, 'node', nodeSchema => {
+          return callbackFunction(nodeSchema);
+        });
+
+        return join(edgeFields, node);
+      });
+
+      return join(pageInfo, edge);
+    }
+
+    return callbackFunction(...arguments);
+  };
+}
+
+export default function connectionAwareRelationship(/* schema, relationshipKey, requestArgsHash, bodyCallback */) {
+  const [schema, relationshipKey, requestArgsHash, bodyCallback] = parseArgs(arguments);
+  let wrappedCallback;
+
+  if (bodyCallback) {
+    wrappedCallback = wrapCallback(bodyCallback);
+  } else {
+    wrappedCallback = bodyCallback;
+  }
+
+  return relationship(schema, relationshipKey, requestArgsHash, wrappedCallback);
+}

--- a/tests/unit/graph/fields-test.js
+++ b/tests/unit/graph/fields-test.js
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+
+import fields from 'shopify-buy/graph-helpers/fields';
+import ProductSchema from 'graph/types/product';
+
+const querySplitter = /\s+/;
+
+module('Unit | GraphHelpers | fields');
+
+test('it extracts and formats fields from the schema, for a query', function (assert) {
+  assert.expect(ProductSchema.fields.length + 1);
+
+  const query = `product {
+    ${fields(ProductSchema)}
+  }`;
+
+  ProductSchema.fields.forEach(field => {
+    assert.ok(query.match(field), `query does not include ${field} from the schema`);
+  });
+
+  assert.equal(query.split(querySplitter).length, ProductSchema.fields.length + 3, 'query is not properly formatted');
+});

--- a/tests/unit/graph/join-test.js
+++ b/tests/unit/graph/join-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+
+import join from 'shopify-buy/graph-helpers/join';
+
+module('Unit | GraphHelpers | join');
+
+test('it joins fields with a single comma followed by a space', function (assert) {
+  assert.expect(1);
+
+  assert.equal(join('query1', 'query2'), 'query1, query2');
+});

--- a/tests/unit/graph/query-test.js
+++ b/tests/unit/graph/query-test.js
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+import q from 'shopify-buy/graph-helpers/query';
+
+module('Unit | GraphHelpers | query');
+
+test('it yields the child schema off of the query root', function (assert) {
+  assert.expect(1);
+
+  q('shop', shop => {
+    assert.equal(shop.name, 'Shop');
+  });
+});
+
+test('it wraps the query in the actual query root string', function (assert) {
+  assert.expect(1);
+
+  const query = q('shop', () => {
+    return 'someField';
+  });
+
+  assert.equal(query, 'query { shop { someField } }');
+});

--- a/tests/unit/graph/raw-relationship-test.js
+++ b/tests/unit/graph/raw-relationship-test.js
@@ -1,0 +1,74 @@
+import { module, test } from 'qunit';
+
+import rawRelationship from 'shopify-buy/graph-helpers/raw-relationship';
+import fields from 'shopify-buy/graph-helpers/fields';
+import QueryRoot from 'graph/query-root';
+
+const querySplitter = /[\s,]+/;
+
+function splitQuery(query) {
+  return query.split(querySplitter);
+}
+
+module('Unit | GraphHelpers | rawRelationship');
+
+test('it wraps the payload from the callback in the query', function (assert) {
+  assert.expect(1);
+
+  const query = rawRelationship(QueryRoot, 'shop', () => {
+    return 'rando-field';
+  });
+
+  assert.deepEqual(splitQuery(query), splitQuery(`shop {
+    rando-field
+  }`));
+});
+
+test('it passes the rawRelationship\'s schema', function (assert) {
+  assert.expect(4);
+
+  rawRelationship(QueryRoot, 'shop', shopSchema => {
+    assert.ok(typeof shopSchema === 'object');
+    assert.ok(Array.isArray(shopSchema.fields));
+    assert.ok(typeof shopSchema.fieldsWithArgs);
+    assert.ok(typeof shopSchema.rawRelationships);
+  });
+});
+
+test('it returns an enumerable schema that can extract fields', function (assert) {
+  let shopFields;
+
+  const shopQuery = rawRelationship(QueryRoot, 'shop', shopSchema => {
+    shopFields = shopSchema.fields;
+
+    return fields(shopSchema);
+  });
+
+  assert.expect(shopFields.length + 1);
+
+  shopFields.forEach(field => {
+    assert.ok(shopQuery.match(field), `query does not include field ${field}`);
+  });
+
+  assert.equal(splitQuery(shopQuery).length, shopFields.length + 3, 'query is not properrly formatted');
+});
+
+test('it takes args', function (assert) {
+  assert.expect(1);
+
+  const query = rawRelationship(QueryRoot, 'product', { id: 10 }, () => {
+    return 'rando-field';
+  });
+
+  assert.deepEqual(splitQuery(query), splitQuery(`product (id: 10) {
+    rando-field
+  }`));
+});
+
+test('it supports empty bodies', function (assert) {
+  assert.expect(1);
+
+  const query = rawRelationship(QueryRoot, 'product', { id: 10 });
+
+  assert.deepEqual(splitQuery(query), splitQuery('product (id: 10)'));
+});

--- a/tests/unit/graph/relationship-test.js
+++ b/tests/unit/graph/relationship-test.js
@@ -1,0 +1,61 @@
+import { module, test } from 'qunit';
+import relationship from 'shopify-buy/graph-helpers/relationship';
+
+import QueryRoot from 'graph/query-root';
+
+module('Unit | GraphHelpers | relationship');
+
+test('it wraps the connection and edge, only passing the root relationship schema', function (assert) {
+  assert.expect(1);
+
+  relationship(QueryRoot, 'shop', shop => {
+    return relationship(shop, 'products', { first: 10 }, product => {
+      assert.equal(product.name, 'Product');
+    });
+  });
+});
+
+test('it includes edges, nodes, and pageInfo for paginated sets', function (assert) {
+  assert.expect(7);
+
+  const query = relationship(QueryRoot, 'shop', shop => {
+    return relationship(shop, 'products', { first: 10 }, () => {
+      return 'some-field';
+    });
+  });
+
+  assert.ok(query, query);
+  assert.ok(query.match(/pageInfo/));
+  assert.ok(query.match(/hasNextPage/));
+  assert.ok(query.match(/hasPreviousPage/));
+  assert.ok(query.match(/cursor/));
+  assert.ok(query.match(/node/));
+  assert.ok(query.match(/edges/));
+});
+
+test('it passes the schema for non-paginated sets', function (assert) {
+  assert.expect(1);
+
+  relationship(QueryRoot, 'product', { id: 1 }, product => {
+    return relationship(product, 'images', image => {
+      assert.equal(image.name, 'Image');
+    });
+  });
+});
+
+test('it doesn\'t include nodes and edges in non-paginated queries', function (assert) {
+  assert.expect(6);
+
+  const query = relationship(QueryRoot, 'product', { id: 1 }, product => {
+    return relationship(product, 'images', () => {
+      return 'some-field';
+    });
+  });
+
+  assert.ok(query.match(/[^pageInfo]/));
+  assert.ok(query.match(/[^hasNextPage]/));
+  assert.ok(query.match(/[^hasPreviousPage]/));
+  assert.ok(query.match(/[^cursor]/));
+  assert.ok(query.match(/[^node]/));
+  assert.ok(query.match(/[^edges]/));
+});


### PR DESCRIPTION
This sort of makes the process of writing graph queries easier. The
syntax is more verbose than I'd like, so I'm open to suggestions on a
better approach.

## What does it provide?
- A guarantee that if you're code works, you're asking for graph API data
that exists.
- Don't know what fields exist on a resource? Don't know resource
relationships? Look at the schema module in the dev console and
introspect all the things, OR use helpers to inject all the things into
your requests.
- Paginated requests. You don't want to have to write your own
nodes/edges/pageInfo fetching code, so this wraps that up.

## Example Usage
```javascript
const query = q('shop', shop => {
  const shopFields = fields(shop);
  const products = relationship(shop, 'products', { first: 10 }, product => {
    return fields(products);
  });

  return join(shopFields, products);
});
```

Query will be a string like
```graphql
query {
  shop {
    name,
    language,
    country,
    etc.
    products (first:10) {
      pageInfo {
        hasNextPage,
        hasPreviousPage
      },
      edges {
        cursor,
        node {
          name,
          handle,
          createdAt,
          updateAt,
          etc.
        }
      }
    }
  }
}
```