### PR TITLE
Docs Content Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ const shopClient = ShopifyBuy.buildClient({
 
 // fetch a product using resource id
 shopClient.fetchAllProducts()
-  .then(function (products) {
-    console.log(products);
-  })
-  .catch(function () {
-    console.log('Request failed');
-  });
+.then(function (products) {
+  console.log(products);
+})
+.catch(function () {
+  console.log('Request failed');
+});
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -8,6 +8,28 @@ checkout.
 
 If you're just getting started, please [read the docs](http://shopify.github.io/js-buy-sdk/).
 
+## Example
+```javascript
+const shopClient = ShopifyBuy.buildClient({
+  apiKey: 'bf081e860bc9dc1ce0654fdfbc20892d',
+  appId: 6,
+  domain: 'embeds.myshopify.com'
+});
+
+// fetch a product using resource id
+shopClient.fetchAllProducts()
+  .then(function (products) {
+    console.log(products);
+  })
+  .catch(function () {
+    console.log('Request failed');
+  });
+```
+
+## Documentation
+
+For full API documentation go checkout the [API docs](http://shopify.github.io/js-buy-sdk/).
+
 ## Contributing
 For help on setting up the repo locally, building, testing, and contributing
 please see [CONTRIBUTING.md](https://github.com/Shopify/js-buy-sdk/blob/master/CONTRIBUTING.md).

--- a/docs/assets/scripts/docs.js
+++ b/docs/assets/scripts/docs.js
@@ -1,4 +1,37 @@
 $(function() {
+  function filterOrderSideNavItem(pageUrl, items) {
+    var ORDER = [
+      'ShopifyBuy',
+      'ShopClient',
+      'ProductModel',
+      'ProductVariantModel',
+      'CartModel',
+      'CartLineItemModel'
+    ];
+
+    var newItems = ORDER.map(function(key) {
+      return items.find(function(docClass) {
+        return docClass.name === key;
+      });
+    })
+    .filter(function(value) {
+      return value;
+    });
+
+    return newItems;
+  }
+
+  function getHTMLForSideNavItems(pageUrl, items) {
+    return items.map(function(docClass) {
+      var activeClass = "";
+      if (pageUrl.includes(docClass.url.slice(2))) {
+        activeClass = "active";
+      }
+      return "<li><a href='" + docClass.url + "' class='docs-sub-nav__link " + activeClass + "'>" +
+        docClass.name +
+        "</a></li>";
+    });
+  }
 
   var highlightSubNavItem = function () {
     var pageUrl = window.location.href;
@@ -18,20 +51,9 @@ $(function() {
 
   var generateApiClassNavItems = function () {
     var pageUrl = window.location.href;
-    var items = window.YUIDocs.classes.map(function(docClass){
-      var activeClass = "";
-      if (pageUrl.includes(docClass.url.slice(2))) {
-        activeClass = "active";
-      }
-      return "<li><a href='" +
-        docClass.url +
-        "' class='docs-sub-nav__link " +
-        activeClass +
-        "'>" +
-        docClass.name +
-        "</a></li>"
-    });
-
+    var items = window.YUIDocs.classes.slice();
+    items = filterOrderSideNavItem(pageUrl, items);
+    items = getHTMLForSideNavItems(pageUrl, items);
 
     var html = "<ul class='docs-sub-nav'>" + items.join('') + "</ul>";
     $('.nav-item--reference').append(html);

--- a/docs/assets/scripts/docs.js
+++ b/docs/assets/scripts/docs.js
@@ -5,6 +5,7 @@ $(function() {
       'ShopClient',
       'ProductModel',
       'ProductVariantModel',
+      'ProductOptionModel',
       'CartModel',
       'CartLineItemModel'
     ];

--- a/docs/assets/scripts/docs.js
+++ b/docs/assets/scripts/docs.js
@@ -1,4 +1,4 @@
-$(function() {
+$(function () {
   function filterOrderSideNavItem(pageUrl, items) {
     var ORDER = [
       'ShopifyBuy',
@@ -10,12 +10,14 @@ $(function() {
       'CartLineItemModel'
     ];
 
-    var newItems = ORDER.map(function(key) {
-      return items.find(function(docClass) {
+    var newItems = ORDER.map(function (key) {
+      return items.find(function (docClass) {
+        console.log(docClass.name);
+
         return docClass.name === key;
       });
     })
-    .filter(function(value) {
+    .filter(function (value) {
       return value;
     });
 
@@ -23,7 +25,7 @@ $(function() {
   }
 
   function getHTMLForSideNavItems(pageUrl, items) {
-    return items.map(function(docClass) {
+    return items.map(function (docClass) {
       var activeClass = "";
       if (pageUrl.includes(docClass.url.slice(2))) {
         activeClass = "active";
@@ -45,7 +47,7 @@ $(function() {
   };
   highlightSubNavItem();
 
-  $(window).bind( 'hashchange', function(e) {
+  $(window).bind( 'hashchange', function (e) {
     highlightSubNavItem();
   });
 
@@ -65,14 +67,14 @@ $(function() {
 
   if(document.queryCommandSupported('copy')) {
     var clipboard = new Clipboard('[data-clipboard-text]');
-    clipboard.on('success', function(e) {
+    clipboard.on('success', function (e) {
       var previousText = $(e.trigger).text();
       $(e.trigger).text('Copied!');
-      setTimeout(function() {
+      setTimeout(function () {
         $(e.trigger).text(previousText);
       }, 2000);
     });
-    clipboard.on('error', function(e) {
+    clipboard.on('error', function (e) {
       $(e.trigger).text('Press ⌘-C now to copy');
     });
   }

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -134,9 +134,11 @@ To generate a `<select>` menus for a product's options, you would have to loop o
 
 ```js
 var selects = product.options.map(function (option) {
-  return '<select name="' + option.name + '">' + option.values.map(function(value) {
-    return '<option value="' + value + '">' + value + '</option>';
-  });
+  return '<select name="' + option.name + '">' + 
+    option.values.map(function(value) {
+      return '<option value="' + value + '">' + value + '</option>';
+    }).join('\n') +
+  '</select>';
 })
 ```
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -15,23 +15,26 @@ the [examples](/js-buy-sdk/examples).
 
 ## Creating a single "Buy Button" that links to checkout
 
-Once you have created your `ShopClient` ([see documentation here](/js-buy-sdk/#creating-a-shop-client)), fetch information about your product to display in your UI:
+Once you have created your `ShopClient` ([see documentation here](/js-buy-sdk/#creating-a-shop-client)), fetch a product:
 
 ```js
-var product;
-shopClient.fetchProduct(1234)
+shopClient.fetchProduct('8569911558')
   .then(function (product) {
-    product = product;
+    // do something with the product
   });
 ```
 
-To generate a checkout URL for this product, you can call the `checkoutUrl` getter for a variant and pass in a value for quantity:
+To generate a checkout URL for this product, you can call `checkoutUrl` on a [Product Variant](/js-buy-sdk/api/classes/ProductVariantModel.html#method-checkoutUrl) and pass in the quantity to be purchased:
 
 ```js
-var variant = product.variants[0];
-var checkoutURL;
+shopClient.fetchProduct('8569911558')
+  .then(function (product) {
+    var variant = product.variants[0];
+    var quantity = 1;
+    var checkoutURL;
 
-checkoutURL = variant.checkoutUrl(1);
+    checkoutURL = variant.checkoutUrl(quantity);
+  });
 ```
 
 Once you have obtained a checkout URL, you can insert this URL into the DOM by your preferred method.
@@ -41,64 +44,88 @@ Once you have obtained a checkout URL, you can insert this URL into the DOM by y
 
 ## Managing a Cart with the JS Buy SDK
 
-The JavaScript Buy SDK provides several convenience methods for managing a local Cart object, and synchronizing
-this cart with Shopify to obtain an accurate checkout link.
+The JavaScript Buy SDK provides several convenience methods for managing a [local Cart object](/js-buy-sdk/api/classes/CartModel.html), and synchronizing
+this cart with Shopify to obtain an accurate [checkout link](/js-buy-sdk/api/classes/CartModel.html#prop-checkoutUrl).
 
-### Initializing a cart
+### Initializing an empty cart
 
-Initializing a cart without passing through a variant will produce an empty cart which you can then
+Initializing a cart without passing a variant will produce an empty cart which you can then
 add and remove variants from.
 
 ```js
-var cart;
-shopClient.createCart().then(function (cart) {
-  // do something with cart
-});
-```
-
-Variants can be passed in during initalization to create a non-empty cart with those variants.
-
-```js
-var cart;
-shopClient.createCart({id: 123, quantity: 1}).then(function (cart) {
-  cart = cart;
-  // do something with cart
-});
+shopClient.createCart()
+  .then(function (cart) {
+    // do something with cart
+  });
 ```
 
 ### Adding items to a cart
 
-Items are added to the cart by calling the cart's `addVariants` method, which accepts one or more objects containing
-a variant ID and quantity. `addVariants` will update the cart and synchronizing it with Shopify. If you add a
+Items are added to the cart by calling the cart's `createLineItemsFromVariants` method, which accepts one or more objects containing
+a variant ID and quantity. `createLineItemsFromVariants` will update the cart and synchronizing it with Shopify. If you add a
 variant ID that already exists in the cart, that line item's quantity will be incremented.
 
-> Note: `addVariants` accepts a variable number of arguments, each of which must be an object containing an id and quantity.
+> Note: `createLineItemsFromVariants` accepts a variable number of arguments, each of which must be an object containing an id and quantity.
 
 ```js
-cart.addVariants({variant: variantObject, quantity: 1}).then(function (cart) {
-  // do something with updated cart
-});
+cart.createLineItemsFromVariants({variant: productVariant, quantity: 1})
+  .then(function (cart) {
+    // do something with updated cart
+  });
 ```
-> Note: `cart` is modified by calling `addVariants`
+> Note: `cart` is modified by calling `createLineItemsFromVariants`
 
-### Updating cart items
+### Updating cart line items
 
-You can update the quantity of items in the cart with the `updateLineItem` method, which accepts a cart item ID and a new quantity
-for the line item. If the quantity is less than 1, the line item will be removed.  
+You can update the quantity of items in the cart with the `updateLineItem` method, which accepts a line item ID and a new quantity
+for the line item.
 
 ```js
-cart.updateLineItem(123, 1).then(function (cart) {
-  // do something with updated cart
-});
+const firstLineItemId = cart.lineItems[0].id;
 
-cart.removeLineItem(123).then(function (cart) {
-  // do something with updated cart
-});
+// the following will set the quantity of the first line item to be 5
+cart.updateLineItem(firstLineItemId, 5)
+  .then(function (cart) {
+    // do something with updated cart
+  });
 ```
 
-> Note: Cart item IDs are strings, not integers
+### Removing cart line items
+
+You can remove line items by calling `removeLineItem`, which accepts the line item ID to be removed.
+
+```js
+const firstLineItemId = cart.lineItems[0].id;
+
+// the following will remove the first line item from the cart
+cart.removeLineItem(firstLineItemId)
+  .then(function (cart) {
+    // do something with updated cart
+  });
+```
+
+### Clearing cart line items
 
 You can remove all items from a cart with the `clearLineItems` method.
+
+```js
+// the following will remove all line item from the cart
+cart.clearLineItems()
+  .then(function (cart) {
+    // do something with updated cart
+  });
+```
+
+### Initializing a cart with a Variant
+
+Above we showed an example on how to initialize an empty cart. Alternately variants can be passed in during initalization to create a non-empty cart with those variants.
+
+```js
+shopClient.createCart({id: 123, quantity: 1})
+  .then(function (cart) {
+    // do something with cart
+  });
+```
 
 ## Selecting variants
 
@@ -134,7 +161,7 @@ option.value = selectedValue;
 The product's `selectedVariant` property will now reflect the variant matching the selected options.
 
 ```js
-cart.addVariants({
+cart.createLineItemsFromVariants({
   variant: product.selectedVariant,
   quantity: 1
 }).then(function (cart) {

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -116,17 +116,6 @@ cart.clearLineItems()
   });
 ```
 
-### Initializing a cart with a Variant
-
-Above we showed an example on how to initialize an empty cart. Alternately variants can be passed in during initalization to create a non-empty cart with those variants.
-
-```js
-shopClient.createCart({id: 123, quantity: 1})
-  .then(function (cart) {
-    // do something with cart
-  });
-```
-
 ## Selecting variants
 
 A product's options are accessed through `product.options`. Options are used to determine which variant is selected.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -129,8 +129,11 @@ shopClient.createCart({id: 123, quantity: 1})
 
 ## Selecting variants
 
-A product's options are accessed through `product.options`. Each option has a `values` property which is an array of possible values.
-To generate a `<select>` menus for a product's options, you would have to loop over the `product.options` array and the `values` array for each option.
+A product's options are accessed through `product.options`. Options are used to determine which variant is selected.
+
+Each option has a `values` Array which contains all possible valuse for a products option. For instance if an option is Size values could be: Small, Medium, Large.
+
+Here is an example to generate `<select>` menus for a product's options:
 
 ```js
 var selects = product.options.map(function (option) {
@@ -139,35 +142,65 @@ var selects = product.options.map(function (option) {
       return '<option value="' + value + '">' + value + '</option>';
     }).join('\n') +
   '</select>';
-})
+});
 ```
+
+If this product only had one option: Size. `selects[0]` would be as follows:
+
+```html
+<select name="Size">
+  <option value="Small">Small</option>
+  <option value="Medium">Medium</option>
+  <option value="Large">Large</option>
+</select>
+```
+
+
 
 You can also use buttons or radio inputs to allow customers to select options, but in any case you will need to update the selected variant based
 on the user's selection.
 
 ### Updating selected variant
 
-When a customer selects an option, you will need to set the `selected` property for that option to the selected value. For example:
+When a customer selects an option, you will need to set the `value` property for that option to the selected value. 
+
+The example below builds on the example above. A series of `<select>` elements is created but this time we add an `onchange` listener which updates the products selected options:
 
 ```js
-var optionName, selectedValue;
-// option Name and selected value obtained from DOM/user interaction
+// handleChange will be called whenever one of the selects
+// values are changed
+function handleChange(select) {
+  var optionName = select.name;
+  var selectedValue = select.value;
 
-var option = product.options.filter(function (option) {
-  return option.name === optionName;
-})[0];
+  var option = product.options.filter(function (option) {
+    return option.name === optionName;
+  })[0];
 
-option.value = selectedValue;
+  option.selected = selectedValue;
+}
+
+// the following is the code from the above example showing how to
+// create a select from a products options
+var selects = product.options.map(function (option) {
+  return '<select name="' + option.name + '" onchange="handleChange">' + 
+    option.values.map(function(value) {
+      return '<option value="' + value + '">' + value + '</option>';
+    }).join('\n') +
+  '</select>';
+});
 ```
 
-The product's `selectedVariant` property will now reflect the variant matching the selected options.
+The product's `selectedVariant` property will be updated to reflect the variant matching the selected options.
+
+`selectedVariant` can be quickly used to create line items for a cart like this:
 
 ```js
 cart.createLineItemsFromVariants({
   variant: product.selectedVariant,
   quantity: 1
 }).then(function (cart) {
-  cart = cart;
+  // do something with the cart such as create a checkout url
 });
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -109,7 +109,7 @@ cart.addVariants({variant: product.selectedVariant, quantity: 1}).then(function 
 });
 ```
 
-### Creating a checkout URL
+### Creating a cart checkout URL
 
 You can generate a checkout URL for a given cart at any time by retrieving the `cart.checkoutUrl`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,14 @@ or `fetchCollection`, or an array of `Cart` or `Collection` models for `fetchAll
 To request an individual resource, you will need to pass that resource's ID as the first argument. <a href="https://docs.shopify.com/api/sdks/js-buy-sdk/getting-started#retrieving-products" target="_blank">How do I find my resource ID?</a>
 
 ```js
-shopClient.fetchProduct(1234)
+const shopClient = ShopifyBuy.buildClient({
+  apiKey: 'bf081e860bc9dc1ce0654fdfbc20892d',
+  appId: 6,
+  domain: 'embeds.myshopify.com'
+});
+
+// fetch a product using resource id
+shopClient.fetchProduct('8569911558')
   .then(function (product) {
     console.log(product);
   })

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,12 @@ This tool is intended for use by developers who are experienced with JavaScript.
 
 ## Including the Buy SDK
 
+### via NPM
+```
+npm install shopify-buy
+```
+
+### via CDN
 ```html
 <script src="http://sdks.shopifycdn.com/js-buy-sdk/v{{majorVersion}}/latest/shopify-buy.umd.polyfilled.min.js"></script>
 ```
@@ -65,7 +71,7 @@ To request an individual resource, you will need to pass that resource's ID as t
 ```js
 const shopClient = ShopifyBuy.buildClient({
   apiKey: 'bf081e860bc9dc1ce0654fdfbc20892d',
-  appId: 6,
+  appId: '6',
   domain: 'embeds.myshopify.com'
 });
 

--- a/examples/cart/index.js
+++ b/examples/cart/index.js
@@ -312,7 +312,7 @@ $(function() {
   function addVariantToCart(variant, quantity) {
     openCart();
 
-    cart.addVariants({ variant: variant, quantity: quantity }).then(function() {
+    cart.createLineItemsFromVariants({ variant: variant, quantity: quantity }).then(function() {
       var cartItem = cart.lineItems.filter(function (item) {
         return (item.variant_id === variant.id);
       })[0];

--- a/examples/checkout/index.js
+++ b/examples/checkout/index.js
@@ -17,7 +17,7 @@ $(function() {
     cart = values[0];
     product = values[1];
     
-    return cart.addVariants(
+    return cart.createLineItemsFromVariants(
       {
         variant: product.variants[0], 
         quantity: 5

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "wdio-mocha-framework": "0.3.1",
     "webdriverio": "4.0.9",
     "whatwg-fetch": "0.10.1",
-    "yuidoc-lucid-theme": "git+ssh://git@github.com/Shopify/yuidoc-lucid-theme.git#0b226d5",
+    "yuidoc-lucid-theme": "git+ssh://git@github.com/Shopify/yuidoc-lucid-theme.git#c9c62ba",
     "yuidocjs": "0.10.2"
   },
   "browser": {

--- a/src/config.js
+++ b/src/config.js
@@ -1,22 +1,7 @@
 import CoreObject from './metal/core-object';
 import logger from './logger';
 
-/**
- * @module shopify-buy
- * @submodule config
- */
-
 const Config = CoreObject.extend({
-  /**
-   * @class Config
-   * @constructor
-   * @param {Object} attrs An object of required config data.
-   * @param {String} attrs.apiKey Your api client's public token
-   * @param {String} attrs.appId The app whose listings the client will be
-   * using. If you are just modifying a buy button, the buy-button's app id is
-   * 6. Otherwise, obtain the app id of the app you're modifying or extending.
-   * @param {String} attrs.domain Your shop's full domain. (i.e. `craftedgoods.myshopify.com`)
-   */
   constructor(attrs) {
     Object.keys(this.deprecatedProperties).forEach(key => {
       if (attrs.hasOwnProperty(key)) {
@@ -84,7 +69,7 @@ const Config = CoreObject.extend({
    * @attribute apiKey
    * @default ''
    * @type String
-   * @public
+   * @private
    */
   apiKey: '',
 
@@ -92,7 +77,7 @@ const Config = CoreObject.extend({
    * @attribute appId
    * @default ''
    * @type String
-   * @public
+   * @private
    */
   appId: '',
 
@@ -101,7 +86,7 @@ const Config = CoreObject.extend({
    * @attribute domain
    * @default ''
    * @type String
-   * @public
+   * @private
    */
   domain: '',
 
@@ -110,7 +95,7 @@ const Config = CoreObject.extend({
    * @attribute myShopifyDomain
    * @default ''
    * @type String
-   * @public
+   * @private
    * @deprecated Use `config.domain` instead.
    */
   myShopifyDomain: ''

--- a/src/logger.js
+++ b/src/logger.js
@@ -27,6 +27,7 @@ const Logger = CoreObject.extend({
   /**
    * Wrapper around the console log so in the future we can have better dev output.
    * Also allows us to disable output in production.
+   * @private
    * @class Logger
    * @constructor
    */

--- a/src/logger.js
+++ b/src/logger.js
@@ -27,8 +27,6 @@ const Logger = CoreObject.extend({
   /**
    * Wrapper around the console log so in the future we can have better dev output.
    * Also allows us to disable output in production.
-   * @class Logger
-   * @constructor
    */
   constructor() { },
   debug: wrapConsole('debug'),

--- a/src/logger.js
+++ b/src/logger.js
@@ -27,6 +27,8 @@ const Logger = CoreObject.extend({
   /**
    * Wrapper around the console log so in the future we can have better dev output.
    * Also allows us to disable output in production.
+   * @class Logger
+   * @constructor
    */
   constructor() { },
   debug: wrapConsole('debug'),

--- a/src/models/cart-line-item-model.js
+++ b/src/models/cart-line-item-model.js
@@ -1,31 +1,83 @@
 import BaseModel from './base-model';
 import { GUID_KEY } from '../metal/set-guid-for';
 
-const CartLineItem = BaseModel.extend({
+/**
+ * A cart stores an Array of `CartLineItemModel`'s in it's `lineItems` property.
+ * @class CartLineItemModel
+ * @constructor
+ */
+const CartLineItemModel = BaseModel.extend({
   constructor() {
     this.super(...arguments);
   },
 
+  /**
+   * A line item ID.
+   * @property id
+   * @readOnly
+   * @type {String} 
+   */
   get id() {
     return this.attrs[GUID_KEY];
   },
 
+  /**
+   * ID of line item variant.
+   * @property variant_id
+   * @readOnly
+   * @type {String}
+   */
   get variant_id() {
     return this.attrs.variant_id;
   },
 
+  /**
+   * ID of variant's product.
+   * @property product_id
+   * @readOnly
+   * @type {String}
+   */
   get product_id() {
     return this.attrs.product_id;
   },
 
+  /**
+   * Variant's image.
+   * Example `Object` returned:
+   * ```
+   * {
+   *    "id": 18723183238,
+   *    "created_at": "2016-09-14T17:12:12-04:00",
+   *    "position": 1,
+   *    "updated_at": "2016-09-14T17:12:12-04:00",
+   *    "product_id": 8569911558,
+   *    "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/Mop__three_different_mop_handles.jpg?v=1473887532",
+   *    "variant_ids": []
+   *  }
+   * ```
+   * @property image
+   * @readOnly
+   * @type {Object}
+   */
   get image() {
     return this.attrs.image;
   },
 
+  /**
+   * Product title of variant's parent product.
+   * @property title
+   * @readOnly
+   * @type {String}
+   */
   get title() {
     return this.attrs.title;
   },
 
+  /**
+   * Count of variants to order.
+   * @property quantity
+   * @type {Number}
+   */
   get quantity() {
     return this.attrs.quantity;
   },
@@ -45,9 +97,16 @@ const CartLineItem = BaseModel.extend({
     return this.attrs.quantity;
   },
 
+  /**
+   * Customization information for a product. 
+   * <a href="https://help.shopify.com/themes/customization/products/get-customization-information-for-products" target="_blank">See here for more info</a>.
+   * @property properties
+   * @type {Object}
+   * @private
+   */
   get properties() {
     return this.attrs.properties || {};
-  },
+  },  
 
   set properties(value) {
     this.attrs.properties = value || {};
@@ -55,25 +114,60 @@ const CartLineItem = BaseModel.extend({
     return value;
   },
 
+  /**
+   * Title of variant.
+   * @property variant_title
+   * @readOnly
+   * @type {String}
+   */
   get variant_title() {
     return this.attrs.variant_title;
   },
 
+  /**
+   * Price of the variant. For example: `"5.00"`.
+   * @property price
+   * @readOnly
+   * @type {String}
+   */
   get price() {
     return this.attrs.price;
   },
 
+  /**
+    * Compare at price for variant. The `compareAtPrice` would be
+    * the price of the product previously before the product went on sale. For more info 
+    * go <a href="https://docs.shopify.com/manual/products/promoting-marketing/sales" target="_blank">here</a>.
+    *
+    * If no `compareAtPrice` is set then this value will be `null`. An example value: `"5.00"`.
+    * @property compareAtPrice
+    * @readOnly
+    * @type {String}
+  */
   get compare_at_price() {
     return this.attrs.compare_at_price;
   },
 
+  /**
+   * The total price for this line item. For instance if the variant costs `1.50` and you have a quantity
+   * of 2 then `line_price` will be `3.00`.
+   * @property line_price
+   * @readOnly
+   * @type {String}
+   */
   get line_price() {
     return (this.quantity * parseFloat(this.price)).toFixed(2);
   },
 
+  /**
+   * Variant's weight in grams. If no weight is set then `0` is returned.
+   * @property grams
+   * @readOnly
+   * @type {Number}
+   */
   get grams() {
     return this.attrs.grams;
   }
 });
 
-export default CartLineItem;
+export default CartLineItemModel;

--- a/src/models/cart-line-item-model.js
+++ b/src/models/cart-line-item-model.js
@@ -15,7 +15,7 @@ const CartLineItemModel = BaseModel.extend({
    * A line item ID.
    * @property id
    * @readOnly
-   * @type {String} 
+   * @type {String}
    */
   get id() {
     return this.attrs[GUID_KEY];
@@ -98,15 +98,17 @@ const CartLineItemModel = BaseModel.extend({
   },
 
   /**
-   * Customization information for a product. 
-   * <a href="https://help.shopify.com/themes/customization/products/get-customization-information-for-products" target="_blank">See here for more info</a>.
+   * Customization information for a product.
+   * <a href="https://help.shopify.com/themes/customization/products/get-customization-information-for-products" target="_blank">
+   * See here for more info
+   * </a>.
    * @property properties
    * @type {Object}
    * @private
    */
   get properties() {
     return this.attrs.properties || {};
-  },  
+  },
 
   set properties(value) {
     this.attrs.properties = value || {};
@@ -136,7 +138,7 @@ const CartLineItemModel = BaseModel.extend({
 
   /**
     * Compare at price for variant. The `compareAtPrice` would be
-    * the price of the product previously before the product went on sale. For more info 
+    * the price of the product previously before the product went on sale. For more info
     * go <a href="https://docs.shopify.com/manual/products/promoting-marketing/sales" target="_blank">here</a>.
     *
     * If no `compareAtPrice` is set then this value will be `null`. An example value: `"5.00"`.

--- a/src/models/cart-model.js
+++ b/src/models/cart-model.js
@@ -66,7 +66,9 @@ const CartModel = BaseModel.extend({
   },
 
   /**
-    * Get current subtotal price for all line items. Example: two items have been added to the cart that cost $1.25 then the subtotal will be `2.50`
+    * Get current subtotal price for all line items. Example: two items have been added to the cart that cost $1.25
+    * then the subtotal will be `2.50`
+    *
     * @property subtotal
     * @readOnly
     * @type {String}
@@ -297,7 +299,7 @@ const CartModel = BaseModel.extend({
     * {{#crossLink "CartModel/updateLineItem"}}{{/crossLink}},
     * {{#crossLink "CartModel/removeLineItem"}}{{/crossLink}},
     * and {{#crossLink "CartModel/removeLineItem"}}{{/crossLink}}
-    * 
+    *
     * @method updateModel
     * @public
     * @return {Promise|CartModel} - the cart instance

--- a/src/models/cart-model.js
+++ b/src/models/cart-model.js
@@ -42,7 +42,7 @@ const CartModel = BaseModel.extend({
   },
 
   /**
-    * Get an `Array` of current line items for the cart
+    * Get an `Array` of {{#crossLink "CartLineItemModel"}}CartLineItemModel's{{/crossLink}}
     * @property lineItems
     * @readOnly
     * @type {Array}
@@ -54,7 +54,7 @@ const CartModel = BaseModel.extend({
   },
 
   /**
-    * Gets the total sum quantity of all line items. Example: you've added two variants with quantities 3 and 2. `lineItemCount` will be 5.
+    * Gets the total quantity of all line items. Example: you've added two variants with quantities 3 and 2. `lineItemCount` will be 5.
     * @property lineItemCount
     * @readOnly
     * @type {Number}

--- a/src/models/cart-model.js
+++ b/src/models/cart-model.js
@@ -4,6 +4,7 @@ import assign from '../metal/assign';
 import setGuidFor from '../metal/set-guid-for';
 import globalVars from '../metal/global-vars';
 import { GUID_KEY } from '../metal/set-guid-for';
+import logger from '../logger';
 
 function objectsEqual(one, two) {
   if (one === two) {
@@ -21,13 +22,11 @@ function objectsEqual(one, two) {
   });
 }
 
+/**
+* Class for cart model
+* @class CartModel
+*/
 const CartModel = BaseModel.extend({
-
-  /**
-    * Class for cart model
-    * @class CartModel
-    * @constructor
-  */
   constructor() {
     this.super(...arguments);
   },
@@ -35,6 +34,7 @@ const CartModel = BaseModel.extend({
   /**
     * get ID for current cart
     * @property id
+    * @readOnly
     * @type {String}
   */
   get id() {
@@ -44,6 +44,7 @@ const CartModel = BaseModel.extend({
   /**
     * Get current line items for cart
     * @property lineItems
+    * @readOnly
     * @type {Array}
   */
   get lineItems() {
@@ -55,6 +56,7 @@ const CartModel = BaseModel.extend({
   /**
     * Gets the sum quantity of each line item
     * @property lineItemCount
+    * @readOnly
     * @type {Number}
   */
   get lineItemCount() {
@@ -66,6 +68,7 @@ const CartModel = BaseModel.extend({
   /**
     * Get current subtotal price for all line items
     * @property subtotal
+    * @readOnly
     * @type {String}
   */
   get subtotal() {
@@ -79,6 +82,7 @@ const CartModel = BaseModel.extend({
   /**
     * Get checkout URL for current cart
     * @property checkoutUrl
+    * @readOnly
     * @type {String}
   */
   get checkoutUrl() {
@@ -108,21 +112,43 @@ const CartModel = BaseModel.extend({
   },
 
   /**
-    * Add items to cart. Updates cart's `lineItems`
+    * Add items to the cart. Updates cart's `lineItems` based on variants passed in.
     * ```javascript
     * cart.addVariants({variant: variantObject, quantity: 1}).then(cart => {
     *   // do things with the updated cart.
     * });
     * ```
+    * @deprecated `createLineItemsFromVariants` will be used in the future as it's more descriptive
     * @method addVariants
     * @param {Object} item - One or more variants
-    * @param {Object} item.variant - variant object
+    * @param {ProductVariantModel} item.variant - variant object
     * @param {Number} item.quantity - quantity
-    * @param {Object} [nextItem...] - further lineItems may be passed
+    * @param {Object} [moreItems...] - further objects defining `variant` and `quantity` maybe passed in
     * @public
     * @return {Promise|CartModel} - updated cart instance.
   */
   addVariants() {
+    logger.warn('CartModel - ', 'addVariants is deprecated, please use createLineItemsFromVariants instead');
+
+    return this.createLineItemsFromVariants(...arguments);
+  },
+
+  /**
+    * Add items to the cart. Updates cart's `lineItems` based on variants passed in.
+    * ```javascript
+    * cart.addVariants({variant: variantObject, quantity: 1}).then(cart => {
+    *   // do things with the updated cart.
+    * });
+    * ```
+    * @method createLineItemsFromVariants
+    * @param {Object} item - One or more variants
+    * @param {ProductVariantModel} item.variant - variant object
+    * @param {Number} item.quantity - quantity
+    * @param {Object} [moreItems...] - further objects defining `variant` and `quantity` maybe passed in
+    * @public
+    * @return {Promise|CartModel} - updated cart instance.
+  */
+  createLineItemsFromVariants() {
     const newLineItems = [...arguments].map(item => {
       const lineItem = {
         image: item.variant.image,

--- a/src/models/cart-model.js
+++ b/src/models/cart-model.js
@@ -42,7 +42,7 @@ const CartModel = BaseModel.extend({
   },
 
   /**
-    * Get current line items for cart
+    * Get an `Array` of current line items for the cart
     * @property lineItems
     * @readOnly
     * @type {Array}
@@ -54,7 +54,7 @@ const CartModel = BaseModel.extend({
   },
 
   /**
-    * Gets the sum quantity of each line item
+    * Gets the total sum quantity of all line items. Example: you've added two variants with quantities 3 and 2. `lineItemCount` will be 5.
     * @property lineItemCount
     * @readOnly
     * @type {Number}
@@ -66,7 +66,7 @@ const CartModel = BaseModel.extend({
   },
 
   /**
-    * Get current subtotal price for all line items
+    * Get current subtotal price for all line items. Example: two items have been added to the cart that cost $1.25 then the subtotal will be `2.50`
     * @property subtotal
     * @readOnly
     * @type {String}
@@ -115,7 +115,7 @@ const CartModel = BaseModel.extend({
     * Add items to the cart. Updates cart's `lineItems` based on variants passed in.
     * ```javascript
     * cart.addVariants({variant: variantObject, quantity: 1}).then(cart => {
-    *   // do things with the updated cart.
+    *   // the cart has created line items
     * });
     * ```
     * @deprecated `createLineItemsFromVariants` will be used in the future as it's more descriptive
@@ -124,8 +124,8 @@ const CartModel = BaseModel.extend({
     * @param {ProductVariantModel} item.variant - variant object
     * @param {Number} item.quantity - quantity
     * @param {Object} [moreItems...] - further objects defining `variant` and `quantity` maybe passed in
-    * @public
-    * @return {Promise|CartModel} - updated cart instance.
+    * @private
+    * @return {Promise|CartModel} - the cart instance.
   */
   addVariants() {
     logger.warn('CartModel - ', 'addVariants is deprecated, please use createLineItemsFromVariants instead');
@@ -136,8 +136,8 @@ const CartModel = BaseModel.extend({
   /**
     * Add items to the cart. Updates cart's `lineItems` based on variants passed in.
     * ```javascript
-    * cart.addVariants({variant: variantObject, quantity: 1}).then(cart => {
-    *   // do things with the updated cart.
+    * cart.createLineItemsFromVariants({variant: variantObject, quantity: 1}).then(cart => {
+    *   // the cart has created line items
     * });
     * ```
     * @method createLineItemsFromVariants
@@ -146,7 +146,7 @@ const CartModel = BaseModel.extend({
     * @param {Number} item.quantity - quantity
     * @param {Object} [moreItems...] - further objects defining `variant` and `quantity` maybe passed in
     * @public
-    * @return {Promise|CartModel} - updated cart instance.
+    * @return {Promise|CartModel} - the cart instance.
   */
   createLineItemsFromVariants() {
     const newLineItems = [...arguments].map(item => {
@@ -200,18 +200,21 @@ const CartModel = BaseModel.extend({
   },
 
   /**
-    * Update line item quantity
+    * Update a line item quantity based on line item id
     * ```javascript
-    * cart.updateLineItem(123, 2).then(cart => {
-    *   // do things with the updated cart.
+    * // This example changes the quantity for the first line item to 2
+    * const firstLineItemId = cart.lineItems[0].id;
+    *
+    * cart.updateLineItem(firstLineItemId, 2).then(cart => {
+    *   // the cart has updated the line item
     * });
     * ```
     * @method updateLineItem
-    * @param {Number} id - line item ID
+    * @param {String} id - line item ID
     * @param {Number} quantity - new quantity for line item
     * @throws {Error} if line item with ID is not in cart.
     * @public
-    * @return {Promise|CartModel} - updated cart instance
+    * @return {Promise|CartModel} - the cart instance
   */
   updateLineItem(id, quantity) {
     if (quantity < 1) {
@@ -234,12 +237,21 @@ const CartModel = BaseModel.extend({
   },
 
   /**
-    * Remove line item from cart
+    * Remove a line item from cart based on line item id
+    * ```javascript
+    * // This example removes the first line item
+    * const firstLineItemId = cart.lineItems[0].id;
+    *
+    * cart.removeLineItem(firstLineItemId).then(cart => {
+    *   // the cart has removed the line item
+    * });
+    * ```
+    *
     * @method removeLineItem
-    * @param {Number} id - line item ID
+    * @param {String} id - line item ID
     * @throws {Error} if line item with ID is not in cart.
     * @public
-    * @return {Promise|CartModel} - updated cart instance
+    * @return {Promise|CartModel} - the cart instance
   */
   removeLineItem(id) {
     const oldLength = this.lineItems.length;
@@ -263,9 +275,14 @@ const CartModel = BaseModel.extend({
 
   /**
     * Remove all line items from cart
+    * ```javascript
+    * // This example removes all line items from the cart
+    * cart.clearLineItems().then(cart => {
+    *   // the cart has removed all line items
+    * });
     * @method clearLineItems
     * @public
-    * @return {Promise|CartModel} - updated cart instance
+    * @return {Promise|CartModel} - the cart instance
   */
   clearLineItems() {
     this.attrs.line_items = [];
@@ -274,10 +291,16 @@ const CartModel = BaseModel.extend({
   },
 
   /**
-    * force update of cart model on server
+    * Force update of cart model on server. This function will only be used in advanced situations and does not need to be called
+    * explicitly to update line items. It is automatically called after
+    * {{#crossLink "CartModel/createLineItemsFromVariants"}}{{/crossLink}},
+    * {{#crossLink "CartModel/updateLineItem"}}{{/crossLink}},
+    * {{#crossLink "CartModel/removeLineItem"}}{{/crossLink}},
+    * and {{#crossLink "CartModel/removeLineItem"}}{{/crossLink}}
+    * 
     * @method updateModel
     * @public
-    * @return {Promise|CartModel} - updated cart instance
+    * @return {Promise|CartModel} - the cart instance
   */
   updateModel() {
     return this.shopClient.update('carts', this).then(updateCart => {

--- a/src/models/product-model.js
+++ b/src/models/product-model.js
@@ -17,7 +17,7 @@ const ProductModel = BaseModel.extend({
 
   /**
     * Product unique ID
-    * 
+    *
     * @property id
     * @type {String}
   */
@@ -72,11 +72,12 @@ const ProductModel = BaseModel.extend({
   },
 
   /**
-   *  Get an array of {{#crossLink "ProductOptionModel"}}ProductOptionModels{{/crossLink}}. 
+   *  Get an array of {{#crossLink "ProductOptionModel"}}ProductOptionModels{{/crossLink}}.
    *  {{#crossLink "ProductOptionModel"}}ProductOptionModels{{/crossLink}} can be used to
-   *  define the currently `selectedVariant` from which you can get a checkout url ({{#crossLink "ProductVariantModel/checkoutUrl"}}ProductVariantModel.checkoutUrl{{/crossLink}}) or can
+   *  define the currently `selectedVariant` from which you can get a checkout url
+   *  ({{#crossLink "ProductVariantModel/checkoutUrl"}}ProductVariantModel.checkoutUrl{{/crossLink}}) or can
    *  be added to a cart ({{#crossLink "CartModel/createLineItemsFromVariants"}}CartModel.createLineItemsFromVariants{{/crossLink}}).
-   *  
+   *
    *  Below is an example on how to create html for option selections:
    * ```javascript
    *  // the following will create an Array of HTML to create multiple select inputs
@@ -155,9 +156,10 @@ const ProductModel = BaseModel.extend({
     * Retrieve variant for currently selected options. By default the first value in each
     * option is selected which means `selectedVariant` will never be `null`.
     *
-    * With a `selectedVariant` you can create checkout url ({{#crossLink "ProductVariantModel/checkoutUrl"}}ProductVariantModel.checkoutUrl{{/crossLink}}) or it can
+    * With a `selectedVariant` you can create checkout url
+    * ({{#crossLink "ProductVariantModel/checkoutUrl"}}ProductVariantModel.checkoutUrl{{/crossLink}}) or it can
     * be added to a cart ({{#crossLink "CartModel/createLineItemsFromVariants"}}CartModel.createLineItemsFromVariants{{/crossLink}}).
-    * 
+    *
     * @property selectedVariant
     * @type {ProductVariantModel}
   */
@@ -182,7 +184,7 @@ const ProductModel = BaseModel.extend({
     *   variant_ids: [ 27690103238 ]
     * }
     * ```
-    * 
+    *
     * @property selectedVariantImage
     * @type {Object}
   */

--- a/src/models/product-model.js
+++ b/src/models/product-model.js
@@ -72,18 +72,33 @@ const ProductModel = BaseModel.extend({
   },
 
   /**
-     *  Get array of options with nested values. Useful for creating UI for selecting options.
-     *
-     * ```javascript
-     *  var elements = product.options.map(function(option) {
-     *    return '<select name="' + option.name + '">' + option.values.map(function(value) {
-     *      return '<option value="' + value + '">' + value + '</option>';
-     *    }) + '</select>';
-     *  });
-     * ```
-     *
-     * @property options
-     * @type {Array|Option}
+   *  Get an array of {{#crossLink "ProductOptionModel"}}ProductOptionModels{{/crossLink}}. 
+   *  {{#crossLink "ProductOptionModel"}}ProductOptionModels{{/crossLink}} can be used to
+   *  define the currently `selectedVariant` from which you can get a checkout url ({{#crossLink "ProductVariantModel/checkoutUrl"}}ProductVariantModel.checkoutUrl{{/crossLink}}) or can
+   *  be added to a cart ({{#crossLink "CartModel/createLineItemsFromVariants"}}CartModel.createLineItemsFromVariants{{/crossLink}}).
+   *  
+   *  Below is an example on how to create html for option selections:
+   * ```javascript
+   *  // the following will create an Array of HTML to create multiple select inputs
+   *  // global callbacks are also created which will set the option as selected
+   *  var elements = product.options.map(function(option) {
+   *    // we'll create a callback in global scope
+   *    // which will be called when the select's value changes
+   *    var callBackName = option.name + 'onChange';
+   *    window[ callBackName ] = function(select) {
+   *      // set the products option to be selected
+   *      option.selected = select.value;
+   *    };
+   *
+   *    // return a string which will be HTML for the select
+   *    return '<select name="' + option.name + '" onchange="'callBackName'(this)">' + option.values.map(function(value) {
+   *      return '<option value="' + value + '">' + value + '</option>';
+   *    }) + '</select>';
+   *  });
+   * ```
+   *
+   * @property options
+   * @type {Array|ProductOptionModel}
    */
   get options() {
     if (this.memoized.options) {
@@ -128,7 +143,7 @@ const ProductModel = BaseModel.extend({
   /**
     * Retrieve currently selected option values.
     * @property selections
-    * @type {Option}
+    * @type {ProductOptionModel}
   */
   get selections() {
     return this.options.map(option => {
@@ -137,9 +152,14 @@ const ProductModel = BaseModel.extend({
   },
 
   /**
-    * Retrieve variant for currently selected options
+    * Retrieve variant for currently selected options. By default the first value in each
+    * option is selected which means `selectedVariant` will never be `null`.
+    *
+    * With a `selectedVariant` you can create checkout url ({{#crossLink "ProductVariantModel/checkoutUrl"}}ProductVariantModel.checkoutUrl{{/crossLink}}) or it can
+    * be added to a cart ({{#crossLink "CartModel/createLineItemsFromVariants"}}CartModel.createLineItemsFromVariants{{/crossLink}}).
+    * 
     * @property selectedVariant
-    * @type {Object}
+    * @type {ProductVariantModel}
   */
   get selectedVariant() {
     const variantTitle = this.selections.join(' / ');
@@ -150,7 +170,19 @@ const ProductModel = BaseModel.extend({
   },
 
   /**
-    * Retrieve image for currently selected variantImage
+    * Retrieve image for currently selected variantImage. An example image Object would look like this:
+    * ```
+    * {
+    *   created_at: "2016-08-29T12:35:09-04:00",
+    *   id: 17690553350,
+    *   position: 1,
+    *   product_id: 8291029446,
+    *   src: "https://cdn.shopify.com/s/files/1/1019/0495/products/i11_c3334325-2d67-4623-8cd4-0a6b08aa1b83.jpg?v=1472488509",
+    *   updated_at: "2016-08-29T12:35:09-04:00",
+    *   variant_ids: [ 27690103238 ]
+    * }
+    * ```
+    * 
     * @property selectedVariantImage
     * @type {Object}
   */

--- a/src/models/product-model.js
+++ b/src/models/product-model.js
@@ -141,9 +141,9 @@ const ProductModel = BaseModel.extend({
   },
 
   /**
-    * Retrieve currently selected option values.
+    * An Array of Strings represented currently selected option values. eg. `["Large", "Red"]`
     * @property selections
-    * @type {ProductOptionModel}
+    * @type {Array | String}
   */
   get selections() {
     return this.options.map(option => {

--- a/src/models/product-model.js
+++ b/src/models/product-model.js
@@ -142,7 +142,7 @@ const ProductModel = BaseModel.extend({
   },
 
   /**
-    * An Array of Strings represented currently selected option values. eg. `["Large", "Red"]`
+    * A read only `Array` of Strings represented currently selected option values. eg. `["Large", "Red"]`
     * @property selections
     * @type {Array | String}
   */

--- a/src/models/product-model.js
+++ b/src/models/product-model.js
@@ -17,6 +17,7 @@ const ProductModel = BaseModel.extend({
 
   /**
     * Product unique ID
+    * 
     * @property id
     * @type {String}
   */
@@ -25,7 +26,7 @@ const ProductModel = BaseModel.extend({
   },
 
   /**
-    * Product title
+    * The product title
     * @property title
     * @type {String}
   */
@@ -34,7 +35,7 @@ const ProductModel = BaseModel.extend({
   },
 
   /**
-    * Product description. The exposes the `body_html` property on the listings API
+    * A product description.
     * @property description
     * @type {String}
   */
@@ -43,7 +44,20 @@ const ProductModel = BaseModel.extend({
   },
 
   /**
-    * All images associated with product.
+    * An `Array` of `Objects` that contain meta data about an image including `src` of the images.
+    *
+    * An example image `Object`:
+    * ```
+    * {
+    *   created_at: "2016-08-29T12:35:09-04:00",
+    *   id: 17690553350,
+    *   position: 1,
+    *   product_id: 8291029446,
+    *   src: "https://cdn.shopify.com/s/files/1/1019/0495/products/i11_c3334325-2d67-4623-8cd4-0a6b08aa1b83.jpg?v=1472488509",
+    *   updated_at: "2016-08-29T12:35:09-04:00",
+    *   variant_ids: [ 27690103238 ]
+    * }
+    * ```
     * @property images
     * @type {Array} array of image objects.
   */
@@ -101,7 +115,7 @@ const ProductModel = BaseModel.extend({
   },
 
   /**
-    * All variants of a product.
+    * An `Array` of {{#crossLink "ProductVariantModel"}}ProductVariantModel's{{/crossLink}}
     * @property variants
     * @type {Array|ProductVariantModel} array of ProductVariantModel instances.
   */

--- a/src/models/product-model.js
+++ b/src/models/product-model.js
@@ -82,7 +82,7 @@ const ProductModel = BaseModel.extend({
      *  });
      * ```
      *
-     * @attribute options
+     * @property options
      * @type {Array|Option}
    */
   get options() {
@@ -127,7 +127,7 @@ const ProductModel = BaseModel.extend({
 
   /**
     * Retrieve currently selected option values.
-    * @attribute selections
+    * @property selections
     * @type {Option}
   */
   get selections() {
@@ -138,7 +138,7 @@ const ProductModel = BaseModel.extend({
 
   /**
     * Retrieve variant for currently selected options
-    * @attribute selectedVariant
+    * @property selectedVariant
     * @type {Object}
   */
   get selectedVariant() {
@@ -151,7 +151,7 @@ const ProductModel = BaseModel.extend({
 
   /**
     * Retrieve image for currently selected variantImage
-    * @attribute selectedVariantImage
+    * @property selectedVariantImage
     * @type {Object}
   */
   get selectedVariantImage() {

--- a/src/models/product-option-model.js
+++ b/src/models/product-option-model.js
@@ -4,7 +4,7 @@ import includes from '../metal/includes';
 
 /**
   * Class for product option
-  * @class Option
+  * @class ProductOptionModel
   * @constructor
 */
 const ProductOptionModel = BaseModel.extend({
@@ -15,8 +15,9 @@ const ProductOptionModel = BaseModel.extend({
   },
 
   /**
-    * name of option (ex. "Size", "Color")
+    * name of option. Example values: `"Size"`, `"Color"`, etc.
     * @property name
+    * @readOnly
     * @type String
   */
   get name() {
@@ -24,8 +25,11 @@ const ProductOptionModel = BaseModel.extend({
   },
 
   /**
-    * possible values for selection
+    * an Array possible values for option. For instance if this option is a "Size" option an example value 
+    * for values could be: `["Large", "Medium", "Small"]`
+    * 
     * @property values
+    * @readOnly
     * @type Array
   */
   get values() {
@@ -33,8 +37,10 @@ const ProductOptionModel = BaseModel.extend({
   },
 
   /**
-    * get/set selected option value (ex. "Large"). Setting this will update the
-    * selected value on the model. Throws {Error} if setting selected to value that does not exist for option
+    * get/set the currently selected option value with one of the values from the {{#crossLink "ProductOptionModel/values"}}ProductOptionModel.values{{/crossLink}} array. For 
+    * instance if the option values array had the following `["Large", "Medium", "Small"]` setting `selected` to be 
+    * `"Large"`, `"Medium"`, or `"Small"` would be valid any other value would throw an `Error`.
+    * 
     * @property selected
     * @type String
   */

--- a/src/models/product-option-model.js
+++ b/src/models/product-option-model.js
@@ -25,9 +25,9 @@ const ProductOptionModel = BaseModel.extend({
   },
 
   /**
-    * an Array possible values for option. For instance if this option is a "Size" option an example value 
+    * an Array possible values for option. For instance if this option is a "Size" option an example value
     * for values could be: `["Large", "Medium", "Small"]`
-    * 
+    *
     * @property values
     * @readOnly
     * @type Array
@@ -37,10 +37,11 @@ const ProductOptionModel = BaseModel.extend({
   },
 
   /**
-    * get/set the currently selected option value with one of the values from the {{#crossLink "ProductOptionModel/values"}}ProductOptionModel.values{{/crossLink}} array. For 
-    * instance if the option values array had the following `["Large", "Medium", "Small"]` setting `selected` to be 
+    * get/set the currently selected option value with one of the values from the
+    * {{#crossLink "ProductOptionModel/values"}}ProductOptionModel.values{{/crossLink}} array. For
+    * instance if the option values array had the following `["Large", "Medium", "Small"]` setting `selected` to be
     * `"Large"`, `"Medium"`, or `"Small"` would be valid any other value would throw an `Error`.
-    * 
+    *
     * @property selected
     * @type String
   */

--- a/src/models/product-variant-model.js
+++ b/src/models/product-variant-model.js
@@ -158,9 +158,16 @@ const ProductVariantModel = BaseModel.extend({
   },
 
   /**
-    * Checkout URL for purchasing variant with quantity.
+    * Get a checkout url for a specific product variant. You can
+    * optionally pass a quantity. If no quantity is passed then quantity
+    * will default to 1. The example below will grab a checkout url for
+    * 3 copies of the first variant:
+    * ```
+    * const checkoutURL = product.variants[ 0 ].checkoutUrl(3);
+    * ```
+    * 
     * @method checkoutUrl
-    * @param {Number} [quantity = 1] quantity of variant
+    * @param {Number} [quantity = 1] quantity of variants
     * @public
     * @return {String} Checkout URL
   */

--- a/src/models/product-variant-model.js
+++ b/src/models/product-variant-model.js
@@ -114,7 +114,7 @@ const ProductVariantModel = BaseModel.extend({
   },
 
   /**
-    * Variant in stock (always true if inventory tracking is disabled)
+    * Variant in stock. Always `true` if inventory tracking is disabled.
     * @property available
     * @type {Boolean}
   */

--- a/src/models/product-variant-model.js
+++ b/src/models/product-variant-model.js
@@ -48,8 +48,11 @@ const ProductVariantModel = BaseModel.extend({
   },
 
   /**
-    * <a href="https://docs.shopify.com/manual/products/promoting-marketing/sales">
-    * Compare at</a> price for variant formatted as currency.
+    * Compare at price for variant formatted as currency. The `compareAtPrice` would be
+    * the price of the product previously before the product went on sale. For more info 
+    * go <a href="https://docs.shopify.com/manual/products/promoting-marketing/sales" target="_blank">here</a>.
+    *
+    * If no `compareAtPrice` is set then this value will be `null`. An example value: `"5.00"`
     * @property compareAtPrice
     * @type {String}
   */
@@ -59,7 +62,8 @@ const ProductVariantModel = BaseModel.extend({
 
 
   /**
-    * Price of variant, formatted as currency
+    * Price of the variant. The price will be in the following form: `"10.00"`
+    * 
     * @property price
     * @type {String}
   */
@@ -77,7 +81,7 @@ const ProductVariantModel = BaseModel.extend({
   },
 
   /**
-    * Variant weight in grams
+    * Variant weight in grams. If no weight is defined grams will be `0`.
     * @property grams
     * @type {Number}
   */
@@ -86,7 +90,22 @@ const ProductVariantModel = BaseModel.extend({
   },
 
   /**
-    * Option values associated with this variant, ex {name: "color", value: "Blue"}
+    * Option values associated with this variant. Example `optionValues`:
+    * ```
+    * [
+    *   {
+    *     "name": "Size",
+    *     "option_id": 9165336518,
+    *     "value": "small"
+    *   },
+    *   {
+    *     "name": "Color",
+    *     "option_id": 9640532358,
+    *     "value": "blue"
+    *   }
+    * ]
+    * ````
+    * 
     * @property optionValues
     * @type {Array|Object}
   */
@@ -104,7 +123,19 @@ const ProductVariantModel = BaseModel.extend({
   },
 
   /**
-    * Image for variant
+    * Image for variant. An example image `Object`:
+    * ```
+    * {
+    *   created_at: "2016-08-29T12:35:09-04:00",
+    *   id: 17690553350,
+    *   position: 1,
+    *   product_id: 8291029446,
+    *   src: "https://cdn.shopify.com/s/files/1/1019/0495/products/i11_c3334325-2d67-4623-8cd4-0a6b08aa1b83.jpg?v=1472488509",
+    *   updated_at: "2016-08-29T12:35:09-04:00",
+    *   variant_ids: [ 27690103238 ]
+    * }
+    * ```
+    *
     * @property image
     * @type {Object}
   */
@@ -121,8 +152,22 @@ const ProductVariantModel = BaseModel.extend({
   },
 
   /**
-    * Image variants available for a variant, ex [ {"name":"pico","dimension":"16x16","src":"https://cdn.shopify.com/image-two_pico.jpg"} ]
-    * See <a href="https://help.shopify.com/themes/liquid/filters/url-filters#size-parameters"> for list of available variants.</a>
+    * Image variants available for a variant. An example value of `imageVariant`:
+    * ```
+    * [
+    *   {
+    *     "name": "pico",
+    *     "dimensions": "16x16",
+    *     "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/alien_146ef7c1-26e9-4e96-96e6-9d37128d0005_pico.jpg?v=1469046423"
+    *   },
+    *   {
+    *     "name": "compact",
+    *     "dimensions": "160x160",
+    *     "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/alien_146ef7c1-26e9-4e96-96e6-9d37128d0005_compact.jpg?v=1469046423"
+    *   }
+    * ]
+    * ```
+    *
     * @property imageVariant
     * @type {Array}
   */

--- a/src/models/product-variant-model.js
+++ b/src/models/product-variant-model.js
@@ -48,7 +48,7 @@ const ProductVariantModel = BaseModel.extend({
   },
 
   /**
-    * Compare at price for variant formatted as currency. The `compareAtPrice` would be
+    * Compare at price for variant. The `compareAtPrice` would be
     * the price of the product previously before the product went on sale. For more info 
     * go <a href="https://docs.shopify.com/manual/products/promoting-marketing/sales" target="_blank">here</a>.
     *

--- a/src/models/product-variant-model.js
+++ b/src/models/product-variant-model.js
@@ -49,7 +49,7 @@ const ProductVariantModel = BaseModel.extend({
 
   /**
     * Compare at price for variant. The `compareAtPrice` would be
-    * the price of the product previously before the product went on sale. For more info 
+    * the price of the product previously before the product went on sale. For more info
     * go <a href="https://docs.shopify.com/manual/products/promoting-marketing/sales" target="_blank">here</a>.
     *
     * If no `compareAtPrice` is set then this value will be `null`. An example value: `"5.00"`
@@ -63,7 +63,7 @@ const ProductVariantModel = BaseModel.extend({
 
   /**
     * Price of the variant. The price will be in the following form: `"10.00"`
-    * 
+    *
     * @property price
     * @type {String}
   */
@@ -72,8 +72,10 @@ const ProductVariantModel = BaseModel.extend({
   },
 
   /**
-    * Price of variant, formatted according to shop currency format string
-    * @property price
+    * Price of variant, formatted according to shop currency format string.
+    * For instance `"$10.00"`
+    *
+    * @property formattedPrice
     * @type {String}
   */
   get formattedPrice() {
@@ -105,7 +107,7 @@ const ProductVariantModel = BaseModel.extend({
     *   }
     * ]
     * ````
-    * 
+    *
     * @property optionValues
     * @type {Array|Object}
   */
@@ -210,7 +212,7 @@ const ProductVariantModel = BaseModel.extend({
     * ```
     * const checkoutURL = product.variants[ 0 ].checkoutUrl(3);
     * ```
-    * 
+    *
     * @method checkoutUrl
     * @param {Number} [quantity = 1] quantity of variants
     * @public

--- a/src/models/reference-model.js
+++ b/src/models/reference-model.js
@@ -5,6 +5,7 @@ const ReferenceModel = BaseModel.extend({
 
   /**
     * Class for reference model
+    * @private
     * @class ReferenceModel
     * @constructor
   */

--- a/src/shop-client.js
+++ b/src/shop-client.js
@@ -309,29 +309,31 @@ const ShopClient = CoreObject.extend({
   fetchCart: fetchFactory('one', 'carts'),
 
   /**
-   * Convenience wrapper for {{#crossLink "ShopClient/fetchAll:method"}}
-   * {{/crossLink}}. Equivalent to:
-   *
-   * ```javascript
-   * client.fetchAll('products');
+   * This function will return an `Array` of products from your store
    * ```
-   *
+   * client.fetchAllProducts()
+   * .then(function(products) {
+   *   // all products in store
+   * });
+   * ```
+   * 
    * @method fetchAllProducts
-   * @private
+   * @public
    * @return {Promise|Array} The product models.
    */
   fetchAllProducts: fetchFactory('all', 'products'),
 
   /**
-   * Convenience wrapper for {{#crossLink "ShopClient/fetchAll:method"}}
-   * {{/crossLink}}. Equivalent to:
-   *
-   * ```javascript
-   * client.fetchAll('collections');
+   * This function will return an `Array` of collections from your store
    * ```
-   *
+   * client.fetchAllCollections()
+   * .then(function(collections) {
+   *   
+   * });
+   * ```
+   * 
    * @method fetchAllCollections
-   * @private
+   * @public
    * @return {Promise|Array} The collection models.
    */
   fetchAllCollections: fetchFactory('all', 'collections'),

--- a/src/shop-client.js
+++ b/src/shop-client.js
@@ -246,7 +246,7 @@ const ShopClient = CoreObject.extend({
   },
 
   /**
-    * Creates a {{#crossLink "CartModel"}}CartModel{{/crossLink}} instance, optionally including `attrs`.
+    * Creates a {{#crossLink "CartModel"}}CartModel{{/crossLink}} instance.
     *
     * ```javascript
     * client.createCart().then(cart => {
@@ -254,7 +254,6 @@ const ShopClient = CoreObject.extend({
     * });
     * ```
     *
-    * @param {Object}[attrs={}] attributes representing the internal state of the cart to be persisted to localStorage.
     * @method createCart
     * @public
     * @return {Promise|CartModel} - new cart instance.
@@ -283,7 +282,7 @@ const ShopClient = CoreObject.extend({
     * });
     * ```
     *
-    * @param {Object}[attrs={}] attributes representing the internal state of the cart to be persisted to localStorage.
+    * @param {CartModel} updatedCart an updated CartModel
     * @method updateCart
     * @public
     * @return {Promise|CartModel} - updated cart instance.
@@ -388,6 +387,11 @@ const ShopClient = CoreObject.extend({
    *   @param {String|Number} [query.limit=50] The number of products to retrieve per page
    *   @param {String} [query.handle] The handle of the product to look up
    *   @param {String} [query.updated_at_min] Products updated since the supplied timestamp (format: 2008-12-31 03:00)
+   *   @param {String} [query.sort_by] Will modify how products are ordered. Possible values are:
+   *                                   `"updated_at"`, `"best-selling"`, `"title-ascending"`, `"title-descending"`,
+   *                                   `"price-descending"`, `"price-ascending"`, `"created-descending"`, `"created-ascending"`,
+   *                                   or `"collection-default"`. Using `"collection-default"` means that products will be ordered
+   *                                   the using the custom ordering defined in your Shopify Admin. Default value `"collection-default"`.
    * @return {Promise|Array} The product models.
    */
   fetchQueryProducts: fetchFactory('query', 'products'),

--- a/src/shop-client.js
+++ b/src/shop-client.js
@@ -284,7 +284,7 @@ const ShopClient = CoreObject.extend({
     *
     * @param {CartModel} updatedCart an updated CartModel
     * @method updateCart
-    * @public
+    * @private
     * @return {Promise|CartModel} - updated cart instance.
   */
   updateCart(updatedCart) {

--- a/src/shop-client.js
+++ b/src/shop-client.js
@@ -316,7 +316,7 @@ const ShopClient = CoreObject.extend({
    *   // all products in store
    * });
    * ```
-   * 
+   *
    * @method fetchAllProducts
    * @public
    * @return {Promise|Array} The product models.
@@ -328,10 +328,10 @@ const ShopClient = CoreObject.extend({
    * ```
    * client.fetchAllCollections()
    * .then(function(collections) {
-   *   
+   *
    * });
    * ```
-   * 
+   *
    * @method fetchAllCollections
    * @public
    * @return {Promise|Array} The collection models.

--- a/src/shop-client.js
+++ b/src/shop-client.js
@@ -342,8 +342,8 @@ const ShopClient = CoreObject.extend({
    * Fetch one product by its ID.
    *
    * ```javascript
-   * client.fetchProduct(123).then(product => {
-   *   console.log(product); // The product with an ID of 123
+   * client.fetchProduct('8569911558').then(product => {
+   *   console.log(product); // The product with an ID of '8569911558'
    * });
    * ```
    *
@@ -358,8 +358,8 @@ const ShopClient = CoreObject.extend({
    * Fetch one collection by its ID.
    *
    * ```javascript
-   * client.fetchCollection(123).then(collection => {
-   *   console.log(collection); // The collection with an ID of 123
+   * client.fetchCollection('336903494').then(collection => {
+   *   console.log(collection); // The collection with an ID of '336903494'
    * });
    * ```
    *
@@ -374,8 +374,8 @@ const ShopClient = CoreObject.extend({
    * Fetches a list of products matching a specified query.
    *
    * ```javascript
-   * client.fetchQueryProducts({ collection_id: 123, tag: ['hats'] }).then(products => {
-   *   console.log(products); // An array of products in collection `123` having the tag `hats`
+   * client.fetchQueryProducts({ collection_id: '336903494', tag: ['hats'] }).then(products => {
+   *   console.log(products); // An array of products in collection '336903494' having the tag 'hats'
    * });
    * ```
    * @method fetchQueryProducts

--- a/src/shop-client.js
+++ b/src/shop-client.js
@@ -40,8 +40,6 @@ const ShopClient = CoreObject.extend({
   /**
    * @class ShopClient
    * @constructor
-   * @param {Config} [config] Config data to be used throughout all API
-   * interaction
    */
   constructor(config) {
     this.config = config;

--- a/src/shopify.js
+++ b/src/shopify.js
@@ -11,7 +11,12 @@ import { NO_IMAGE_URI } from './models/product-model';
  */
 
 /**
- * This namespace contains all globally accessible classes
+ * `ShopifyBuy` only defines one function {{#crossLink "ShopifyBuy/buildClient"}}{{/crossLink}} which can
+ * be used to build a {{#crossLink "ShopClient"}}{{/crossLink}} to query your store using the
+ * provided
+ * {{#crossLink "ShopifyBuy/buildClient/configAttrs:apiKey"}}`apiKey`{{/crossLink}},
+ * {{#crossLink "ShopifyBuy/buildClient/configAttrs:appId"}}`appId`{{/crossLink}},
+ * and {{#crossLink "ShopifyBuy/buildClient/configAttrs:domain"}}`domain`{{/crossLink}}.
  * @class ShopifyBuy
  * @static
  */
@@ -26,10 +31,10 @@ const Shopify = {
    *
    * ```javascript
    * const client = ShopifyBuy.buildClient({
-   *   apiKey: 'abc123',
-   *   appId: 123456,
+   *   apiKey: 'bf081e860bc9dc1ce0654fdfbc20892d',
+   *   appId: 6,
    *   myShopifyDomain: 'your-shop-subdomain.myshopify.com', //Deprecated. Use `domain` instead
-   *   domain: 'myshop.myshopify.com'
+   *   domain: 'embeds.myshopify.com'
    * });
    * ```
    *
@@ -37,15 +42,14 @@ const Shopify = {
    * @for ShopifyBuy
    * @static
    * @public
-   * @param {Object} configAttrs An object of required config data.
-   * @param {String} configAttrs.apiKey Your api client's public token.
-   * @param {String} configAttrs.appId The app whose listings the client will be
-   * using. If you are just modifying a buy button, the buy-button's app id is 6.
-   * Otherwise, obtain the app id of the app you're modifying or extending.
-   * @param {String} configAttrs.myShopifyDomain You shop's `myshopify.com` domain.
-   * [deprecated Use configAttrs.domain]
-   * @param {String} configAttrs.domain You shop's full `myshopify.com` domain.
-   * @return {ShopClient} a client for the shop using your api credentials.
+   * @param {Object} configAttrs An object of required config data such as: `apiKey`, `appId`, `domain`
+   * @param {String} configAttrs.apiKey An API Key for your store. Documentation how to get an API Key:
+   *                                    https://help.shopify.com/api/sdks/js-buy-sdk/getting-started#api-key
+   * @param {String} configAttrs.appId Typically will be 6 which is the Buy Button App Id. For more info on App Id see:
+   *                                   https://help.shopify.com/api/sdks/js-buy-sdk/getting-started#app-id
+   * @param {String} configAttrs.domain Your shop's full `myshopify.com` domain. For example: `embeds.myshopify.com`
+   * @param {String} configAttrs.myShopifyDomain You shop's `myshopify.com` domain. [deprecated Use configAttrs.domain]
+   * @return {ShopClient} a client for the shop using your api credentials which you can use to query your store.
    */
   buildClient(configAttrs = {}) {
     const config = new this.Config(configAttrs);

--- a/tests/unit/models/cart-model-test.js
+++ b/tests/unit/models/cart-model-test.js
@@ -73,7 +73,7 @@ test('it proxies sub total from the underlying cart', function (assert) {
   assert.equal(model.subtotal, cartFixture.cart.subtotal_price);
 });
 
-test('it creates a line item when you add a variant', function (assert) {
+test('it deprecates addVariants to createLineItemsFromVariants', function (assert) {
   assert.expect(3);
 
   const done = assert.async();
@@ -96,6 +96,29 @@ test('it creates a line item when you add a variant', function (assert) {
   });
 });
 
+test('it creates a line item when you add a variant', function (assert) {
+  assert.expect(3);
+
+  const done = assert.async();
+
+  const quantity = 2;
+
+  const variant = singleProductFixture.product_listing.variants[1];
+
+  model.createLineItemsFromVariants({ variant, quantity }).then(cart => {
+    assert.equal(cart, model, 'it should be the same model, with updated attrs');
+    assert.equal(cart.lineItems.length, 2);
+    assert.equal(cart.lineItems.filter(item => {
+      return item.variant_id === variant.id && item.quantity === quantity;
+    }).length, 1, 'the line item exists');
+
+    done();
+  }).catch(() => {
+    assert.ok(false, 'promise should not reject');
+    done();
+  });
+});
+
 test('it returns correct lineItemCount', function (assert) {
   assert.expect(2);
   const done = assert.async();
@@ -105,7 +128,7 @@ test('it returns correct lineItemCount', function (assert) {
   const quantity = 8;
   const variant = singleProductFixture.product_listing.variants[1];
 
-  model.addVariants({ variant, quantity }).then(cart => {
+  model.createLineItemsFromVariants({ variant, quantity }).then(cart => {
     assert.equal(cart.lineItemCount, 9);
     done();
   }).catch(() => {
@@ -176,7 +199,7 @@ test('it dedupes line items with the same variant_id when added together', funct
   const quantity = 1;
   const variant = singleProductFixture.product_listing.variants[1];
 
-  model.addVariants({ variant, quantity }, { variant, quantity }).then(cart => {
+  model.createLineItemsFromVariants({ variant, quantity }, { variant, quantity }).then(cart => {
     assert.equal(cart, model, 'it should be the same model, with updated attrs');
     assert.equal(cart.lineItems.length, 2);
     assert.equal(cart.lineItems.filter(item => {
@@ -201,7 +224,7 @@ test('it dedupes line items with the same variant_id when added one after anothe
   const summedQuantity = quantity + cartFixture.cart.line_items[0].quantity;
   const properties = assign({}, cartFixture.cart.line_items[0].properties);
 
-  model.addVariants({ variant, quantity, properties }).then(cart => {
+  model.createLineItemsFromVariants({ variant, quantity, properties }).then(cart => {
     assert.equal(cart, model, 'it should be the same model, with updated attrs');
     assert.equal(cart.lineItems.length, 1, 'we\'re adding to the existing line_item');
     assert.equal(cart.lineItems.filter(item => {
@@ -234,7 +257,7 @@ test('it treats line_items with same variant_ids and different properties as dif
     properties: propertiesTwo
   }];
 
-  model.addVariants(...items).then(cart => {
+  model.createLineItemsFromVariants(...items).then(cart => {
     assert.equal(cart, model, 'it should be the same model, with updated attrs');
     assert.equal(cart.lineItems.length, 3);
     assert.equal(cart.lineItems.filter(item => {
@@ -284,7 +307,7 @@ test('it generates checkout permalinks', function (assert) {
 
   const variant = singleProductFixture.product_listing.variants[1];
 
-  model.addVariants({ variant, quantity: 1 }).then(cart => {
+  model.createLineItemsFromVariants({ variant, quantity: 1 }).then(cart => {
     const checkoutVariantPath = cart.lineItems.map(lineItem => {
       return `${lineItem.variant_id}:${lineItem.quantity}`;
     }).join(',');
@@ -324,7 +347,7 @@ test('it detects google analytics and appends the cross-domain linker param', fu
     callback(tracker);
   });
 
-  model.addVariants({ variant, quantity: 1 }).then(cart => {
+  model.createLineItemsFromVariants({ variant, quantity: 1 }).then(cart => {
     const checkoutVariantPath = cart.lineItems.map(lineItem => {
       return `${lineItem.variant_id}:${lineItem.quantity}`;
     }).join(',');
@@ -352,8 +375,8 @@ test('it keeps line_item attrs hashes, and doesn\'t inject classes into internal
   const variantOne = singleProductFixture.product_listing.variants[0];
   const variantTwo = singleProductFixture.product_listing.variants[1];
 
-  model.addVariants({ variant: variantOne, quantity }).then(_cart => {
-    _cart.addVariants({ variant: variantTwo, quantity }).then(cart => {
+  model.createLineItemsFromVariants({ variant: variantOne, quantity }).then(_cart => {
+    _cart.createLineItemsFromVariants({ variant: variantTwo, quantity }).then(cart => {
       assert.equal(cart.lineItems.length, 2);
 
       cart.lineItems.forEach(item => {
@@ -383,7 +406,7 @@ test('it doesn\'t pollute "attrs.line_items" with "CartLineItem" class instances
   const variantOne = singleProductFixture.product_listing.variants[0];
   const variantTwo = singleProductFixture.product_listing.variants[1];
 
-  model.addVariants({ variant: variantOne, quantity }, { variant: variantTwo, quantity }).then(cart => {
+  model.createLineItemsFromVariants({ variant: variantOne, quantity }, { variant: variantTwo, quantity }).then(cart => {
     assert.equal(cart.lineItems.length, 2);
     cart.removeLineItem(cart.lineItems[0].id);
     assert.equal(cart.lineItems.length, 1);

--- a/tests/unit/models/cart-model-test.js
+++ b/tests/unit/models/cart-model-test.js
@@ -78,15 +78,22 @@ test('it deprecates addVariants to createLineItemsFromVariants', function (asser
 
   const done = assert.async();
 
-  const quantity = 2;
-
   const variant = singleProductFixture.product_listing.variants[1];
+  const quantity = 2;
+  const initialLineItems = model.lineItems.filter(lineItem => {
+    return lineItem.variant_id === variant.id;
+  });
+  let quantityInitial = 0;
+
+  if (initialLineItems.length === 1) {
+    quantityInitial = initialLineItems[0].quantity;
+  }
 
   model.addVariants({ variant, quantity }).then(cart => {
     assert.equal(cart, model, 'it should be the same model, with updated attrs');
     assert.equal(cart.lineItems.length, 2);
     assert.equal(cart.lineItems.filter(item => {
-      return item.variant_id === variant.id && item.quantity === quantity;
+      return item.variant_id === variant.id && item.quantity === quantity + quantityInitial;
     }).length, 1, 'the line item exists');
 
     done();
@@ -101,15 +108,22 @@ test('it creates a line item when you add a variant', function (assert) {
 
   const done = assert.async();
 
-  const quantity = 2;
-
   const variant = singleProductFixture.product_listing.variants[1];
+  const quantity = 2;
+  const initialLineItems = model.lineItems.filter(lineItem => {
+    return lineItem.variant_id === variant.id;
+  });
+  let quantityInitial = 0;
 
-  model.createLineItemsFromVariants({ variant, quantity }).then(cart => {
+  if (initialLineItems.length === 1) {
+    quantityInitial = initialLineItems[0].quantity;
+  }
+
+  model.addVariants({ variant, quantity }).then(cart => {
     assert.equal(cart, model, 'it should be the same model, with updated attrs');
     assert.equal(cart.lineItems.length, 2);
     assert.equal(cart.lineItems.filter(item => {
-      return item.variant_id === variant.id && item.quantity === quantity;
+      return item.variant_id === variant.id && item.quantity === quantity + quantityInitial;
     }).length, 1, 'the line item exists');
 
     done();


### PR DESCRIPTION
This pull request does the following:
- Some updates to docs content
  + Made sure there were more examples in the docs
  + Examples actually have real world ids and data not just `"1234"` for ids
  + The first example encountered in docs should be copy and pasteable
- New docs created for some models
- Re-order API docs in sidebar based on "importance" rather than sorting it alphabetically
- Added a useable example to the Readme. (might not be bad to have 2 or three examples)

Would love if @minasmart @tessalt @yomexzo you could take a look. Unfortunately right now you cannot run `npm run doc:build` currently so to preview the docs in `yuidoc` just run:
```
node_modules/.bin/yuidoc --server 8080 -T default src/
```

I don't think this PR should be merged in until we can preview the actual docs but I figured I'd put this out there.