### PR TITLE
Only use graph types

### DIFF
--- a/graph/generator.js
+++ b/graph/generator.js
@@ -57,8 +57,7 @@ function transformRelationship(field) {
     fieldName: field.name,
     isList,
     type,
-    args,
-    schemaModule: dasherize(type)
+    args
   };
 
   return relationship;
@@ -75,8 +74,7 @@ function getParents(typeName, typeList) {
     }).length > 0);
   }).map(parent => {
     return {
-      type: parent.name,
-      schemaModule: dasherize(parent.name)
+      type: parent.name
     };
   });
 }
@@ -109,7 +107,6 @@ function extractTypeData(types) {
 
     return {
       name: type.name,
-      moduleName: dasherize(type.name),
       isBuiltin: isBuiltin(type.name),
       fields: fields.map(transformField).reduce(objectifyField, {}),
       fieldsWithArgs: fieldsWithArgs.map(transformFieldWithArgs).reduce(objectifyField, {}),
@@ -158,7 +155,7 @@ function exportBundle(types) {
   const declaration = `const ${moduleName} = {}`;
 
   const assignments = types.map(type => {
-    return `${moduleName}['${dasherize(type.name)}'] = ${type.name};`;
+    return `${moduleName}['${type.name}'] = ${type.name};`;
   }).join('\n');
 
   const body = `${imports}

--- a/src/graph-helpers/descriptor-for-field.js
+++ b/src/graph-helpers/descriptor-for-field.js
@@ -1,16 +1,19 @@
 import rawDescriptorForField from './raw-descriptor-for-field';
 
-export default function descriptorForField(/* field, typeModuleName */) {
+export default function descriptorForField(fieldName/* , typeModuleName */) {
   const rawDescriptor = rawDescriptorForField(...arguments);
 
-  if (rawDescriptor.name.match(/Connection$/)) {
-    const edgeDescriptor = rawDescriptorForField('edges', rawDescriptor.type.moduleName);
-    const nodeDescriptor = rawDescriptorForField('node', edgeDescriptor.type.moduleName);
+  if (rawDescriptor.typeName.match(/Connection$/)) {
+
+    const edgeDescriptor = rawDescriptorForField('edges', rawDescriptor.typeName);
+    const nodeDescriptor = rawDescriptorForField('node', edgeDescriptor.typeName);
 
     return {
-      name: nodeDescriptor.name,
+      fieldName,
+      typeName: nodeDescriptor.typeName,
       isList: edgeDescriptor.isList,
-      type: nodeDescriptor.type
+      type: nodeDescriptor.type,
+      isPaginated: true
     };
   }
 

--- a/src/graph-helpers/raw-descriptor-for-field.js
+++ b/src/graph-helpers/raw-descriptor-for-field.js
@@ -5,7 +5,8 @@ function findInFields(fieldName, type) {
 
   if (fieldDescriptor) {
     return {
-      name: 'Scalar',
+      fieldName,
+      typeName: 'Scalar',
       isList: fieldDescriptor.isList
     };
   }
@@ -18,7 +19,8 @@ function findInFieldsWithArgs(fieldName, type) {
 
   if (fieldDescriptor) {
     return {
-      name: 'Scalar',
+      fieldName,
+      typeName: 'Scalar',
       isList: fieldDescriptor.isList
     };
   }
@@ -30,10 +32,11 @@ function findInRelationships(fieldName, type) {
   const fieldDescriptor = type.relationships[fieldName];
 
   if (fieldDescriptor) {
-    const fieldType = graphSchema[fieldDescriptor.schemaModule];
+    const fieldType = graphSchema[fieldDescriptor.type];
 
     return {
-      name: fieldType.name,
+      fieldName,
+      typeName: fieldType.name,
       isList: fieldDescriptor.isList,
       type: fieldType
     };
@@ -52,6 +55,10 @@ function find(fieldName, type) {
 
 export default function rawDescriptorForField(fieldName, typeModuleName) {
   const containerType = graphSchema[typeModuleName];
+
+  if (!containerType) {
+    throw new Error(`Unknown parent GraphQL type ${typeModuleName}`);
+  }
 
   return find(fieldName, containerType);
 }

--- a/src/graph-helpers/raw-relationship.js
+++ b/src/graph-helpers/raw-relationship.js
@@ -32,7 +32,7 @@ export function parseArgs(args) {
 export default function rawRelationship(/* schema, relationshipKey, requestArgsHash, bodyCallback */) {
   const [schema, relationshipKey, requestArgsHash, bodyCallback] = parseArgs(arguments);
 
-  const relationshipModuleName = schema.relationships[relationshipKey].schemaModule;
+  const relationshipModuleName = schema.relationships[relationshipKey].type;
   const relationshipSchema = graphSchema[relationshipModuleName];
 
   let requestArgs;

--- a/tests/unit/graph/descriptor-for-field-test.js
+++ b/tests/unit/graph/descriptor-for-field-test.js
@@ -4,49 +4,58 @@ import graphSchema from 'graph/schema';
 
 module('Unit | GraphHelpers | descriptorForField');
 
-test('it returns the exact field type for fields representing singular', function (assert) {
-  assert.expect(11);
+test('it returns the exact field type for fields representing singular resources', function (assert) {
+  assert.expect(15);
 
-  const shopDescriptor = descriptorForField('shop', 'query-root');
-  const productDescriptor = descriptorForField('product', 'query-root');
-  const collectionDescriptor = descriptorForField('collection', 'query-root');
+  const shopDescriptor = descriptorForField('shop', 'QueryRoot');
+  const productDescriptor = descriptorForField('product', 'QueryRoot');
+  const collectionDescriptor = descriptorForField('collection', 'QueryRoot');
 
-  const shopNameDescriptor = descriptorForField('name', 'shop');
+  const shopNameDescriptor = descriptorForField('name', 'Shop');
 
-  assert.equal(shopDescriptor.name, 'Shop');
+  assert.equal(shopDescriptor.fieldName, 'shop');
+  assert.equal(shopDescriptor.typeName, 'Shop');
   assert.equal(shopDescriptor.isList, false);
-  assert.deepEqual(shopDescriptor.type, graphSchema.shop);
-  assert.equal(productDescriptor.name, 'Product');
+  assert.deepEqual(shopDescriptor.type, graphSchema.Shop);
+  assert.equal(productDescriptor.fieldName, 'product');
+  assert.equal(productDescriptor.typeName, 'Product');
   assert.equal(productDescriptor.isList, false);
-  assert.deepEqual(productDescriptor.type, graphSchema.product);
-  assert.equal(collectionDescriptor.name, 'Collection');
+  assert.deepEqual(productDescriptor.type, graphSchema.Product);
+  assert.equal(collectionDescriptor.fieldName, 'collection');
+  assert.equal(collectionDescriptor.typeName, 'Collection');
   assert.equal(collectionDescriptor.isList, false);
-  assert.deepEqual(collectionDescriptor.type, graphSchema.collection);
+  assert.deepEqual(collectionDescriptor.type, graphSchema.Collection);
 
-  assert.equal(shopNameDescriptor.name, 'Scalar');
+  assert.equal(shopNameDescriptor.fieldName, 'name');
+  assert.equal(shopNameDescriptor.typeName, 'Scalar');
   assert.equal(shopNameDescriptor.isList, false);
 });
 
 test('it returns the wrapped type for paginated lists', function (assert) {
-  assert.expect(6);
+  assert.expect(10);
 
-  const shopProductsDescriptor = descriptorForField('products', 'shop');
-  const shopCollectionsDescriptor = descriptorForField('collections', 'shop');
+  const shopProductsDescriptor = descriptorForField('products', 'Shop');
+  const shopCollectionsDescriptor = descriptorForField('collections', 'Shop');
 
-  assert.equal(shopProductsDescriptor.name, 'Product');
+  assert.equal(shopProductsDescriptor.fieldName, 'products');
+  assert.equal(shopProductsDescriptor.typeName, 'Product');
   assert.equal(shopProductsDescriptor.isList, true);
-  assert.deepEqual(shopProductsDescriptor.type, graphSchema.product);
-  assert.equal(shopCollectionsDescriptor.name, 'Collection');
+  assert.equal(shopProductsDescriptor.isPaginated, true);
+  assert.deepEqual(shopProductsDescriptor.type, graphSchema.Product);
+  assert.equal(shopCollectionsDescriptor.fieldName, 'collections');
+  assert.equal(shopCollectionsDescriptor.typeName, 'Collection');
   assert.equal(shopCollectionsDescriptor.isList, true);
-  assert.deepEqual(shopCollectionsDescriptor.type, graphSchema.collection);
+  assert.equal(shopCollectionsDescriptor.isPaginated, true);
+  assert.deepEqual(shopCollectionsDescriptor.type, graphSchema.Collection);
 });
 
 test('it returns the exact type field for basic lists', function (assert) {
-  assert.expect(3);
+  assert.expect(4);
 
-  const productImagesDescriptor = descriptorForField('images', 'product');
+  const productImagesDescriptor = descriptorForField('images', 'Product');
 
-  assert.equal(productImagesDescriptor.name, 'Image', 'productImage\'s type');
+  assert.equal(productImagesDescriptor.fieldName, 'images', 'productImage\'s type');
+  assert.equal(productImagesDescriptor.typeName, 'Image', 'productImage\'s type');
   assert.equal(productImagesDescriptor.isList, true, 'productImage isList');
-  assert.deepEqual(productImagesDescriptor.type, graphSchema.image);
+  assert.deepEqual(productImagesDescriptor.type, graphSchema.Image);
 });

--- a/tests/unit/graph/raw-descriptor-for-field-test.js
+++ b/tests/unit/graph/raw-descriptor-for-field-test.js
@@ -5,44 +5,51 @@ import graphSchema from 'graph/schema';
 module('Unit | GraphHelpers | rawDescriptorForField');
 
 test('it returns the type name with the exact field type and name', function (assert) {
-  assert.expect(20);
+  assert.expect(27);
 
-  const shopDescriptor = rawDescriptorForField('shop', 'query-root');
-  const productDescriptor = rawDescriptorForField('product', 'query-root');
-  const collectionDescriptor = rawDescriptorForField('collection', 'query-root');
+  const shopDescriptor = rawDescriptorForField('shop', 'QueryRoot');
+  const productDescriptor = rawDescriptorForField('product', 'QueryRoot');
+  const collectionDescriptor = rawDescriptorForField('collection', 'QueryRoot');
 
-  const shopNameDescriptor = rawDescriptorForField('name', 'shop');
-  const shopProductsDescriptor = rawDescriptorForField('products', 'shop');
-  const shopCollectionsDescriptor = rawDescriptorForField('collections', 'shop');
+  const shopNameDescriptor = rawDescriptorForField('name', 'Shop');
+  const shopProductsDescriptor = rawDescriptorForField('products', 'Shop');
+  const shopCollectionsDescriptor = rawDescriptorForField('collections', 'Shop');
 
-  const productImagesDescriptor = rawDescriptorForField('images', 'product');
+  const productImagesDescriptor = rawDescriptorForField('images', 'Product');
 
-  assert.equal(shopDescriptor.name, 'Shop', 'shop\'s type name');
+  assert.equal(shopDescriptor.fieldName, 'shop', 'shop\'s field name');
+  assert.equal(shopDescriptor.typeName, 'Shop', 'shop\'s type name');
   assert.equal(shopDescriptor.isList, false, 'shop isList');
-  assert.deepEqual(shopDescriptor.type, graphSchema.shop, 'shop\'s type');
+  assert.deepEqual(shopDescriptor.type, graphSchema.Shop, 'shop\'s type');
 
-  assert.equal(productDescriptor.name, 'Product', 'product\'s type name');
+  assert.equal(productDescriptor.fieldName, 'product', 'product\'s field name');
+  assert.equal(productDescriptor.typeName, 'Product', 'product\'s type name');
   assert.equal(productDescriptor.isList, false, 'product isList');
-  assert.deepEqual(productDescriptor.type, graphSchema.product, 'shop type');
+  assert.deepEqual(productDescriptor.type, graphSchema.Product, 'shop type');
 
-  assert.equal(collectionDescriptor.name, 'Collection', 'collection\'s type');
+  assert.equal(collectionDescriptor.fieldName, 'collection', 'collection\'s field name');
+  assert.equal(collectionDescriptor.typeName, 'Collection', 'collection\'s type name');
   assert.equal(collectionDescriptor.isList, false, 'collection isList');
-  assert.deepEqual(collectionDescriptor.type, graphSchema.collection, 'collection\'s type');
+  assert.deepEqual(collectionDescriptor.type, graphSchema.Collection, 'collection\'s type');
 
 
-  assert.equal(shopNameDescriptor.name, 'Scalar', 'shopName\'s type name');
+  assert.equal(shopNameDescriptor.fieldName, 'name', 'shopName\'s field name');
+  assert.equal(shopNameDescriptor.typeName, 'Scalar', 'shopName\'s type name');
   assert.equal(shopNameDescriptor.isList, false, 'shopName isList');
 
-  assert.equal(shopProductsDescriptor.name, 'ProductConnection', 'shopProduct\'s type name');
+  assert.equal(shopProductsDescriptor.fieldName, 'products', 'shopProduct\'s field name');
+  assert.equal(shopProductsDescriptor.typeName, 'ProductConnection', 'shopProduct\'s type name');
   assert.equal(shopProductsDescriptor.isList, false, 'shopProduct isList');
-  assert.deepEqual(shopProductsDescriptor.type, graphSchema['product-connection'], 'shopProduct\'s type');
+  assert.deepEqual(shopProductsDescriptor.type, graphSchema.ProductConnection, 'shopProduct\'s type');
 
-  assert.equal(shopCollectionsDescriptor.name, 'CollectionConnection', 'shopCollection\'s type name');
+  assert.equal(shopCollectionsDescriptor.fieldName, 'collections', 'shopCollection\'s type name');
+  assert.equal(shopCollectionsDescriptor.typeName, 'CollectionConnection', 'shopCollection\'s type name');
   assert.equal(shopCollectionsDescriptor.isList, false, 'shopCollection isList');
-  assert.deepEqual(shopCollectionsDescriptor.type, graphSchema['collection-connection'], 'collectionConnection\'s type');
+  assert.deepEqual(shopCollectionsDescriptor.type, graphSchema.CollectionConnection, 'collectionConnection\'s type');
 
 
-  assert.equal(productImagesDescriptor.name, 'Image', 'productImage\'s type name');
+  assert.equal(productImagesDescriptor.fieldName, 'images', 'productImage\'s field name');
+  assert.equal(productImagesDescriptor.typeName, 'Image', 'productImage\'s type name');
   assert.equal(productImagesDescriptor.isList, true, 'productImage isList');
-  assert.deepEqual(productImagesDescriptor.type, graphSchema.image, 'productImage\'s type');
+  assert.deepEqual(productImagesDescriptor.type, graphSchema.Image, 'productImage\'s type');
 });


### PR DESCRIPTION
I was using a mix of dasherized and canonical graph type names. The dasherized names existed more for aesthetics than anything else, but really just introduced a spot for me to make (poor) decisions. Using the canonical name everywhere removes that decision point, and makes it simpler to follow the code.