### PR TITLE
Moved guid to it's own file

### DIFF
--- a/src/adapters/local-storage-adapter.js
+++ b/src/adapters/local-storage-adapter.js
@@ -1,7 +1,7 @@
 import CoreObject from '../metal/core-object';
 import setGuidFor from '../metal/set-guid-for';
 import Store from '../store';
-import { GUID_KEY } from '../metal/set-guid-for';
+import GUID_KEY from '../metal/guid-key';
 
 const LocalStorageAdapter = CoreObject.extend({
   constructor() {

--- a/src/metal/guid-key.js
+++ b/src/metal/guid-key.js
@@ -1,0 +1,1 @@
+export default 'shopify-buy-uuid';

--- a/src/metal/set-guid-for.js
+++ b/src/metal/set-guid-for.js
@@ -1,6 +1,5 @@
 /* eslint no-undefined: 0 complexity: 0 */
-
-const GUID_KEY = 'shopify-buy-uuid';
+import GUID_KEY from './guid-key';
 
 const GUID_PREFIX = `shopify-buy.${Date.now()}`;
 
@@ -89,4 +88,3 @@ function setGuidFor(obj) {
 }
 
 export default setGuidFor;
-export { GUID_KEY };

--- a/src/models/cart-line-item-model.js
+++ b/src/models/cart-line-item-model.js
@@ -1,5 +1,5 @@
 import BaseModel from './base-model';
-import { GUID_KEY } from '../metal/set-guid-for';
+import GUID_KEY from '../metal/guid-key';
 
 /**
  * A cart stores an Array of `CartLineItemModel`'s in it's `lineItems` property.

--- a/src/models/cart-model.js
+++ b/src/models/cart-model.js
@@ -3,7 +3,7 @@ import CartLineItem from './cart-line-item-model';
 import assign from '../metal/assign';
 import setGuidFor from '../metal/set-guid-for';
 import globalVars from '../metal/global-vars';
-import { GUID_KEY } from '../metal/set-guid-for';
+import GUID_KEY from '../metal/guid-key';
 import logger from '../logger';
 
 function objectsEqual(one, two) {

--- a/src/models/reference-model.js
+++ b/src/models/reference-model.js
@@ -1,5 +1,5 @@
 import BaseModel from './base-model';
-import { GUID_KEY } from '../metal/set-guid-for';
+import GUID_KEY from '../metal/guid-key';
 
 const ReferenceModel = BaseModel.extend({
 

--- a/src/shop-client.js
+++ b/src/shop-client.js
@@ -5,7 +5,7 @@ import ReferenceSerializer from './serializers/reference-serializer';
 import LocalStorageAdapter from './adapters/local-storage-adapter';
 import CoreObject from './metal/core-object';
 import assign from './metal/assign';
-import { GUID_KEY } from './metal/set-guid-for';
+import GUID_KEY from './metal/guid-key';
 
 /**
  * @module shopify-buy

--- a/tests/fixtures/cart-fixture.js
+++ b/tests/fixtures/cart-fixture.js
@@ -1,4 +1,4 @@
-import { GUID_KEY } from 'shopify-buy/metal/set-guid-for';
+import GUID_KEY from 'shopify-buy/metal/guid-key';
 
 export const cartFixture = {
   cart: {

--- a/tests/integration/shop-client-cart-test.js
+++ b/tests/integration/shop-client-cart-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { step, resetStep } from 'shopify-buy/tests/helpers/assert-step';
 import ShopClient from 'shopify-buy/shop-client';
 import Config from 'shopify-buy/config';
-import { GUID_KEY } from 'shopify-buy/metal/set-guid-for';
+import GUID_KEY from 'shopify-buy/metal/guid-key';
 import assign from 'shopify-buy/metal/assign';
 
 const configAttrs = {

--- a/tests/integration/shop-client-recent-cart-test.js
+++ b/tests/integration/shop-client-recent-cart-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import ShopClient from 'shopify-buy/shop-client';
 import Config from 'shopify-buy/config';
-import { GUID_KEY } from 'shopify-buy/metal/set-guid-for';
+import GUID_KEY from 'shopify-buy/metal/guid-key';
 import CartModel from 'shopify-buy/models/cart-model';
 
 const configAttrs = {

--- a/tests/unit/api/shop-client-test.js
+++ b/tests/unit/api/shop-client-test.js
@@ -3,7 +3,7 @@ import { step, resetStep } from 'shopify-buy/tests/helpers/assert-step';
 import ShopClient from 'shopify-buy/shop-client';
 import Config from 'shopify-buy/config';
 import CartModel from 'shopify-buy/models/cart-model';
-import { GUID_KEY } from 'shopify-buy/metal/set-guid-for';
+import GUID_KEY from 'shopify-buy/metal/guid-key';
 
 const configAttrs = {
   domain: 'buckets-o-stuff.myshopify.com',

--- a/tests/unit/models/cart-line-item-model-test.js
+++ b/tests/unit/models/cart-line-item-model-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import CartLineItemModel from 'shopify-buy/models/cart-line-item-model';
 import assign from 'shopify-buy/metal/assign';
-import { GUID_KEY } from 'shopify-buy/metal/set-guid-for';
+import GUID_KEY from 'shopify-buy/metal/guid-key';
 import BaseModel from 'shopify-buy/models/base-model';
 
 let model;


### PR DESCRIPTION
For some reason `set-guid-for.js` was not being transpiled properly for the es5 CommonJS output. 

The transpiled code looked like this:
```
exports['default'] = setGuidFor;
exports.GUID_KEY = GUID_KEY;
```

It should have looked something like this:
```
exports['default'] = setGuidFor;
exports.GUID_KEY = GUID_KEY;
module.exports = exports['default'];
module.exports.GUID_KEY = GUID_KEY;
```

Moving `GUID_KEY` to it's own file `../metal/guid-key` seems to resolve this issue.

@tessalt @minasmart 
