### PR TITLE
Simplified Brocfile.js and added in a .babelrc file

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["babel-preset-es2015"],
+  "plugins": ["transform-object-assign"]
+}

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,12 +1,3 @@
 /* global require, module */
 
-require('babel-register')({
-  presets: [
-    require('babel-preset-es2015')
-  ],
-  plugins: [
-    'transform-object-assign'
-  ]
-});
-
 module.exports = require('./js-buy-sdk-build');

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "babel-plugin-transform-es2015-modules-commonjs": "6.8.0",
     "babel-plugin-transform-object-assign": "6.8.0",
     "babel-preset-es2015": "6.9.0",
-    "babel-register": "6.9.0",
     "broccoli": "0.16.9",
     "broccoli-asset-rev": "2.4.1",
     "broccoli-babel-transpiler": "git+ssh://git@github.com/babel/broccoli-babel-transpiler.git#17b304da9a1c2c93ff484e3d37029f5fad0f96c9",


### PR DESCRIPTION
Hey I'm putting up this PR for discussions sake.

I've simplified the `Brocfile.js` where it doesn't register/setup Babel preset's and plugins. Doing this also allows for `babel-register` to be removed as a dev dep.

Thoughts? @minasmart @richgilbank @yomexzo 