### PR TITLE
Fix the ci test script to actually move the xunit report files in to place.

### DIFF
--- a/ci/test
+++ b/ci/test
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -x
 
 echo <<MESSAGE
 
@@ -16,10 +16,14 @@ echo <<MESSAGE
 
 MESSAGE
 
-npm run test-ci
-npm run test-examples
+(npm run test-ci)
+qunit_tests_status=$?
+(npm run test-examples)
+wdio_tests_status=$?
 
 mkdir -p $CIRCLE_TEST_REPORTS/xunit
 
 mv tests.xml $CIRCLE_TEST_REPORTS/xunit/
 mv WDIO.*.xml $CIRCLE_TEST_REPORTS/xunit/
+
+exit $qunit_tests_status || $wdio_tests_status


### PR DESCRIPTION
Previously, the test script was exiting at any failure. With this change, it captures test status, moves xunit files into place, then exits with the combined exit statuses of the test scripts to inform circle of any failures