### PR TITLE
use xhr in IE10

### DIFF
--- a/examples/cart/index.js
+++ b/examples/cart/index.js
@@ -4,7 +4,7 @@ $(function() {
   ============================================================ */
   var client = ShopifyBuy.buildClient({
     apiKey: 'bf081e860bc9dc1ce0654fdfbc20892d',
-    myShopifyDomain: 'embeds',
+    domain: 'embeds.myshopify.com',
     appId: '6'
   });
 

--- a/examples/cart/index.js
+++ b/examples/cart/index.js
@@ -4,7 +4,7 @@ $(function() {
   ============================================================ */
   var client = ShopifyBuy.buildClient({
     apiKey: 'bf081e860bc9dc1ce0654fdfbc20892d',
-    domain: 'embeds.myshopify.com',
+    myShopifyDomain: 'embeds',
     appId: '6'
   });
 

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -1,5 +1,4 @@
 import ie9Ajax from './ie9-ajax';
-import global from './metal/global';
 
 function checkStatus(response) {
   if (response.status >= 200 && response.status < 300) {
@@ -26,8 +25,9 @@ function parseResponse(response) {
 }
 
 export default function ajax(method, url, opts = {}) {
-  var xhr = new XMLHttpRequest();
-  if (!'withCredentials' in xhr) {
+  const xhr = new XMLHttpRequest();
+
+  if (!('withCredentials' in xhr)) {
     return ie9Ajax(...arguments);
   }
 

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -26,7 +26,8 @@ function parseResponse(response) {
 }
 
 export default function ajax(method, url, opts = {}) {
-  if (global.XDomainRequest) {
+  var xhr = new XMLHttpRequest();
+  if (!'withCredentials' in xhr) {
     return ie9Ajax(...arguments);
   }
 


### PR DESCRIPTION
Since IE10 still has an `XDomainRequest` object, IE10 was making requests with XDR instead of XHR (which is supported in IE10), and they were failing for some reason that I haven't quite determined (XDR is "deprecated" in IE10 but still there). Checking for `'withCredentials' in xhr` is the recommended [solution from MS](https://blogs.msdn.microsoft.com/ie/2012/02/09/cors-for-xhr-in-ie10/) and examples page does work in IE10. 

Still works in IE9, but only if the host page is running HTTPS, which I don't think is a regression. 

@minasmart @richgilbank @mikkoh 