### PR TITLE
Add files to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,6 +13,22 @@ tmp
 # Build artifacts
 .dist-test
 tests.xml
+.babelrc
+.eslintrc.json
+.gitignore
+.npmignore
+.rollup.config.umd.polyfilled.js
+.sass-cache
+DEPLOYING.md
+circle.yml
+examples
+scripts
+service.yml
+shipit.yml
+src
+testem.json
+tests
+yuidoc.json
 
 # The following files are gitignored, but MUST be pushed to NPM
 # dist


### PR DESCRIPTION
There were many files added to the `js-buy-sdk` when the build tool was setup. This PR adds those files to `.npmignore`.

👀 @minasmart @tessalt ?