### PR TITLE
Updated docs readme for local build

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -11,10 +11,10 @@
 - `npm install`
 
 ### Update the API docs
-- `npm run doc-build`
+- `npm run doc:build`
 
 ### Serve the documentation
-- `npm run doc-serve`
+- `npm run doc:serve`
 
 ## Deployment
 Changes to the `docs` directory will automatically be deployed to http://shopify.github.io/js-buy-sdk/ when added to `master` (remote).


### PR DESCRIPTION
`npm run doc-build` and `doc:serve` don't exist. Updates to the same task names as https://github.com/Shopify/js-buy-sdk/blob/d37914a2fa23dcacf492f92049a14a902d0972f8/CONTRIBUTING.md

@tessalt 