### PR TITLE
`npm run doc:build` generates documentation src/ to docs/api by default

### DIFF
--- a/scripts/build-doc
+++ b/scripts/build-doc
@@ -4,7 +4,6 @@
 const docBuilder = require('./util/doc-builder');
 const commandLineOptions = require('commander')
   .option('-r, --references <items>', 'Comma separated list of GIT tags or branches. For example, to generate docs for master, v0.2.1 and v0.2.2, use, `npm run doc:build -- --references master,v0.2.1,v0.2.2`', val => val.split(','))
-  .option('-d, --head', 'Use this to generate docs for HEAD. It copies `src` directory instead of checking out the `src` using `git`')
   .parse(process.argv);
 
 let docBuilderOptions = {


### PR DESCRIPTION
This pull request modifies `feature/docs` slightly by default generating docs for the current src. It completely ignores `git` for doc generation and simply generates docs when you run:
```
npm run doc:build
```

@minasmart @yomexzo 