### PR TITLE
[FIX] Copy button links were pointing to old CDN

### DIFF
--- a/docs/downloads/index.md
+++ b/docs/downloads/index.md
@@ -17,7 +17,7 @@ To get up and running quickly, copy the following snippet and add it to your sit
 <script src="http://sdks.shopifycdn.com/js-buy-sdk/v{{majorVersion}}/latest/shopify-buy.umd.polyfilled.min.js"></script>
 ```
 
-<button class="marketing-button copy-button" data-clipboard-text="<script src=&quot;http://sdks.shopifycdn.com/js-buy-sdk/latest/shopify-buy.polyfilled.globals.min.js&quot;></script>">Copy to clipboard</button>
+<button class="marketing-button copy-button" data-clipboard-text="<script src=&quot;http://sdks.shopifycdn.com/js-buy-sdk/v{{majorVersion}}/latest/shopify-buy.umd.polyfilled.min.js&quot;></script>">Copy to clipboard</button>
 
 ## NPM Package
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ npm install shopify-buy
 <script src="http://sdks.shopifycdn.com/js-buy-sdk/v{{majorVersion}}/latest/shopify-buy.umd.polyfilled.min.js"></script>
 ```
 
-<button class="marketing-button copy-button" data-clipboard-text="<script src=&quot;http://sdks.shopifycdn.com/js-buy-sdk/latest/shopify-buy.polyfilled.globals.min.js&quot;></script>">Copy to clipboard</button>
+<button class="marketing-button copy-button" data-clipboard-text="<script src=&quot;http://sdks.shopifycdn.com/js-buy-sdk/v{{majorVersion}}/latest/shopify-buy.umd.polyfilled.min.js&quot;></script>">Copy to clipboard</button>
 
 ## Creating a Shop Client
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify-buy",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The JS Buy SDK is a lightweight library that allows you to build ecommerce into any website. It is based on Shopify's API and provides the ability to retrieve products and collections from your shop, add products to a cart, and checkout.",
   "main": "lib/shopify.js",
   "jsnext:main": "src/shopify.js",


### PR DESCRIPTION
In the documentation the CDN url was pointing to an older version of the JS Buy SDK

@tessalt @minasmart 