### PR TITLE
make console.log act like a proper function

### DIFF
--- a/examples/cart/index.html
+++ b/examples/cart/index.html
@@ -5,26 +5,6 @@
   <meta name="viewport" content="width=device-width">
   <title>JS Buy SDK Example -- Cart 001</title>
   <link rel="stylesheet" href="index.css">
-  <script>
-
-  if (typeof Function.prototype.bind != 'function') {
-    Function.prototype.bind = function bind(obj) {
-      var args = Array.prototype.slice.call(arguments, 1),
-        self = this,
-        nop = function() {},
-        bound = function() {
-          return self.apply(
-            this instanceof nop ? this : (obj || {}), args.concat(
-              Array.prototype.slice.call(arguments)
-            )
-          );
-        };
-      nop.prototype = this.prototype || {};
-      bound.prototype = new nop();
-      return bound;
-    };
-  }
-  </script>
   <script src="//code.jquery.com/jquery-2.2.1.min.js"></script>
   <script src="/shopify-buy.polyfilled.globals.js"></script>
   <script src="/examples/cart/index.js"></script>

--- a/examples/cart/index.html
+++ b/examples/cart/index.html
@@ -5,6 +5,26 @@
   <meta name="viewport" content="width=device-width">
   <title>JS Buy SDK Example -- Cart 001</title>
   <link rel="stylesheet" href="index.css">
+  <script>
+
+  if (typeof Function.prototype.bind != 'function') {
+    Function.prototype.bind = function bind(obj) {
+      var args = Array.prototype.slice.call(arguments, 1),
+        self = this,
+        nop = function() {},
+        bound = function() {
+          return self.apply(
+            this instanceof nop ? this : (obj || {}), args.concat(
+              Array.prototype.slice.call(arguments)
+            )
+          );
+        };
+      nop.prototype = this.prototype || {};
+      bound.prototype = new nop();
+      return bound;
+    };
+  }
+  </script>
   <script src="//code.jquery.com/jquery-2.2.1.min.js"></script>
   <script src="/shopify-buy.polyfilled.globals.js"></script>
   <script src="/examples/cart/index.js"></script>

--- a/src/logger.js
+++ b/src/logger.js
@@ -2,12 +2,15 @@ import CoreObject from './metal/core-object';
 
 function wrapConsole(logCommand) {
   const logMethod = function () {
+    let log;
+
     /* eslint-disable no-console */
     if (console[logCommand]) {
-      console[logCommand](...arguments);
+      log = Function.prototype.bind.call(console[logCommand], console);
     } else {
-      console.log(...arguments);
+      log = Function.prototype.bind.call(console.log, console);
     }
+    log(...arguments);
     /* eslint-enable no-console */
   };
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -3,6 +3,26 @@
   <meta charset="utf-8">
   <title>Buy Button SDK: Tests</title>
   <link rel="stylesheet" href="/qunit.css">
+  <script>
+
+  if (typeof Function.prototype.bind != 'function') {
+    Function.prototype.bind = function bind(obj) {
+      var args = Array.prototype.slice.call(arguments, 1),
+        self = this,
+        nop = function() {},
+        bound = function() {
+          return self.apply(
+            this instanceof nop ? this : (obj || {}), args.concat(
+              Array.prototype.slice.call(arguments)
+            )
+          );
+        };
+      nop.prototype = this.prototype || {};
+      bound.prototype = new nop();
+      return bound;
+    };
+  }
+  </script>
   <script src="/qunit.js"></script>
   <script src="/testem.js"></script>
 </head>


### PR DESCRIPTION
I swear we fixed this before... but anyways, in IE9, `console.log` isn't a proper function and doesn't support `apply`, which is what `...arguments` desugars to. 

@minasmart @richgilbank @mikkoh 