### PR TITLE
fix argument index in includes polyfill

### DIFF
--- a/src/metal/includes.js
+++ b/src/metal/includes.js
@@ -9,7 +9,7 @@ if (!Array.prototype.includes) {
       return false;
     }
 
-    const startIndex = parseInt(arguments[1], 10) || 0;
+    const startIndex = parseInt(arguments[2], 10) || 0;
     let index;
 
     if (startIndex >= 0) {


### PR DESCRIPTION
@minasmart 

`arguments[1]` will return the search string which could potentially be `parseInt`able. 
