### PR TITLE
Explicitely adding btoa and atob to window scope

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,9 +1,18 @@
-import promisePoly from 'core-js/fn/promise';
 import 'whatwg-fetch/fetch.js';
-import 'Base64/base64.js';
+import promisePoly from 'core-js/fn/promise';
+import base64 from 'Base64/base64.js';
 import scope from './metal/global';
 
-// write polyfills to global scope
+// drop in polyfills from base64
+if (!scope.btoa) {
+  scope.btoa = base64.btoa;
+}
+
+if (!scope.atob) {
+  scope.atob = base64.atob;
+}
+
+// drop in polyfills from Promise
 if (!scope.Promise) {
   scope.Promise = promisePoly;
 }


### PR DESCRIPTION
@tessalt noticed that `btoa` and `atob` were not being polyfilled in properly.

I checked the source of the `base64` module and it was doing some fancy stuff to try to recognize whether it was being used as a module or globally.

This does not fix IE9 issues. Will need to investigate those further.

👀 @tessalt @minasmart ?