### PR TITLE
Add helpers to discern types from fields

### DIFF
--- a/ci/deps
+++ b/ci/deps
@@ -17,7 +17,7 @@ echo <<MESSAGE
 MESSAGE
 
 # Versions differ intentionally. NPM package at 2.1.6 contains phantom 2.1.1
-curl -k -L -o phantomjs.tar.bz2 https://s3.amazonaws.com/travis-phantomjs/phantomjs-${PHANTOMJS_VERSION}-ubuntu-12.04.tar.bz2
+curl -k -L -o phantomjs.tar.bz2 https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2
 tar -jxf phantomjs.tar.bz2
 
 # Grab selenium standalone

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ machine:
     NODE_012_VERSION: v0.12.0
     NODE_4_VERSION: v4.2.2
     NODE_5_VERSION: v5.5.0
-    PHANTOMJS_VERSION: 2.0.0
+    PHANTOMJS_VERSION: 2.1.1
 
 dependencies:
   cache_directories:

--- a/graph/generator.js
+++ b/graph/generator.js
@@ -109,6 +109,7 @@ function extractTypeData(types) {
 
     return {
       name: type.name,
+      moduleName: dasherize(type.name),
       isBuiltin: isBuiltin(type.name),
       fields: fields.map(transformField).reduce(objectifyField, {}),
       fieldsWithArgs: fieldsWithArgs.map(transformFieldWithArgs).reduce(objectifyField, {}),

--- a/src/graph-helpers/raw-type-for-field.js
+++ b/src/graph-helpers/raw-type-for-field.js
@@ -5,7 +5,7 @@ function findInFields(property, type) {
 
   if (propertyDescriptor) {
     return {
-      name: 'Literal',
+      name: 'Scalar',
       isList: propertyDescriptor.isList
     };
   }
@@ -18,7 +18,7 @@ function findInFieldsWithArgs(property, type) {
 
   if (propertyDescriptor) {
     return {
-      name: 'Literal',
+      name: 'Scalar',
       isList: propertyDescriptor.isList
     };
   }

--- a/src/graph-helpers/raw-type-for-field.js
+++ b/src/graph-helpers/raw-type-for-field.js
@@ -1,0 +1,53 @@
+import graphSchema from 'graph/schema';
+
+function findInFields(property, type) {
+  const propertyDescriptor = type.fields[property];
+
+  if (propertyDescriptor) {
+    return {
+      name: 'Literal',
+      isList: propertyDescriptor.isList
+    };
+  }
+
+  return null;
+}
+
+function findInFieldsWithArgs(property, type) {
+  const propertyDescriptor = type.fieldsWithArgs[property];
+
+  if (propertyDescriptor) {
+    return {
+      name: 'Literal',
+      isList: propertyDescriptor.isList
+    };
+  }
+
+  return null;
+}
+
+function findInRelationships(property, type) {
+  const propertyDescriptor = type.relationships[property];
+
+  if (propertyDescriptor) {
+    const propertyType = graphSchema[propertyDescriptor.schemaModule];
+
+    return Object.assign({ isList: propertyDescriptor.isList }, propertyType);
+  }
+
+  return null;
+}
+
+function find(property, type) {
+  return (
+    findInFields(property, type) ||
+    findInFieldsWithArgs(property, type) ||
+    findInRelationships(property, type)
+  );
+}
+
+export default function rawTypeForField(property, typeModuleName) {
+  const containerType = graphSchema[typeModuleName];
+
+  return find(property, containerType);
+}

--- a/src/graph-helpers/raw-type-for-field.js
+++ b/src/graph-helpers/raw-type-for-field.js
@@ -1,4 +1,5 @@
 import graphSchema from 'graph/schema';
+import assign from '../metal/assign';
 
 function findInFields(property, type) {
   const propertyDescriptor = type.fields[property];
@@ -32,7 +33,7 @@ function findInRelationships(property, type) {
   if (propertyDescriptor) {
     const propertyType = graphSchema[propertyDescriptor.schemaModule];
 
-    return Object.assign({ isList: propertyDescriptor.isList }, propertyType);
+    return assign({ isList: propertyDescriptor.isList }, propertyType);
   }
 
   return null;

--- a/src/graph-helpers/type-for-field.js
+++ b/src/graph-helpers/type-for-field.js
@@ -1,0 +1,14 @@
+import rawTypeForField from './raw-type-for-field';
+
+export default function typeForField(/* field, typeModuleName */) {
+  const rawType = rawTypeForField(...arguments);
+
+  if (rawType.name.match(/Connection$/)) {
+    const edgeType = rawTypeForField('edges', rawType.moduleName);
+    const nodeType = rawTypeForField('node', edgeType.moduleName);
+
+    return Object.assign(nodeType, { isList: edgeType.isList });
+  }
+
+  return rawType;
+}

--- a/src/graph-helpers/type-for-field.js
+++ b/src/graph-helpers/type-for-field.js
@@ -1,4 +1,5 @@
 import rawTypeForField from './raw-type-for-field';
+import assign from '../metal/assign';
 
 export default function typeForField(/* field, typeModuleName */) {
   const rawType = rawTypeForField(...arguments);
@@ -7,7 +8,7 @@ export default function typeForField(/* field, typeModuleName */) {
     const edgeType = rawTypeForField('edges', rawType.moduleName);
     const nodeType = rawTypeForField('node', edgeType.moduleName);
 
-    return Object.assign(nodeType, { isList: edgeType.isList });
+    return assign(nodeType, { isList: edgeType.isList });
   }
 
   return rawType;

--- a/tests/unit/graph/raw-type-for-field-test.js
+++ b/tests/unit/graph/raw-type-for-field-test.js
@@ -3,8 +3,8 @@ import rawTypeForField from 'shopify-buy/graph-helpers/raw-type-for-field';
 
 module('Unit | GraphHelpers | rawTypeForField');
 
-test('', function (assert) {
-  assert.expect(12);
+test('it returns the exact field type', function (assert) {
+  assert.expect(14);
 
   const shopType = rawTypeForField('shop', 'query-root');
   const productType = rawTypeForField('product', 'query-root');

--- a/tests/unit/graph/raw-type-for-field-test.js
+++ b/tests/unit/graph/raw-type-for-field-test.js
@@ -14,6 +14,8 @@ test('it returns the exact field type', function (assert) {
   const shopProductsType = rawTypeForField('products', 'shop');
   const shopCollectionsType = rawTypeForField('collections', 'shop');
 
+  const productImagesType = rawTypeForField('images', 'product');
+
   assert.equal(shopType.name, 'Shop', 'shop\'s type');
   assert.equal(shopType.isList, false, 'shop isList');
   assert.equal(productType.name, 'Product', 'product\'s type');
@@ -27,4 +29,7 @@ test('it returns the exact field type', function (assert) {
   assert.equal(shopProductsType.isList, false, 'shopProduct isList');
   assert.equal(shopCollectionsType.name, 'CollectionConnection', 'shopCollection\'s type');
   assert.equal(shopCollectionsType.isList, false, 'shopCollection isList');
+
+  assert.equal(productImagesType.name, 'Image', 'productImage\'s type');
+  assert.equal(productImagesType.isList, true, 'productImage isList');
 });

--- a/tests/unit/graph/raw-type-for-field-test.js
+++ b/tests/unit/graph/raw-type-for-field-test.js
@@ -23,7 +23,7 @@ test('it returns the exact field type', function (assert) {
   assert.equal(collectionType.name, 'Collection', 'collection\'s type');
   assert.equal(collectionType.isList, false, 'collection isList');
 
-  assert.equal(shopNameType.name, 'Literal', 'shopName\'s type');
+  assert.equal(shopNameType.name, 'Scalar', 'shopName\'s type');
   assert.equal(shopNameType.isList, false, 'shopName isList');
   assert.equal(shopProductsType.name, 'ProductConnection', 'shopProduct\'s type');
   assert.equal(shopProductsType.isList, false, 'shopProduct isList');

--- a/tests/unit/graph/raw-type-for-field-test.js
+++ b/tests/unit/graph/raw-type-for-field-test.js
@@ -1,0 +1,30 @@
+import { module, test } from 'qunit';
+import rawTypeForField from 'shopify-buy/graph-helpers/raw-type-for-field';
+
+module('Unit | GraphHelpers | rawTypeForField');
+
+test('', function (assert) {
+  assert.expect(12);
+
+  const shopType = rawTypeForField('shop', 'query-root');
+  const productType = rawTypeForField('product', 'query-root');
+  const collectionType = rawTypeForField('collection', 'query-root');
+
+  const shopNameType = rawTypeForField('name', 'shop');
+  const shopProductsType = rawTypeForField('products', 'shop');
+  const shopCollectionsType = rawTypeForField('collections', 'shop');
+
+  assert.equal(shopType.name, 'Shop', 'shop\'s type');
+  assert.equal(shopType.isList, false, 'shop isList');
+  assert.equal(productType.name, 'Product', 'product\'s type');
+  assert.equal(productType.isList, false, 'product isList');
+  assert.equal(collectionType.name, 'Collection', 'collection\'s type');
+  assert.equal(collectionType.isList, false, 'collection isList');
+
+  assert.equal(shopNameType.name, 'Literal', 'shopName\'s type');
+  assert.equal(shopNameType.isList, false, 'shopName isList');
+  assert.equal(shopProductsType.name, 'ProductConnection', 'shopProduct\'s type');
+  assert.equal(shopProductsType.isList, false, 'shopProduct isList');
+  assert.equal(shopCollectionsType.name, 'CollectionConnection', 'shopCollection\'s type');
+  assert.equal(shopCollectionsType.isList, false, 'shopCollection isList');
+});

--- a/tests/unit/graph/type-for-field-test.js
+++ b/tests/unit/graph/type-for-field-test.js
@@ -1,0 +1,41 @@
+import { module, test } from 'qunit';
+import typeForField from 'shopify-buy/graph-helpers/type-for-field';
+
+module('Unit | GraphHelpers | typeForField');
+
+test('it returns the exact field type for fields representing singular', function (assert) {
+  assert.expect(14);
+
+  const shopType = typeForField('shop', 'query-root');
+  const productType = typeForField('product', 'query-root');
+  const collectionType = typeForField('collection', 'query-root');
+
+  const shopNameType = typeForField('name', 'shop');
+
+  assert.equal(shopType.name, 'Shop');
+  assert.equal(shopType.isList, false);
+  assert.equal(productType.name, 'Product');
+  assert.equal(productType.isList, false);
+  assert.equal(collectionType.name, 'Collection');
+  assert.equal(collectionType.isList, false);
+
+  assert.equal(shopNameType.name, 'Literal');
+  assert.equal(shopNameType.isList, false);
+});
+
+test('it returns the wrapped type for paginated lists', function (assert) {
+  const shopProductsType = typeForField('products', 'shop');
+  const shopCollectionsType = typeForField('collections', 'shop');
+
+  assert.equal(shopProductsType.name, 'Product');
+  assert.equal(shopProductsType.isList, true);
+  assert.equal(shopCollectionsType.name, 'Collection');
+  assert.equal(shopCollectionsType.isList, true);
+});
+
+test('it returns the exact type field for basic lists', function (assert) {
+  const productImagesType = typeForField('images', 'product');
+
+  assert.equal(productImagesType.name, 'Image', 'productImage\'s type');
+  assert.equal(productImagesType.isList, true, 'productImage isList');
+});

--- a/tests/unit/graph/type-for-field-test.js
+++ b/tests/unit/graph/type-for-field-test.js
@@ -4,7 +4,7 @@ import typeForField from 'shopify-buy/graph-helpers/type-for-field';
 module('Unit | GraphHelpers | typeForField');
 
 test('it returns the exact field type for fields representing singular', function (assert) {
-  assert.expect(14);
+  assert.expect(8);
 
   const shopType = typeForField('shop', 'query-root');
   const productType = typeForField('product', 'query-root');
@@ -19,7 +19,7 @@ test('it returns the exact field type for fields representing singular', functio
   assert.equal(collectionType.name, 'Collection');
   assert.equal(collectionType.isList, false);
 
-  assert.equal(shopNameType.name, 'Literal');
+  assert.equal(shopNameType.name, 'Scalar');
   assert.equal(shopNameType.isList, false);
 });
 


### PR DESCRIPTION
Adds to helper methods:
- `rawTypeForField(fieldName, schemaModuleName);`
  Returns the exact type for a field, as indicated by the graphql schema
- `typeForField(fieldName, schemaModuleName);`
  Returns the type for the field in a paginated-set aware way. Traversing connections
  and edges, and exposing the node type as the base type for the list.

The returned type data is the graphql type combined with an `isList` attribute which is extracted from the field