### PR TITLE
add image model

### DIFF
--- a/src/models/image-model.js
+++ b/src/models/image-model.js
@@ -1,5 +1,18 @@
 import CoreObject from '../metal/core-object';
 
+const variants = [
+  { name: 'pico', dimension: '16x16' },
+  { name: 'icon', dimension: '32x32' },
+  { name: 'thumb', dimension: '50x50' },
+  { name: 'small', dimension: '100x100' },
+  { name: 'compact', dimension: '160x160' },
+  { name: 'medium', dimension: '240x240' },
+  { name: 'large', dimension: '480x480' },
+  { name: 'grande', dimension: '600x600' },
+  { name: '1024x1024', dimension: '1024x1024' },
+  { name: '2048x2048', dimension: '2048x2048' }
+];
+
 const ImageModel = CoreObject.extend({
   constructor(attrs) {
     Object.keys(attrs).forEach(key => {
@@ -8,7 +21,7 @@ const ImageModel = CoreObject.extend({
   },
 
   /**
-    * Image variants available for a variant. An example value of `imageVariant`:
+    * Image variants available for an image. An example value of `imageVariant`:
     * ```
     * [
     *   {
@@ -32,18 +45,6 @@ const ImageModel = CoreObject.extend({
     const extensionIndex = src.lastIndexOf('.');
     const pathAndBasename = src.slice(0, extensionIndex);
     const extension = src.slice(extensionIndex);
-    const variants = [
-      { name: 'pico', dimension: '16x16' },
-      { name: 'icon', dimension: '32x32' },
-      { name: 'thumb', dimension: '50x50' },
-      { name: 'small', dimension: '100x100' },
-      { name: 'compact', dimension: '160x160' },
-      { name: 'medium', dimension: '240x240' },
-      { name: 'large', dimension: '480x480' },
-      { name: 'grande', dimension: '600x600' },
-      { name: '1024x1024', dimension: '1024x1024' },
-      { name: '2048x2048', dimension: '2048x2048' }
-    ];
 
     variants.forEach(variant => {
       variant.src = `${pathAndBasename}_${variant.name}${extension}`;

--- a/src/models/image-model.js
+++ b/src/models/image-model.js
@@ -37,7 +37,7 @@ const ImageModel = CoreObject.extend({
     * ]
     * ```
     *
-    * @property imageVariant
+    * @attribute variants
     * @type {Array}
   */
   get variants() {

--- a/src/models/image-model.js
+++ b/src/models/image-model.js
@@ -1,0 +1,56 @@
+import CoreObject from '../metal/core-object';
+
+const ImageModel = CoreObject.extend({
+  constructor(attrs) {
+    Object.keys(attrs).forEach(key => {
+      this[key] = attrs[key];
+    });
+  },
+
+  /**
+    * Image variants available for a variant. An example value of `imageVariant`:
+    * ```
+    * [
+    *   {
+    *     "name": "pico",
+    *     "dimensions": "16x16",
+    *     "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/alien_146ef7c1-26e9-4e96-96e6-9d37128d0005_pico.jpg?v=1469046423"
+    *   },
+    *   {
+    *     "name": "compact",
+    *     "dimensions": "160x160",
+    *     "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/alien_146ef7c1-26e9-4e96-96e6-9d37128d0005_compact.jpg?v=1469046423"
+    *   }
+    * ]
+    * ```
+    *
+    * @property imageVariant
+    * @type {Array}
+  */
+  get variants() {
+    const src = this.src;
+    const extensionIndex = src.lastIndexOf('.');
+    const pathAndBasename = src.slice(0, extensionIndex);
+    const extension = src.slice(extensionIndex);
+    const variants = [
+      { name: 'pico', dimension: '16x16' },
+      { name: 'icon', dimension: '32x32' },
+      { name: 'thumb', dimension: '50x50' },
+      { name: 'small', dimension: '100x100' },
+      { name: 'compact', dimension: '160x160' },
+      { name: 'medium', dimension: '240x240' },
+      { name: 'large', dimension: '480x480' },
+      { name: 'grande', dimension: '600x600' },
+      { name: '1024x1024', dimension: '1024x1024' },
+      { name: '2048x2048', dimension: '2048x2048' }
+    ];
+
+    variants.forEach(variant => {
+      variant.src = `${pathAndBasename}_${variant.name}${extension}`;
+    });
+
+    return variants;
+  }
+});
+
+export default ImageModel;

--- a/src/models/product-model.js
+++ b/src/models/product-model.js
@@ -1,6 +1,7 @@
 import BaseModel from './base-model';
 import ProductOptionModel from './product-option-model';
 import ProductVariantModel from './product-variant-model';
+import ImageModel from './image-model';
 import uniq from '../metal/uniq';
 
 const NO_IMAGE_URI = 'https://widgets.shopifyapps.com/assets/no-image.svg';
@@ -62,7 +63,9 @@ const ProductModel = BaseModel.extend({
     * @type {Array} array of image objects.
   */
   get images() {
-    return this.attrs.images;
+    return this.attrs.images.map(image => {
+      return new ImageModel(image);
+    });
   },
 
   get memoized() {

--- a/src/models/product-variant-model.js
+++ b/src/models/product-variant-model.js
@@ -150,13 +150,13 @@ const ProductVariantModel = BaseModel.extend({
       return image.variant_ids.indexOf(id) !== -1;
     })[0];
 
-    const productImage = variantImage || primaryImage;
+    const image = variantImage || primaryImage;
 
-    if (!productImage) {
+    if (!image) {
       return null;
     }
 
-    return new ImageModel(productImage);
+    return new ImageModel(image);
   },
 
   /**

--- a/src/models/product-variant-model.js
+++ b/src/models/product-variant-model.js
@@ -1,5 +1,5 @@
 import BaseModel from './base-model';
-
+import ImageModel from './image-model';
 
 /**
   * Model for product variant
@@ -150,7 +150,13 @@ const ProductVariantModel = BaseModel.extend({
       return image.variant_ids.indexOf(id) !== -1;
     })[0];
 
-    return (variantImage || primaryImage);
+    const productImage = variantImage || primaryImage;
+
+    if (!productImage) {
+      return null;
+    }
+
+    return new ImageModel(productImage);
   },
 
   /**
@@ -174,34 +180,11 @@ const ProductVariantModel = BaseModel.extend({
     * @type {Array}
   */
   get imageVariants() {
-    const image = this.image;
-
-    if (!image) {
+    if (!this.image) {
       return [];
     }
 
-    const src = this.image.src;
-    const extensionIndex = src.lastIndexOf('.');
-    const pathAndBasename = src.slice(0, extensionIndex);
-    const extension = src.slice(extensionIndex);
-    const variants = [
-      { name: 'pico', dimension: '16x16' },
-      { name: 'icon', dimension: '32x32' },
-      { name: 'thumb', dimension: '50x50' },
-      { name: 'small', dimension: '100x100' },
-      { name: 'compact', dimension: '160x160' },
-      { name: 'medium', dimension: '240x240' },
-      { name: 'large', dimension: '480x480' },
-      { name: 'grande', dimension: '600x600' },
-      { name: '1024x1024', dimension: '1024x1024' },
-      { name: '2048x2048', dimension: '2048x2048' }
-    ];
-
-    variants.forEach(variant => {
-      variant.src = `${pathAndBasename}_${variant.name}${extension}`;
-    });
-
-    return variants;
+    return this.image.variants;
   },
 
   /**

--- a/tests/unit/models/image-model-test.js
+++ b/tests/unit/models/image-model-test.js
@@ -1,0 +1,39 @@
+import { module, test } from 'qunit';
+import ImageModel from 'shopify-buy/models/image-model';
+import CoreObject from 'shopify-buy/metal/core-object';
+import { singleProductFixture } from '../../fixtures/product-fixture';
+
+let model;
+
+const config = {};
+
+module('Unit | ImageModel', {
+  setup() {
+    model = new ImageModel(singleProductFixture.product_listing.images[0], { config });
+  }
+});
+
+test('it extends from CoreObject', function (assert) {
+  assert.expect(1);
+
+  assert.ok(CoreObject.prototype.isPrototypeOf(model));
+});
+
+test('it copies attrs to properties', function (assert) {
+  assert.expect(5);
+  assert.equal(model.src, singleProductFixture.product_listing.images[0].src);
+  assert.equal(model.created_at, singleProductFixture.product_listing.images[0].created_at);
+  assert.deepEqual(model.variant_ids, singleProductFixture.product_listing.images[0].variant_ids);
+  assert.equal(model.product_id, singleProductFixture.product_listing.images[0].product_id);
+  assert.equal(model.position, singleProductFixture.product_listing.images[0].position);
+});
+
+test('it populates image variants', function (assert) {
+  assert.expect(2);
+  assert.equal(model.variants.length, 10);
+  assert.deepEqual(model.variants[0], {
+    name: 'pico',
+    dimension: '16x16',
+    src: 'https://cdn.shopify.com/image-one_pico.jpg'
+  });
+});

--- a/tests/unit/models/product-model-test.js
+++ b/tests/unit/models/product-model-test.js
@@ -68,7 +68,7 @@ test('it proxies attrs for most commonly used props', function (assert) {
 
   assert.equal(model.id, singleProductFixture.product_listing.product_id);
   assert.equal(model.title, singleProductFixture.product_listing.title);
-  assert.deepEqual(model.images[0].id, singleProductFixture.product_listing.images[0].id);
+  assert.equal(model.images[0].id, singleProductFixture.product_listing.images[0].id);
 
   // Variants are now rich models, so we just want to guarantee that same-state
   // is represented.

--- a/tests/unit/models/product-model-test.js
+++ b/tests/unit/models/product-model-test.js
@@ -68,7 +68,7 @@ test('it proxies attrs for most commonly used props', function (assert) {
 
   assert.equal(model.id, singleProductFixture.product_listing.product_id);
   assert.equal(model.title, singleProductFixture.product_listing.title);
-  assert.deepEqual(model.images, singleProductFixture.product_listing.images);
+  assert.deepEqual(model.images[0].id, singleProductFixture.product_listing.images[0].id);
 
   // Variants are now rich models, so we just want to guarantee that same-state
   // is represented.

--- a/tests/unit/models/product-variant-test.js
+++ b/tests/unit/models/product-variant-test.js
@@ -144,11 +144,11 @@ test('it returns the image variants for the variant', function (assert) {
 test('it returns the image for the variant', function (assert) {
   assert.expect(2);
 
-  assert.deepEqual(model.image, baseAttrs.product.images[1]);
+  assert.deepEqual(model.image.id, baseAttrs.product.images[1].id);
 
   model.attrs.variant.id = 'abc123';
 
-  assert.deepEqual(model.image, baseAttrs.product.images[0], 'the first image is default when no id matches');
+  assert.deepEqual(model.image.id, baseAttrs.product.images[0].id, 'the first image is default when no id matches');
 });
 
 test('image variants should be empty when there\'s not image', function (assert) {

--- a/tests/unit/models/product-variant-test.js
+++ b/tests/unit/models/product-variant-test.js
@@ -144,11 +144,11 @@ test('it returns the image variants for the variant', function (assert) {
 test('it returns the image for the variant', function (assert) {
   assert.expect(2);
 
-  assert.deepEqual(model.image.id, baseAttrs.product.images[1].id);
+  assert.equal(model.image.id, baseAttrs.product.images[1].id);
 
   model.attrs.variant.id = 'abc123';
 
-  assert.deepEqual(model.image.id, baseAttrs.product.images[0].id, 'the first image is default when no id matches');
+  assert.equal(model.image.id, baseAttrs.product.images[0].id, 'the first image is default when no id matches');
 });
 
 test('image variants should be empty when there\'s not image', function (assert) {


### PR DESCRIPTION
so we kind of have an issue in buy button land. 
Sometimes products have images that are not attached to variants. Sometimes we like to show these images at specific sizes like "pico" or "grande". Currently, you can only access these size-specific srcs through the variant model. 

I propose an `Image` model. It's slightly gross because i want the API to be backwards compatible, but I think it works? @minasmart @mikkoh @harisaurus 