### PR TITLE
specify jsnext:main entry point for es6 consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.3",
   "description": "The JS Buy SDK is a lightweight library that allows you to build ecommerce into any website. It is based on Shopify's API and provides the ability to retrieve products and collections from your shop, add products to a cart, and checkout.",
   "main": "lib/shopify.js",
+  "jsnext:main": "src/shopify.js",
   "repository": "git@github.com:Shopify/js-buy-sdk.git",
   "scripts": {
     "build": "node ./scripts/build",


### PR DESCRIPTION
https://github.com/rollup/rollup/wiki/jsnext:main

Allows consumers using rollup to require es6 modules for tree-shakability. 