### PR TITLE
Fix broken build after nested eslint dependency broke things.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,19 +1,6 @@
 /* global require, module */
 
 require('babel-register')({
-  ignore: function (fileName) {
-    var whitelistedPackages = [
-      'broccoli-lint-eslint'
-    ].join('|');
-
-    if (fileName.match(new RegExp(whitelistedPackages))) {
-      return false;
-    } else if (fileName.match(/node_modules/)) {
-      return true;
-    }
-
-    return false;
-  },
   presets: [
     require('babel-preset-es2015')
   ],

--- a/build-lib/examples.js
+++ b/build-lib/examples.js
@@ -4,7 +4,7 @@
 
 const funnel = require('broccoli-funnel');
 const mergeTrees = require('broccoli-merge-trees');
-const sass = require('broccoli-sass');
+const sass = require('broccoli-sass-source-maps');
 
 module.exports = function (pathConfig) {
   const staticFiles = funnel(pathConfig.examples, {
@@ -12,7 +12,7 @@ module.exports = function (pathConfig) {
     destDir: 'examples'
   });
 
-  const css = sass(['examples/cart/styles'], 'styles.scss', 'examples/cart/index.css');
+  const css = sass(['examples/cart/styles'], 'styles.scss', 'examples/cart/index.css', {});
 
   return mergeTrees([staticFiles, css]);
 };

--- a/examples/cart/wdio.conf.js
+++ b/examples/cart/wdio.conf.js
@@ -22,7 +22,7 @@ exports.config = {
   coloredLogs: true,
   screenshotPath: './errorShots/',
   baseUrl: 'http://localhost:4200/examples/cart',
-  waitforTimeout: 30000,
+  waitforTimeout: 60000,
   connectionRetryTimeout: 90000,
   connectionRetryCount: 3,
   framework: 'mocha',

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "broccoli-merge-trees": "1.1.1",
     "broccoli-plugin": "1.2.1",
     "broccoli-sane-watcher": "1.1.4",
-    "broccoli-sass": "0.7.0",
+    "broccoli-sass-source-maps": "1.7.0",
     "broccoli-static-compiler": "0.2.2",
     "broccoli-uglify-js": "0.1.3",
     "broccoli-uglify-sourcemap": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "broccoli-concat": "2.2.0",
     "broccoli-env": "0.0.1",
     "broccoli-funnel": "1.0.1",
-    "broccoli-lint-eslint": "2.2.1",
+    "broccoli-lint-eslint": "2.4.1",
     "broccoli-merge-trees": "1.1.1",
     "broccoli-plugin": "1.2.1",
     "broccoli-sane-watcher": "1.1.4",


### PR DESCRIPTION
We've been using babel-register to allow us to write es6 code in our build
tooling and have it run in node 0.12. By default, babel-register doesn't process
node modules. I had to override that behaviour because eslint was using `let` in
the version required by `broccoli-lint-eslint` at `v2.2.1`. After much
investigation, I was able to use the most recent `2.x` version of
`broccoli-lint-eslint`, because it referenced a `2.x` version of eslint. Eslint
2.x is supposed to support node 10 and up, but some intermediate versions (that
peer dependencies referenced) didn't follow through with that commitment.
**NOTE:** the 3.x series of eslint officially dropped support for node 12 via
[this commit](https://github.com/eslint/eslint/commit/58542e4) and we can not
update to eslint 3.x until we drop our support for node 12.

All this became apparent today because of a [flat-cache release](https://github.com/royriojas/flat-cache/commit/cd7aeed3304b839415c67434c1cd683dcdd29920)
that was fuzzy matched and added a dependency on [circular-json](https://github.com/WebReflection/circular-json)
which includes a reference to global `this` [here](https://github.com/WebReflection/circular-json/blob/0.2.0/build/circular-json.node.js#L184-L185)
which is totally broken under babel register (in node, `this === global` in the
global scope, but in babel-register's global scope `this === undefined`).