### PR TITLE
Use access_token param instead of api_key for checkout

### DIFF
--- a/src/models/cart-model.js
+++ b/src/models/cart-model.js
@@ -96,7 +96,7 @@ const CartModel = BaseModel.extend({
       return `${item.variant_id}:${item.quantity}`;
     });
 
-    let query = `api_key=${config.apiKey}&_fd=0`;
+    let query = `access_token=${config.apiKey}&_fd=0`;
 
     if (typeof ga === 'function') {
       let linkerParam;

--- a/tests/integration/shop-client-cart-test.js
+++ b/tests/integration/shop-client-cart-test.js
@@ -154,7 +154,7 @@ test('it has a checkout url reflecting the line items in the cart', function (as
   };
   const baseUrl = `https://${config.domain}/cart`;
   const lineItemPath = `${lineItem.variant_id}:${lineItem.quantity}`;
-  const query = `api_key=${config.apiKey}&_fd=0`;
+  const query = `access_token=${config.apiKey}&_fd=0`;
 
 
   shopClient.fetchCart(id).then(cart => {

--- a/tests/unit/models/cart-model-test.js
+++ b/tests/unit/models/cart-model-test.js
@@ -315,7 +315,7 @@ test('it generates checkout permalinks', function (assert) {
   const baseUrl = `https://${config.domain}/cart`;
   const variantId = model.lineItems[0].variant_id;
   const quantity = model.lineItems[0].quantity;
-  const query = `api_key=${config.apiKey}&_fd=0`;
+  const query = `access_token=${config.apiKey}&_fd=0`;
 
   assert.equal(model.checkoutUrl, `${baseUrl}/${variantId}:${quantity}?${query}`);
 
@@ -344,7 +344,7 @@ test('it detects google analytics and appends the cross-domain linker param', fu
   const baseUrl = `https://${config.domain}/cart`;
   const variantId = model.lineItems[0].variant_id;
   const quantity = model.lineItems[0].quantity;
-  const query = `api_key=${config.apiKey}&_fd=0`;
+  const query = `access_token=${config.apiKey}&_fd=0`;
   const linkerParam = 'ga=some-linker-param';
 
   assert.equal(model.checkoutUrl, `${baseUrl}/${variantId}:${quantity}?${query}`);


### PR DESCRIPTION
This changes the URL param passed to permalink checkout.  (see https://github.com/Shopify/shopify/pull/94780)

In the future with this project we should try to rename the internal use of `apiKey` and start calling it an `accessToken`.  This is a little outside the scope of my work, which was to just get all consumers of the checkout to use the right param on the URL.

I'm not sure how I can 🎩  this project, anyone want to help me out? :)

//review @yomexzo @minasmart 