### PR TITLE
Fix `npm run test-examples` failing on v6.2.2 due to stream event data sent as `Buffer` instead of `String`

### DIFF
--- a/scripts/test-examples
+++ b/scripts/test-examples
@@ -33,7 +33,9 @@ function bootSelenium() {
     var selenium = childProcess.exec('java -jar selenium-standalone.jar');
 
     // Selenium outputs everything on STDERR because it's hateful
-    selenium.stderr.on('data', function (data) {
+    selenium.stderr.on('data', function (rawData) {
+      var data = rawData.toString();
+
       if (data.toString().match(/Selenium Server is up and running/) && !resolved) {
         resolved = true;
         resolve(selenium);

--- a/scripts/test-examples
+++ b/scripts/test-examples
@@ -61,11 +61,16 @@ function bootBroccoli() {
       examplesEnv.EXAMPLES = 1;
 
       var broccoli = childProcess.exec('node ' + broccoliBin + ' serve', { env: examplesEnv });
+      var broccoliOutput = "";
 
       broccoli.stdout.on('data', function (data) {
-        log('broccoli', data);
+        broccoliOutput += data;
+      });
 
-        if (data.match(/Serving on http/) && !resolved) {
+      broccoli.stdout.on('end', function () {
+        log('broccoli', broccoliOutput);
+
+        if (broccoliOutput.match(/Serving on http/) && !resolved) {
           resolved = true;
           resolve(broccoli);
         }

--- a/scripts/test-examples
+++ b/scripts/test-examples
@@ -62,8 +62,9 @@ function bootBroccoli() {
 
       var broccoli = childProcess.exec('node ' + broccoliBin + ' serve', { env: examplesEnv });
 
-      broccoli.stdout.on('data', function (data) {
-        data = data.toString();
+      broccoli.stdout.on('data', function (rawData) {
+        var data = rawData.toString();
+
         log('broccoli', data);
 
         if (data.match(/Serving on http/) && !resolved) {
@@ -72,7 +73,9 @@ function bootBroccoli() {
         }
       });
 
-      broccoli.stderr.on('data', function (data) {
+      broccoli.stderr.on('data', function (rawData) {
+        var data = rawData.toString();
+
         log('broccoli-error', data);
       });
 

--- a/scripts/test-examples
+++ b/scripts/test-examples
@@ -61,7 +61,6 @@ function bootBroccoli() {
       examplesEnv.EXAMPLES = 1;
 
       var broccoli = childProcess.exec('node ' + broccoliBin + ' serve', { env: examplesEnv });
-      var broccoliOutput = "";
 
       broccoli.stdout.on('data', function (data) {
         data = data.toString();

--- a/scripts/test-examples
+++ b/scripts/test-examples
@@ -64,13 +64,10 @@ function bootBroccoli() {
       var broccoliOutput = "";
 
       broccoli.stdout.on('data', function (data) {
-        broccoliOutput += data;
-      });
+        data = data.toString();
+        log('broccoli', data);
 
-      broccoli.stdout.on('end', function () {
-        log('broccoli', broccoliOutput);
-
-        if (broccoliOutput.match(/Serving on http/) && !resolved) {
+        if (data.match(/Serving on http/) && !resolved) {
           resolved = true;
           resolve(broccoli);
         }


### PR DESCRIPTION
A child process sends streams on data events as against a string and the complete output is only available on completion of the stream.

This PR fixes this in `scripts/test-examples`. `npm run test-examples` failed on my machine because `.match` (a string function) is not a valid function on a stream buffer object.

👀 @minasmart @timbeiko 