### PR TITLE
fix includes bug where element begins with number

### DIFF
--- a/src/metal/includes.js
+++ b/src/metal/includes.js
@@ -1,46 +1,34 @@
-let includes;
+export default function (array, searchElement) {
+  const ObjectifiedArray = Object(array);
+  const length = parseInt(ObjectifiedArray.length, 10) || 0;
 
-if (!Array.prototype.includes) {
-  includes = function (array, searchElement) {
-    const ObjectifiedArray = Object(array);
-    const length = parseInt(ObjectifiedArray.length, 10) || 0;
-
-    if (length === 0) {
-      return false;
-    }
-
-    const startIndex = parseInt(arguments[1], 10) || 0;
-    let index;
-
-    if (startIndex >= 0) {
-      index = startIndex;
-    } else {
-      index = length + startIndex;
-
-      if (index < 0) {
-        index = 0;
-      }
-    }
-
-    while (index < length) {
-      const currentElement = ObjectifiedArray[index];
-
-      /* eslint no-self-compare:0 */
-      if (searchElement === currentElement ||
-         (searchElement !== searchElement && currentElement !== currentElement)) { // NaN !== NaN
-        return true;
-      }
-      index++;
-    }
-
+  if (length === 0) {
     return false;
-  };
-} else {
-  includes = function (array) {
-    const args = [].slice.call(arguments, 1);
+  }
 
-    return Array.prototype.includes.apply(array, args);
-  };
+  const startIndex = parseInt(arguments[2], 10) || 0;
+  let index;
+
+  if (startIndex >= 0) {
+    index = startIndex;
+  } else {
+    index = length + startIndex;
+
+    if (index < 0) {
+      index = 0;
+    }
+  }
+
+  while (index < length) {
+    const currentElement = ObjectifiedArray[index];
+
+    /* eslint no-self-compare:0 */
+    if (searchElement === currentElement ||
+       (searchElement !== searchElement && currentElement !== currentElement)) { // NaN !== NaN
+      return true;
+    }
+    index++;
+  }
+
+  return false;
 }
-
-export default includes;


### PR DESCRIPTION
I was originally receiving `Error: Invalid option selection for Size` errors on Firefox but not on Chrome, which I thought was a bit weird. After much debugging I realised the problem was this `includes` function (it isn't polyfilled on Chrome).

I am not sure where this code originally came from, but it looks like a bit of a confused implementation. The correct implementation of array.includes is `array.includes(searchElement[, fromIndex])`, whereas this function is used as `includes(array, searchElement)`. However, this code is trying to use `arguments[1]` as the `fromIndex` at line https://github.com/Shopify/js-buy-sdk/blob/master/src/metal/includes.js#L12, but `arguments[1]` is actually the searchElement here.

As it is doing `parseInt` on the `searchElement`, this means that the function would return `false` if the `searchElement` started with an integer, eg:
```
includes(['size1', 'size2'], 'size1')
-> true
includes(['1size', '2size'], '1size')
-> false
```

As far as I can tell, this function is only ever used directly and is actually not a proper polyfill. As such, I think it makes more sense to just always return the one (fixed) function.

I had some trouble getting the tests running. Let me know what your thoughts are or if there is anything else that needs including as part of the pull request.

Thanks!
