### PR TITLE
Fixed referencing issue when trying to checkout src branch from newly pulled tags

### DIFF
--- a/scripts/util/doc-builder.js
+++ b/scripts/util/doc-builder.js
@@ -43,11 +43,12 @@ function checkoutSrcDirectories() {
     const apiDocsMeta = [];
 
     return foundReferences.reduce((promise, reference) => {
-      const target = reference.targetPeel() || reference.target();
       let name = reference.shorthand();
 
       return promise.then(() => {
-        return repo.getCommit(target);
+        return reference.peel(NodeGit.Object.TYPE.COMMIT);
+      }).then(object => {
+        return repo.getCommit(object.id());
       }).then(commit => {
         console.info('\ninfo:', 'Getting tree for', name);
 


### PR DESCRIPTION
Fixes issue (detailed below) in #205.

In an existing (local) repo, when a new reference (tag) is available and you `git fetch`, the doc generation breaks for that new reference as shown below. The reason is because the object id (SHA) gotten does not point to a valid commit SHA.

This PR "peels" the received reference object (which is either a branch or a tag) until it gets the commit SHA. After which it uses the SHA to get the commit tree.

```
npm run doc:build 

> shopify-buy@0.3.0 doc:build /Users/mikkohaapoja/Documents/work/js-buy-sdk
> ./scripts/build-doc

Building ....

info: Getting all references within the repo
info: Picking objects for each requested references
info: Found 1 references ( v0.3.0 )

Error [Error: The requested type does not match the type in the ODB]
```