### PR TITLE
inline fragments in graph queries

### DIFF
--- a/tests/unit/graph/graph-test.js
+++ b/tests/unit/graph/graph-test.js
@@ -85,3 +85,21 @@ test('it adds connections with pagination info', function (assert) {
     }
   }`));
 });
+
+test('it adds inline fragments', function (assert) {
+  const graph = new Graph();
+
+  graph.addField('shop', {}, function (shop) {
+    shop.addInlineFragmentOn('Shop', function (fragment) {
+      fragment.addField('name');
+    });
+  });
+
+  assert.deepEqual(splitQuery(graph.toQuery()), splitQuery(`query {
+    shop {
+      ... on Shop {
+        name
+      }
+    }
+  }`));
+});


### PR DESCRIPTION
@minasmart and @mikkoh please review

This adds inline fragments to the query builder. A few things I changed along the way:

* replaced the untyped `{ name, args, node, fieldTypeCb }` field objects with `Field` instances that know how to serialize themselves with their own `toQuery` implementation.
* added an `InlineFragment` class whose instances appear together with `Field` instances in `Graph`'s `fields` array (which should soon be renamed to `selections` or similar to reflect its more varied inhabitants).
* replaced usage of `node` as a local variable name with the more specific `selectionSet`.