### PR TITLE
add image variants to cart line items

### DIFF
--- a/src/models/cart-line-item-model.js
+++ b/src/models/cart-line-item-model.js
@@ -64,6 +64,30 @@ const CartLineItemModel = BaseModel.extend({
   },
 
   /**
+    * Image variants available for a variant. An example value of `imageVariant`:
+    * ```
+    * [
+    *   {
+    *     "name": "pico",
+    *     "dimensions": "16x16",
+    *     "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/alien_146ef7c1-26e9-4e96-96e6-9d37128d0005_pico.jpg?v=1469046423"
+    *   },
+    *   {
+    *     "name": "compact",
+    *     "dimensions": "160x160",
+    *     "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/alien_146ef7c1-26e9-4e96-96e6-9d37128d0005_compact.jpg?v=1469046423"
+    *   }
+    * ]
+    * ```
+    *
+    * @property imageVariant
+    * @type {Array}
+  */
+  get imageVariants() {
+    return this.attrs.image_variants;
+  },
+
+  /**
    * Product title of variant's parent product.
    * @property title
    * @readOnly

--- a/src/models/cart-model.js
+++ b/src/models/cart-model.js
@@ -154,6 +154,7 @@ const CartModel = BaseModel.extend({
     const newLineItems = [...arguments].map(item => {
       const lineItem = {
         image: item.variant.image,
+        image_variants: item.variant.imageVariants,
         variant_id: item.variant.id,
         product_id: item.variant.productId,
         title: item.variant.productTitle,

--- a/tests/unit/models/cart-line-item-model-test.js
+++ b/tests/unit/models/cart-line-item-model-test.js
@@ -119,13 +119,13 @@ test('it rejects things that are in no way numbers', function (assert) {
 });
 
 test('it proxies values in attrs that we would like to expose', function (assert) {
-  assert.expect(9);
+  assert.expect(10);
 
   assert.equal(model.id, model.attrs[GUID_KEY]);
   assert.equal(model.variant_id, model.attrs.variant_id);
   assert.equal(model.product_id, model.attrs.product_id);
   assert.equal(model.image, model.attrs.image);
-  assert.equal(model.image_variants, model.attrs.image_variants);
+  assert.equal(model.imageVariants, model.attrs.image_variants);
   assert.equal(model.title, model.attrs.title);
   assert.equal(model.variant_title, model.attrs.variant_title);
   assert.equal(model.price, model.attrs.price);

--- a/tests/unit/models/cart-line-item-model-test.js
+++ b/tests/unit/models/cart-line-item-model-test.js
@@ -8,6 +8,9 @@ let model;
 
 const lineItemFixture = {
   image: 'http://google.com/image.png',
+  image_variants: [
+    'http://google.com/image.png',
+  ],
   variant_id: 12345,
   product_id: 45678,
   title: 'Some Product',
@@ -122,6 +125,7 @@ test('it proxies values in attrs that we would like to expose', function (assert
   assert.equal(model.variant_id, model.attrs.variant_id);
   assert.equal(model.product_id, model.attrs.product_id);
   assert.equal(model.image, model.attrs.image);
+  assert.equal(model.image_variants, model.attrs.image_variants);
   assert.equal(model.title, model.attrs.title);
   assert.equal(model.variant_title, model.attrs.variant_title);
   assert.equal(model.price, model.attrs.price);


### PR DESCRIPTION
currently `CartLineItem.image` returns the default image for a variant, which can be very large. I've added `imageVariants` to the model so that consumers can select a different sized image. 

@minasmart @mikkoh 