### PR TITLE
Add in a graphql deserializer

### DIFF
--- a/src/graph-helpers/deserialize-object.js
+++ b/src/graph-helpers/deserialize-object.js
@@ -31,8 +31,6 @@ export default function deserializeObject(objectGraph, typeName, registry = new 
     return attrAcc;
   }, {});
 
-  const model = new (registry.classForType(typeName))(attrs);
-
   const relationships = relationshipDescriptors.reduce((relationshipAcc, descriptor) => {
     relationshipAcc[descriptor.fieldName] = deserializeObject(objectGraph[descriptor.fieldName], descriptor.typeName, registry);
 
@@ -52,6 +50,8 @@ export default function deserializeObject(objectGraph, typeName, registry = new 
 
     return relationshipListsAcc;
   }, {});
+
+  const model = new (registry.classForType(typeName))(attrs);
 
   Object.assign(model, relationships, relationshipLists);
 

--- a/src/graph-helpers/deserialize-object.js
+++ b/src/graph-helpers/deserialize-object.js
@@ -1,5 +1,6 @@
 import descriptorForField from './descriptor-for-field';
 import ClassRegistry from './class-registry';
+import assign from '../metal/assign';
 
 function extractDescriptors(objectGraph, typeName) {
   return Object.keys(objectGraph).map(fieldName => {
@@ -7,16 +8,16 @@ function extractDescriptors(objectGraph, typeName) {
   });
 }
 
+function isAttr(descriptor) {
+  return descriptor.typeName === 'Scalar';
+}
+
 function isSingularRelationship(descriptor) {
-  return !(descriptor.typeName === 'Scalar' || descriptor.isList);
+  return !(descriptor.isList || isAttr(descriptor));
 }
 
 function isRelationshipList(descriptor) {
-  return descriptor.typeName !== 'Scalar' && descriptor.isList;
-}
-
-function isAttr(descriptor) {
-  return descriptor.typeName === 'Scalar';
+  return descriptor.isList && !isAttr(descriptor);
 }
 
 export default function deserializeObject(objectGraph, typeName, registry = new ClassRegistry()) {
@@ -53,7 +54,7 @@ export default function deserializeObject(objectGraph, typeName, registry = new 
 
   const model = new (registry.classForType(typeName))(attrs);
 
-  Object.assign(model, relationships, relationshipLists);
+  assign(model, relationships, relationshipLists);
 
   return model;
 }

--- a/src/graph-helpers/deserialize-object.js
+++ b/src/graph-helpers/deserialize-object.js
@@ -1,0 +1,59 @@
+import descriptorForField from './descriptor-for-field';
+import ClassRegistry from './class-registry';
+
+function extractDescriptors(objectGraph, typeName) {
+  return Object.keys(objectGraph).map(fieldName => {
+    return descriptorForField(fieldName, typeName);
+  });
+}
+
+function isSingularRelationship(descriptor) {
+  return !(descriptor.typeName === 'Scalar' || descriptor.isList);
+}
+
+function isRelationshipList(descriptor) {
+  return descriptor.typeName !== 'Scalar' && descriptor.isList;
+}
+
+function isAttr(descriptor) {
+  return descriptor.typeName === 'Scalar';
+}
+
+export default function deserializeObject(objectGraph, typeName, registry = new ClassRegistry()) {
+  const descriptors = extractDescriptors(objectGraph, typeName);
+  const relationshipDescriptors = descriptors.filter(isSingularRelationship);
+  const relationshipListDescriptors = descriptors.filter(isRelationshipList);
+  const attrDescriptors = descriptors.filter(isAttr);
+
+  const attrs = attrDescriptors.reduce((attrAcc, descriptor) => {
+    attrAcc[descriptor.fieldName] = objectGraph[descriptor.fieldName];
+
+    return attrAcc;
+  }, {});
+
+  const model = new (registry.classForType(typeName))(attrs);
+
+  const relationships = relationshipDescriptors.reduce((relationshipAcc, descriptor) => {
+    relationshipAcc[descriptor.fieldName] = deserializeObject(objectGraph[descriptor.fieldName], descriptor.typeName, registry);
+
+    return relationshipAcc;
+  }, {});
+
+  const relationshipLists = relationshipListDescriptors.reduce((relationshipListsAcc, descriptor) => {
+    if (descriptor.isPaginated) {
+      relationshipListsAcc[descriptor.fieldName] = objectGraph[descriptor.fieldName].edges.map(object => {
+        return deserializeObject(object.node, descriptor.typeName, registry);
+      });
+    } else {
+      relationshipListsAcc[descriptor.fieldName] = objectGraph[descriptor.fieldName].map(object => {
+        return deserializeObject(object, descriptor.typeName, registry);
+      });
+    }
+
+    return relationshipListsAcc;
+  }, {});
+
+  Object.assign(model, relationships, relationshipLists);
+
+  return model;
+}

--- a/tests/unit/graph/deserialize-object-test.js
+++ b/tests/unit/graph/deserialize-object-test.js
@@ -1,0 +1,129 @@
+import { module, test } from 'qunit';
+import GraphModel from 'shopify-buy/graph-helpers/graph-model';
+import deserializeObject from 'shopify-buy/graph-helpers/deserialize-object';
+import ClassRegistry from 'shopify-buy/graph-helpers/class-registry';
+
+
+const graphFixture = {
+  data: {
+    shop: {
+      name: 'buckets-o-stuff',
+      products: {
+        pageInfo: {
+          hasPreviousPage: false,
+          hasNextPage: false
+        },
+        edges: [
+          {
+            cursor: 'eyJsYXN0X2lkIjozNjc3MTg5ODg5LCJsYXN0X3ZhbHVlIjoiMzY3NzE4OTg4OSJ9',
+            node: {
+              handle: 'aluminum-pole'
+            }
+          },
+          {
+            cursor: 'eyJsYXN0X2lkIjozNjgwODg2NzIxLCJsYXN0X3ZhbHVlIjoiMzY4MDg4NjcyMSJ9',
+            node: {
+              handle: 'electricity-socket-with-jam'
+            }
+          },
+          {
+            cursor: 'eyJsYXN0X2lkIjo0MTQwMTI3MDQxLCJsYXN0X3ZhbHVlIjoiNDE0MDEyNzA0MSJ9',
+            node: {
+              handle: 'borktown'
+            }
+          }
+        ]
+      }
+    }
+  }
+};
+
+const productFixture = {
+  data: {
+    product: {
+      id: 'gid://shopify/Product/3677189889',
+      handle: 'aluminum-pole',
+      images: [
+        {
+          src: 'https://cdn.shopify.com/s/files/1/1090/1932/products/festivus-pole-the-strike-seinfeld.jpg?v=1449866700'
+        },
+        {
+          src: 'https://cdn.shopify.com/s/files/1/1090/1932/products/giphy.gif?v=1450204755'
+        }
+      ]
+    }
+  }
+};
+
+module('Unit | GraphHelpers | deserializeObject');
+
+test('it creates a GraphModel from the root type', function (assert) {
+  assert.expect(1);
+
+  const graph = deserializeObject(graphFixture.data, 'QueryRoot');
+
+  assert.ok(GraphModel.prototype.isPrototypeOf(graph), 'root type is a graph model');
+});
+
+test('it instantiates a model with relationship fields', function (assert) {
+  assert.expect(2);
+
+  const graph = deserializeObject(graphFixture.data, 'QueryRoot');
+
+  assert.ok(GraphModel.prototype.isPrototypeOf(graph.shop), 'shop relationship is a graph model');
+  assert.deepEqual(graph.shop.attrs, { name: 'buckets-o-stuff' }, 'shop model contains payloads attrs');
+});
+
+test('it creates an array from lists of paginated relationships', function (assert) {
+  assert.expect(2);
+
+  const graph = deserializeObject(graphFixture.data, 'QueryRoot');
+
+  assert.ok(Array.isArray(graph.shop.products), 'shops products are in an array');
+  assert.equal(graph.shop.products.length, 3, 'there are three products');
+});
+
+test('it instantiates paginated list members as models', function (assert) {
+  assert.expect(graphFixture.data.shop.products.edges.length * 2);
+
+  const graph = deserializeObject(graphFixture.data, 'QueryRoot');
+
+  graphFixture.data.shop.products.edges.forEach((product, index) => {
+    assert.ok(GraphModel.prototype.isPrototypeOf(graph.shop.products[index]), 'products are graph models');
+    assert.equal(graph.shop.products[index].attrs.handle, product.node.handle, 'products contain payload attrs');
+  });
+});
+
+test('it creates an array from lists of non-paginated relationships', function (assert) {
+  assert.expect(2);
+
+  const graph = deserializeObject(productFixture.data, 'QueryRoot');
+
+  assert.ok(Array.isArray(graph.product.images), 'products images are in an array');
+  assert.equal(graph.product.images.length, 2, 'there are two images');
+});
+
+test('it instantiates basic list members as models', function (assert) {
+  assert.expect(2);
+
+  const graph = deserializeObject(productFixture.data, 'QueryRoot');
+
+  assert.ok(GraphModel.prototype.isPrototypeOf(graph.product.images[0]));
+  assert.equal(graph.product.images[0].src, productFixture.data.product.images[0].src);
+});
+
+test('it instantiates types with their registered models', function (assert) {
+  const registry = new ClassRegistry();
+
+  class ShopModel extends GraphModel { }
+
+  class ProductModel extends GraphModel { }
+
+  registry.registerClassForType(ShopModel, 'Shop');
+  registry.registerClassForType(ProductModel, 'Product');
+
+  const graph = deserializeObject(graphFixture.data, 'QueryRoot', registry);
+
+  assert.ok(ShopModel.prototype.isPrototypeOf(graph.shop), 'shop node is a shop model');
+  assert.ok(ProductModel.prototype.isPrototypeOf(graph.shop.products[0]), 'product node is a product model');
+});


### PR DESCRIPTION
This adds in the deserializer chunk. It breaks fields up into scalars, relationships and lists of relationships. Instantiates a model from the class registry, and attaches relationships. Attributes that are in and of themselves models are recursively instatiated through this same function