### PR TITLE
Update apiKey to accessToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you're just getting started, please [read the docs](http://shopify.github.io/
 ## Example
 ```javascript
 const shopClient = ShopifyBuy.buildClient({
-  apiKey: 'bf081e860bc9dc1ce0654fdfbc20892d',
+  accessToken: 'bf081e860bc9dc1ce0654fdfbc20892d',
   appId: 6,
   domain: 'embeds.myshopify.com'
 });

--- a/docs/_data/package.json
+++ b/docs/_data/package.json
@@ -50,7 +50,7 @@
     "qunit-shim:build": "cross-env BABEL_ENV=amd-test-qunit-shim babel tests/shims/ > .dist-test/qunit-shim.js",
     "qunit:copy": "cp node_modules/qunitjs/qunit/qunit.js .dist-test/qunit.js && cp node_modules/qunitjs/qunit/qunit.css .dist-test/qunit.css",
     "------ Scripts for testing-examples": null,
-    "test-example:run": "concurrently -k --success first 'selenium-standalone start -- -log selenium.log' 'http-server -p 4200 .dist-test/' 'npm run wdio:run'",
+    "test-example:run": "concurrently -k --success last 'selenium-standalone start -- -log selenium.log' 'http-server -p 4200 .dist-test/' 'npm run wdio:run'",
     "test-example:build": "",
     "wdio:run": "wait-on tcp:4444 && wait-on tcp:4200 && wdio --logLevel silent .dist-test/examples/cart/wdio.conf.js",
     "examples:build": "npm run examples:copy && npm run examples-css:build",

--- a/docs/api/api.js
+++ b/docs/api/api.js
@@ -26,7 +26,7 @@ YUI.add("yuidoc-meta", function(Y) {
         {
             "displayName": "shopify",
             "name": "shopify",
-            "description": "`ShopifyBuy` only defines one function {{#crossLink \"ShopifyBuy/buildClient\"}}{{/crossLink}} which can\nbe used to build a {{#crossLink \"ShopClient\"}}{{/crossLink}} to query your store using the\nprovided\n{{#crossLink \"ShopifyBuy/buildClient/configAttrs:apiKey\"}}`apiKey`{{/crossLink}},\n{{#crossLink \"ShopifyBuy/buildClient/configAttrs:appId\"}}`appId`{{/crossLink}},\nand {{#crossLink \"ShopifyBuy/buildClient/configAttrs:domain\"}}`domain`{{/crossLink}}."
+            "description": "`ShopifyBuy` only defines one function {{#crossLink \"ShopifyBuy/buildClient\"}}{{/crossLink}} which can\nbe used to build a {{#crossLink \"ShopClient\"}}{{/crossLink}} to query your store using the\nprovided\n{{#crossLink \"ShopifyBuy/buildClient/configAttrs:accessToken\"}}`accessToken`{{/crossLink}},\n{{#crossLink \"ShopifyBuy/buildClient/configAttrs:appId\"}}`appId`{{/crossLink}},\nand {{#crossLink \"ShopifyBuy/buildClient/configAttrs:domain\"}}`domain`{{/crossLink}}."
         },
         {
             "displayName": "shopify-buy",

--- a/docs/api/classes/Logger.html
+++ b/docs/api/classes/Logger.html
@@ -86,6 +86,36 @@ Also allows us to disable output in production.</p>
     <div id="attrs" class="page-section">
         <h2 class="off-left">Attributes</h2>
 
+<div id="attr-accessToken" class="attr item private">
+    <a name="config_accessToken"></a> 
+    <h3 class="name"><code>accessToken</code></h3>
+    <span class="type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String" class="crosslink external" target="_blank">String</a></span>
+
+
+        <span class="flag private">private</span>
+
+
+
+
+
+
+    <div class="meta">
+                <p>
+        </p>
+
+
+    </div>
+
+    <div class="description">
+        <p>The accessToken for authenticating against shopify. This is your api client's
+storefront access token. Not the shared secret. Set during initialization.</p>
+
+    </div>
+
+        <p><strong>Default:</strong> &#x27;&#x27;</p>
+
+
+</div>
 <div id="attr-ajaxHeaders" class="attr item private">
     <a name="config_ajaxHeaders"></a> 
     <h3 class="name"><code>ajaxHeaders</code></h3>
@@ -114,11 +144,12 @@ Also allows us to disable output in production.</p>
 
 
 </div>
-<div id="attr-apiKey" class="attr item private">
+<div id="attr-apiKey" class="attr item private deprecated">
     <a name="config_apiKey"></a> 
     <h3 class="name"><code>apiKey</code></h3>
     <span class="type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String" class="crosslink external" target="_blank">String</a></span>
 
+        <span class="flag deprecated" title="Use &#x60;config.accessToken&#x60; instead.">deprecated</span>
 
         <span class="flag private">private</span>
 
@@ -131,12 +162,13 @@ Also allows us to disable output in production.</p>
                 <p>
         </p>
 
+            <p>Deprecated: Use &#x60;config.accessToken&#x60; instead.</p>
 
     </div>
 
     <div class="description">
         <p>The apiKey for authenticating against shopify. This is your api client's
-public api token. Not the shared secret. Set during initialation.</p>
+public api token. Not the shared secret. Set during initialization.</p>
 
     </div>
 
@@ -199,7 +231,7 @@ have the value signature function(deprecated_value, config_to_be_transformed)</p
 
     </div>
 
-        <p><strong>Default:</strong> { myShopifyDomain: this.transformMyShopifyDomain }</p>
+        <p><strong>Default:</strong> { apiKey: this.transformApiKey, myShopifyDomain: this.transformMyShopifyDomain }</p>
 
 
 </div>
@@ -317,7 +349,7 @@ have the value signature function(deprecated_value, config_to_be_transformed)</p
 
     </div>
 
-        <p><strong>Default:</strong> [&#x27;apiKey&#x27;, &#x27;appId&#x27;, &#x27;myShopifyDomain&#x27;]</p>
+        <p><strong>Default:</strong> [&#x27;accessToken&#x27;, &#x27;appId&#x27;, &#x27;myShopifyDomain&#x27;]</p>
 
 
 </div>
@@ -327,6 +359,79 @@ have the value signature function(deprecated_value, config_to_be_transformed)</p
     <div id="static-methods" class="page-section">
         <h2 class="off-left">Static Methods</h2>
         <div class="item-list">
+<div id="method-transformApiKey" class="method item private">
+	<div class="method-signature">
+	<span class="name"><code>Logger.transformApiKey</code></span>
+
+		<div class="args">
+			<span class="paren">(</span><ul class="args-list inline commas">
+				<li class="arg">
+						<code>apiKey</code>
+				</li>
+				<li class="arg">
+						<code>attrs.</code>
+				</li>
+			</ul><span class="paren">)</span>
+		</div>
+		<span class="returns-inline">
+			<span class="type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object" class="crosslink external" target="_blank">Object</a></span>
+		</span>
+	</div>
+
+
+		<span class="flag private">private</span>
+
+
+
+
+	<div class="meta">
+				<p>
+		</p>
+
+
+
+	</div>
+
+	<div class="description"><p>Transform the apiKey config to an accessToken config.</p>
+</div>
+
+		<div class="params">
+			<h4>Parameters:</h4>
+
+			<ul class="params-list">
+				<li class="param">
+						<code class="param-name">apiKey</code>
+						<span class="type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String" class="crosslink external" target="_blank">String</a></span>
+
+
+					<div class="param-description"><p>The original api key</p>
+</div>
+
+				</li>
+				<li class="param">
+						<code class="param-name">attrs.</code>
+						<span class="type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object" class="crosslink external" target="_blank">Object</a></span>
+
+
+					<div class="param-description"><p>The config attributes to be transformed to a
+non-deprecated state.</p>
+</div>
+
+				</li>
+			</ul>
+		</div>
+
+		<div class="returns">
+			<h4>Returns:</h4>
+
+			<div class="returns-description">
+						<span class="type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object" class="crosslink external" target="_blank">Object</a></span>:
+					<p>the transformed config attributes.</p>
+
+			</div>
+		</div>
+
+</div>
 <div id="method-transformMyShopifyDomain" class="method item private">
 	<div class="method-signature">
 	<span class="name"><code>Logger.transformMyShopifyDomain</code></span>
@@ -424,6 +529,7 @@ non-deprecated state.</p>
 		<li>
 			<h2>Attributes</h2>
 			<ul>
+				<li class="private"><a href="#attr-accessToken"><span class="iattr">accessToken</span></a></li>
 				<li class="private"><a href="#attr-ajaxHeaders"><span class="iattr">ajaxHeaders</span></a></li>
 				<li class="private"><a href="#attr-apiKey"><span class="iattr">apiKey</span></a></li>
 				<li class="private"><a href="#attr-appId"><span class="iattr">appId</span></a></li>
@@ -438,6 +544,7 @@ non-deprecated state.</p>
 		<li>
 			<h2>Static Methods</h2>
 			<ul>
+				<li class="private"><a href="#method-transformApiKey"><span class="im">Logger.transformApiKey</span></a></li>
 				<li class="private"><a href="#method-transformMyShopifyDomain"><span class="im">Logger.transformMyShopifyDomain</span></a></li>
 			</ul>
 		</li>

--- a/docs/api/classes/ShopifyBuy.html
+++ b/docs/api/classes/ShopifyBuy.html
@@ -46,7 +46,7 @@ layout: api
 <p><code>ShopifyBuy</code> only defines one function <a href="../classes/ShopifyBuy.html#method_buildClient" class="crosslink">buildClient</a> which can
 be used to build a <a href="../classes/ShopClient.html" class="crosslink">ShopClient</a> to query your store using the
 provided
-<a href="../classes/ShopifyBuy.html#method_buildClient" class="crosslink"><code>apiKey</code></a>,
+<a href="../classes/ShopifyBuy.html#method_buildClient" class="crosslink"><code>accessToken</code></a>,
 <a href="../classes/ShopifyBuy.html#method_buildClient" class="crosslink"><code>appId</code></a>,
 and <a href="../classes/ShopifyBuy.html#method_buildClient" class="crosslink"><code>domain</code></a>.</p>
 
@@ -95,7 +95,7 @@ and <a href="../classes/ShopifyBuy.html#method_buildClient" class="crosslink"><c
 
 	<div class="description"><p>Create a ShopClient. This is the main entry point to the SDK.</p>
 <pre class="code prettyprint"><code class="language-javascript">const client = ShopifyBuy.buildClient({
-  apiKey: 'bf081e860bc9dc1ce0654fdfbc20892d',
+  accessToken: 'bf081e860bc9dc1ce0654fdfbc20892d',
   appId: 6,
   myShopifyDomain: 'your-shop-subdomain.myshopify.com', //Deprecated. Use <code>domain</code> instead
   domain: 'embeds.myshopify.com'
@@ -112,16 +112,16 @@ and <a href="../classes/ShopifyBuy.html#method_buildClient" class="crosslink"><c
 						<span class="type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object" class="crosslink external" target="_blank">Object</a></span>
 
 
-					<div class="param-description"><p>An object of required config data such as: <code>apiKey</code>, <code>appId</code>, <code>domain</code></p>
+					<div class="param-description"><p>An object of required config data such as: <code>accessToken</code>, <code>appId</code>, <code>domain</code></p>
 </div>
 
 						<ul class="params-list">
 							<li class="param">
-									<code class="param-name">apiKey</code>
+									<code class="param-name">accessToken</code>
 									<span class="type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String" class="crosslink external" target="_blank">String</a></span>
 
-								<div class="param-description"><p>An API Key for your store. Documentation how to get an API Key:
-<a href="https://help.shopify.com/api/sdks/js-buy-sdk/getting-started#api-key">https://help.shopify.com/api/sdks/js-buy-sdk/getting-started#api-key</a></p>
+								<div class="param-description"><p>An access token for your store. Documentation how to get a token:
+<a href="https://help.shopify.com/api/sdks/custom-storefront/js-buy-sdk/getting-started#generate-javascript-buy-sdk-credentials">https://help.shopify.com/api/sdks/custom-storefront/js-buy-sdk/getting-started#generate-javascript-buy-sdk-credentials</a></p>
 </div>
 
 							</li>

--- a/docs/api/data.json
+++ b/docs/api/data.json
@@ -179,7 +179,7 @@
             "namespace": "",
             "file": "docs/src/src/shopify.js",
             "line": 13,
-            "description": "`ShopifyBuy` only defines one function {{#crossLink \"ShopifyBuy/buildClient\"}}{{/crossLink}} which can\nbe used to build a {{#crossLink \"ShopClient\"}}{{/crossLink}} to query your store using the\nprovided\n{{#crossLink \"ShopifyBuy/buildClient/configAttrs:apiKey\"}}`apiKey`{{/crossLink}},\n{{#crossLink \"ShopifyBuy/buildClient/configAttrs:appId\"}}`appId`{{/crossLink}},\nand {{#crossLink \"ShopifyBuy/buildClient/configAttrs:domain\"}}`domain`{{/crossLink}}."
+            "description": "`ShopifyBuy` only defines one function {{#crossLink \"ShopifyBuy/buildClient\"}}{{/crossLink}} which can\nbe used to build a {{#crossLink \"ShopClient\"}}{{/crossLink}} to query your store using the\nprovided\n{{#crossLink \"ShopifyBuy/buildClient/configAttrs:accessToken\"}}`accessToken`{{/crossLink}},\n{{#crossLink \"ShopifyBuy/buildClient/configAttrs:appId\"}}`appId`{{/crossLink}},\nand {{#crossLink \"ShopifyBuy/buildClient/configAttrs:domain\"}}`domain`{{/crossLink}}."
         },
         "version": {
             "name": "version",
@@ -338,7 +338,7 @@
             "namespace": "",
             "file": "docs/src/src/shopify.js",
             "line": 13,
-            "description": "`ShopifyBuy` only defines one function {{#crossLink \"ShopifyBuy/buildClient\"}}{{/crossLink}} which can\nbe used to build a {{#crossLink \"ShopClient\"}}{{/crossLink}} to query your store using the\nprovided\n{{#crossLink \"ShopifyBuy/buildClient/configAttrs:apiKey\"}}`apiKey`{{/crossLink}},\n{{#crossLink \"ShopifyBuy/buildClient/configAttrs:appId\"}}`appId`{{/crossLink}},\nand {{#crossLink \"ShopifyBuy/buildClient/configAttrs:domain\"}}`domain`{{/crossLink}}.",
+            "description": "`ShopifyBuy` only defines one function {{#crossLink \"ShopifyBuy/buildClient\"}}{{/crossLink}} which can\nbe used to build a {{#crossLink \"ShopClient\"}}{{/crossLink}} to query your store using the\nprovided\n{{#crossLink \"ShopifyBuy/buildClient/configAttrs:accessToken\"}}`accessToken`{{/crossLink}},\n{{#crossLink \"ShopifyBuy/buildClient/configAttrs:appId\"}}`appId`{{/crossLink}},\nand {{#crossLink \"ShopifyBuy/buildClient/configAttrs:domain\"}}`domain`{{/crossLink}}.",
             "static": 1
         }
     },
@@ -951,7 +951,7 @@
             "description": "An object with keys for deprecated properties and values as functions that\nwill transform the value into a usable value. A depracation transform should\nhave the value signature function(deprecated_value, config_to_be_transformed)",
             "itemtype": "attribute",
             "name": "deprecatedProperties",
-            "default": "{ myShopifyDomain: this.transformMyShopifyDomain }",
+            "default": "{ apiKey: this.transformApiKey, myShopifyDomain: this.transformMyShopifyDomain }",
             "type": "Object",
             "access": "private",
             "tagname": "",
@@ -959,7 +959,7 @@
         },
         {
             "file": "docs/src/src/config.js",
-            "line": 41,
+            "line": 42,
             "description": "Transform the myShopifyDomain config to a domain config.",
             "itemtype": "method",
             "name": "transformMyShopifyDomain",
@@ -986,11 +986,38 @@
         },
         {
             "file": "docs/src/src/config.js",
-            "line": 57,
+            "line": 58,
+            "description": "Transform the apiKey config to an accessToken config.",
+            "itemtype": "method",
+            "name": "transformApiKey",
+            "static": 1,
+            "access": "private",
+            "tagname": "",
+            "params": [
+                {
+                    "name": "apiKey",
+                    "description": "The original api key",
+                    "type": "String"
+                },
+                {
+                    "name": "attrs.",
+                    "description": "The config attributes to be transformed to a\nnon-deprecated state.",
+                    "type": "Object"
+                }
+            ],
+            "return": {
+                "description": "the transformed config attributes.",
+                "type": "Object"
+            },
+            "class": "Logger"
+        },
+        {
+            "file": "docs/src/src/config.js",
+            "line": 74,
             "description": "Properties that must be set on initializations",
             "itemtype": "attribute",
             "name": "requiredProperties",
-            "default": "['apiKey', 'appId', 'myShopifyDomain']",
+            "default": "['accessToken', 'appId', 'myShopifyDomain']",
             "type": "Array",
             "access": "private",
             "tagname": "",
@@ -998,7 +1025,7 @@
         },
         {
             "file": "docs/src/src/config.js",
-            "line": 70,
+            "line": 87,
             "description": "Properties that may be set on initializations",
             "itemtype": "attribute",
             "name": "optionalProperties",
@@ -1010,10 +1037,10 @@
         },
         {
             "file": "docs/src/src/config.js",
-            "line": 81,
-            "description": "The apiKey for authenticating against shopify. This is your api client's\npublic api token. Not the shared secret. Set during initialation.",
+            "line": 98,
+            "description": "The accessToken for authenticating against shopify. This is your api client's\nstorefront access token. Not the shared secret. Set during initialization.",
             "itemtype": "attribute",
-            "name": "apiKey",
+            "name": "accessToken",
             "default": "''",
             "type": "String",
             "access": "private",
@@ -1022,7 +1049,21 @@
         },
         {
             "file": "docs/src/src/config.js",
-            "line": 91,
+            "line": 108,
+            "description": "The apiKey for authenticating against shopify. This is your api client's\npublic api token. Not the shared secret. Set during initialization.",
+            "itemtype": "attribute",
+            "name": "apiKey",
+            "default": "''",
+            "type": "String",
+            "access": "private",
+            "tagname": "",
+            "deprecated": true,
+            "deprecationMessage": "Use `config.accessToken` instead.",
+            "class": "Logger"
+        },
+        {
+            "file": "docs/src/src/config.js",
+            "line": 119,
             "itemtype": "attribute",
             "name": "appId",
             "default": "''",
@@ -1033,7 +1074,7 @@
         },
         {
             "file": "docs/src/src/config.js",
-            "line": 99,
+            "line": 127,
             "description": "The domain that all the api requests will go to",
             "itemtype": "attribute",
             "name": "domain",
@@ -1045,7 +1086,7 @@
         },
         {
             "file": "docs/src/src/config.js",
-            "line": 108,
+            "line": 136,
             "description": "The subdomain of myshopify.io that all the api requests will go to",
             "itemtype": "attribute",
             "name": "myShopifyDomain",
@@ -1059,7 +1100,7 @@
         },
         {
             "file": "docs/src/src/config.js",
-            "line": 118,
+            "line": 146,
             "itemtype": "attribute",
             "name": "ajaxHeaders",
             "default": "{}",
@@ -1546,7 +1587,7 @@
         {
             "file": "docs/src/src/shopify.js",
             "line": 29,
-            "description": "Create a ShopClient. This is the main entry point to the SDK.\n\n```javascript\nconst client = ShopifyBuy.buildClient({\n  apiKey: 'bf081e860bc9dc1ce0654fdfbc20892d',\n  appId: 6,\n  myShopifyDomain: 'your-shop-subdomain.myshopify.com', //Deprecated. Use `domain` instead\n  domain: 'embeds.myshopify.com'\n});\n```",
+            "description": "Create a ShopClient. This is the main entry point to the SDK.\n\n```javascript\nconst client = ShopifyBuy.buildClient({\n  accessToken: 'bf081e860bc9dc1ce0654fdfbc20892d',\n  appId: 6,\n  myShopifyDomain: 'your-shop-subdomain.myshopify.com', //Deprecated. Use `domain` instead\n  domain: 'embeds.myshopify.com'\n});\n```",
             "itemtype": "method",
             "name": "buildClient",
             "static": 1,
@@ -1555,17 +1596,17 @@
             "params": [
                 {
                     "name": "configAttrs",
-                    "description": "An object of required config data such as: `apiKey`, `appId`, `domain`",
+                    "description": "An object of required config data such as: `accessToken`, `appId`, `domain`",
                     "type": "Object",
                     "props": [
                         {
-                            "name": "apiKey",
-                            "description": "An API Key for your store. Documentation how to get an API Key:\n                                   https://help.shopify.com/api/sdks/js-buy-sdk/getting-started#api-key",
+                            "name": "accessToken",
+                            "description": "An access token for your store. Documentation how to get a token:\n  https://help.shopify.com/api/sdks/custom-storefront/js-buy-sdk/getting-started#generate-javascript-buy-sdk-credentials",
                             "type": "String"
                         },
                         {
                             "name": "appId",
-                            "description": "Typically will be 6 which is the Buy Button App Id. For more info on App Id see:\n                                  https://help.shopify.com/api/sdks/js-buy-sdk/getting-started#app-id",
+                            "description": "Typically will be 6 which is the Buy Button App Id. For more info on App Id see:\n  https://help.shopify.com/api/sdks/js-buy-sdk/getting-started#app-id",
                             "type": "String"
                         },
                         {

--- a/docs/api/modules/shopify-buy.html
+++ b/docs/api/modules/shopify-buy.html
@@ -125,7 +125,7 @@ layout: api
                         <code>ShopifyBuy</code> only defines one function {{#crossLink "ShopifyBuy/buildClient"}}{{/crossLink}} which can
 be used to build a {{#crossLink "ShopClient"}}{{/crossLink}} to query your store using the
 provided
-{{#crossLink "ShopifyBuy/buildClient/configAttrs:apiKey"}}<code>apiKey</code>{{/crossLink}},
+{{#crossLink "ShopifyBuy/buildClient/configAttrs:accessToken"}}<code>accessToken</code>{{/crossLink}},
 {{#crossLink "ShopifyBuy/buildClient/configAttrs:appId"}}<code>appId</code>{{/crossLink}},
 and {{#crossLink "ShopifyBuy/buildClient/configAttrs:domain"}}<code>domain</code>{{/crossLink}}.
                     </div>

--- a/docs/api/modules/shopify.html
+++ b/docs/api/modules/shopify.html
@@ -44,7 +44,7 @@ layout: api
     <p><code>ShopifyBuy</code> only defines one function <a href="../classes/ShopifyBuy.html#method_buildClient" class="crosslink">buildClient</a> which can
 be used to build a <a href="../classes/ShopClient.html" class="crosslink">ShopClient</a> to query your store using the
 provided
-<a href="../classes/ShopifyBuy.html#method_buildClient" class="crosslink"><code>apiKey</code></a>,
+<a href="../classes/ShopifyBuy.html#method_buildClient" class="crosslink"><code>accessToken</code></a>,
 <a href="../classes/ShopifyBuy.html#method_buildClient" class="crosslink"><code>appId</code></a>,
 and <a href="../classes/ShopifyBuy.html#method_buildClient" class="crosslink"><code>domain</code></a>.</p>
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -12,7 +12,7 @@ To use any of the examples, we first have to set up a Shopify Client in our Java
 ```js
 $(function() {
   var client = ShopifyBuy.buildClient({
-    apiKey: 'your-api-key',
+    accessToken: 'your-access-token',
     domain: 'your-shop-subdomain.myshopify.com',
     appId: '6'
   });

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ begin making requests. <a href="https://docs.shopify.com/api/sdks/js-buy-sdk/get
 
 ```js
 var shopClient = ShopifyBuy.buildClient({
-  apiKey: 'your-api-key',
+  accessToken: 'your-access-token',
   domain: 'your-shop-subdomain.myshopify.com',
   appId: '6'
 });
@@ -70,7 +70,7 @@ To request an individual resource, you will need to pass that resource's ID as t
 
 ```js
 const shopClient = ShopifyBuy.buildClient({
-  apiKey: 'bf081e860bc9dc1ce0654fdfbc20892d',
+  accessToken: 'bf081e860bc9dc1ce0654fdfbc20892d',
   appId: '6',
   domain: 'embeds.myshopify.com'
 });

--- a/src/adapters/listings-adapter.js
+++ b/src/adapters/listings-adapter.js
@@ -10,8 +10,8 @@ const ListingsAdapter = CoreObject.extend({
     this.config = config;
   },
 
-  get base64ApiKey() {
-    return btoa(this.config.apiKey);
+  get base64AccessToken() {
+    return btoa(this.config.accessToken);
   },
 
   get baseUrl() {
@@ -22,7 +22,7 @@ const ListingsAdapter = CoreObject.extend({
 
   get headers() {
     return assign({}, {
-      Authorization: `Basic ${this.base64ApiKey}`,
+      Authorization: `Basic ${this.base64AccessToken}`,
       'Content-Type': 'application/json',
       'X-SDK-Variant': 'javascript',
       'X-SDK-Version': version

--- a/src/config.js
+++ b/src/config.js
@@ -30,11 +30,12 @@ const Config = CoreObject.extend({
    * will transform the value into a usable value. A depracation transform should
    * have the value signature function(deprecated_value, config_to_be_transformed)
    * @attribute deprecatedProperties
-   * @default { myShopifyDomain: this.transformMyShopifyDomain }
+   * @default { apiKey: this.transformApiKey, myShopifyDomain: this.transformMyShopifyDomain }
    * @type Object
    * @private
    */
   deprecatedProperties: {
+    apiKey: 'transformApiKey',
     myShopifyDomain: 'transformMyShopifyDomain'
   },
 
@@ -55,14 +56,30 @@ const Config = CoreObject.extend({
   },
 
   /**
+   * Transform the apiKey config to an accessToken config.
+   * @method transformApiKey
+   * @static
+   * @private
+   * @param {String} apiKey The original api key
+   * @param {Object} attrs. The config attributes to be transformed to a
+   * non-deprecated state.
+   * @return {Object} the transformed config attributes.
+   */
+  transformApiKey(apiKey, attrs) {
+    logger.warn('Config - ',
+       'apiKey is deprecated, please use accessToken instead.');
+    attrs.accessToken = apiKey;
+  },
+
+  /**
    * Properties that must be set on initializations
    * @attribute requiredProperties
-   * @default ['apiKey', 'appId', 'myShopifyDomain']
+   * @default ['accessToken', 'appId', 'myShopifyDomain']
    * @type Array
    * @private
    */
   requiredProperties: [
-    'apiKey',
+    'accessToken',
     'appId',
     'domain'
   ],
@@ -79,12 +96,23 @@ const Config = CoreObject.extend({
   ],
 
   /**
+   * The accessToken for authenticating against shopify. This is your api client's
+   * storefront access token. Not the shared secret. Set during initialization.
+   * @attribute accessToken
+   * @default ''
+   * @type String
+   * @private
+   */
+  accessToken: '',
+
+  /**
    * The apiKey for authenticating against shopify. This is your api client's
-   * public api token. Not the shared secret. Set during initialation.
+   * public api token. Not the shared secret. Set during initialization.
    * @attribute apiKey
    * @default ''
    * @type String
    * @private
+   * @deprecated Use `config.accessToken` instead.
    */
   apiKey: '',
 

--- a/src/models/cart-model.js
+++ b/src/models/cart-model.js
@@ -96,7 +96,7 @@ const CartModel = BaseModel.extend({
       return `${item.variant_id}:${item.quantity}`;
     });
 
-    let query = `access_token=${config.apiKey}&_fd=0`;
+    let query = `access_token=${config.accessToken}&_fd=0`;
 
     if (typeof ga === 'function') {
       let linkerParam;

--- a/src/shopify.js
+++ b/src/shopify.js
@@ -14,7 +14,7 @@ import { NO_IMAGE_URI } from './models/product-model';
  * `ShopifyBuy` only defines one function {{#crossLink "ShopifyBuy/buildClient"}}{{/crossLink}} which can
  * be used to build a {{#crossLink "ShopClient"}}{{/crossLink}} to query your store using the
  * provided
- * {{#crossLink "ShopifyBuy/buildClient/configAttrs:apiKey"}}`apiKey`{{/crossLink}},
+ * {{#crossLink "ShopifyBuy/buildClient/configAttrs:accessToken"}}`accessToken`{{/crossLink}},
  * {{#crossLink "ShopifyBuy/buildClient/configAttrs:appId"}}`appId`{{/crossLink}},
  * and {{#crossLink "ShopifyBuy/buildClient/configAttrs:domain"}}`domain`{{/crossLink}}.
  * @class ShopifyBuy
@@ -31,7 +31,7 @@ const Shopify = {
    *
    * ```javascript
    * const client = ShopifyBuy.buildClient({
-   *   apiKey: 'bf081e860bc9dc1ce0654fdfbc20892d',
+   *   accessToken: 'bf081e860bc9dc1ce0654fdfbc20892d',
    *   appId: 6,
    *   myShopifyDomain: 'your-shop-subdomain.myshopify.com', //Deprecated. Use `domain` instead
    *   domain: 'embeds.myshopify.com'
@@ -42,8 +42,8 @@ const Shopify = {
    * @for ShopifyBuy
    * @static
    * @public
-   * @param {Object} configAttrs An object of required config data such as: `apiKey`, `appId`, `domain`
-   * @param {String} configAttrs.apiKey An API Key for your store. Documentation how to get an API Key:
+   * @param {Object} configAttrs An object of required config data such as: `accessToken`, `appId`, `domain`
+   * @param {String} configAttrs.accessToken An access token for your store. Documentation how to get a token:
    *                                    https://help.shopify.com/api/sdks/js-buy-sdk/getting-started#api-key
    * @param {String} configAttrs.appId Typically will be 6 which is the Buy Button App Id. For more info on App Id see:
    *                                   https://help.shopify.com/api/sdks/js-buy-sdk/getting-started#app-id

--- a/src/shopify.js
+++ b/src/shopify.js
@@ -44,9 +44,9 @@ const Shopify = {
    * @public
    * @param {Object} configAttrs An object of required config data such as: `accessToken`, `appId`, `domain`
    * @param {String} configAttrs.accessToken An access token for your store. Documentation how to get a token:
-   *                                    https://help.shopify.com/api/sdks/js-buy-sdk/getting-started#api-key
+   *   https://help.shopify.com/api/sdks/custom-storefront/js-buy-sdk/getting-started#generate-javascript-buy-sdk-credentials
    * @param {String} configAttrs.appId Typically will be 6 which is the Buy Button App Id. For more info on App Id see:
-   *                                   https://help.shopify.com/api/sdks/js-buy-sdk/getting-started#app-id
+   *   https://help.shopify.com/api/sdks/js-buy-sdk/getting-started#app-id
    * @param {String} configAttrs.domain Your shop's full `myshopify.com` domain. For example: `embeds.myshopify.com`
    * @param {String} configAttrs.myShopifyDomain You shop's `myshopify.com` domain. [deprecated Use configAttrs.domain]
    * @return {ShopClient} a client for the shop using your api credentials which you can use to query your store.

--- a/tests/integration/shop-client-cart-test.js
+++ b/tests/integration/shop-client-cart-test.js
@@ -6,9 +6,9 @@ import GUID_KEY from 'shopify-buy/metal/guid-key';
 import assign from 'shopify-buy/metal/assign';
 
 const configAttrs = {
-  myShopifyDomain: 'buckets-o-stuff',
-  apiKey: 'abc123',
-  appId: 6
+  accessToken: 'abc123',
+  appId: 6,
+  myShopifyDomain: 'buckets-o-stuff'
 };
 
 
@@ -154,7 +154,7 @@ test('it has a checkout url reflecting the line items in the cart', function (as
   };
   const baseUrl = `https://${config.domain}/cart`;
   const lineItemPath = `${lineItem.variant_id}:${lineItem.quantity}`;
-  const query = `access_token=${config.apiKey}&_fd=0`;
+  const query = `access_token=${config.accessToken}&_fd=0`;
 
 
   shopClient.fetchCart(id).then(cart => {

--- a/tests/integration/shop-client-fetch-collection-test.js
+++ b/tests/integration/shop-client-fetch-collection-test.js
@@ -6,7 +6,7 @@ import { singleCollectionFixture, multipleCollectionsFixture } from '../fixtures
 
 const configAttrs = {
   domain: 'buckets-o-stuff.myshopify.com',
-  apiKey: 1,
+  accessToken: 1,
   appId: 6
 };
 

--- a/tests/integration/shop-client-fetch-product-test.js
+++ b/tests/integration/shop-client-fetch-product-test.js
@@ -6,7 +6,7 @@ import { singleProductFixture, multipleProductsFixture } from '../fixtures/produ
 
 const configAttrs = {
   domain: 'buckets-o-stuff.myshopify.com',
-  apiKey: 1,
+  accessToken: 1,
   appId: 6
 };
 

--- a/tests/integration/shop-client-recent-cart-test.js
+++ b/tests/integration/shop-client-recent-cart-test.js
@@ -6,7 +6,7 @@ import CartModel from 'shopify-buy/models/cart-model';
 
 const configAttrs = {
   domain: 'buckets-o-stuff.myshopify.com',
-  apiKey: 'abc123',
+  accessToken: 'abc123',
   appId: 6
 };
 

--- a/tests/unit/adapters/listings-adapter-test.js
+++ b/tests/unit/adapters/listings-adapter-test.js
@@ -7,8 +7,8 @@ let adapter;
 const appId = 6;
 const domain = 'buckets-o-stuff.myshopify.com';
 const baseUrl = `https://${domain}/api/apps/${appId}`;
-const apiKey = 'abc123def456ghi';
-const base64ApiKey = btoa(apiKey);
+const accessToken = 'abc123def456ghi';
+const base64AccessToken = btoa(accessToken);
 
 function resolvingPromise() {
   return new Promise(function (resolve) {
@@ -37,14 +37,14 @@ test('it builds auth headers using the base64 encoded api key', function (assert
   assert.expect(1);
 
   adapter.config = {
-    apiKey,
+    accessToken,
     ajaxHeaders: {
       'test': 'test-string'
     }
   };
 
   assert.deepEqual(adapter.headers, {
-    Authorization: `Basic ${base64ApiKey}`,
+    Authorization: `Basic ${base64AccessToken}`,
     'Content-Type': 'application/json',
     'X-SDK-Variant': 'javascript',
     'X-SDK-Version': version,
@@ -86,13 +86,13 @@ test('it builds the url for a query', function (assert) {
 test('it sends a GET, the correct url, and auth headers for fetchMultiple to #ajax', function (assert) {
   assert.expect(3);
 
-  adapter.config = { domain, appId, apiKey };
+  adapter.config = { domain, appId, accessToken };
 
   adapter.ajax = function (method, url, opts) {
     assert.equal(method, 'GET');
     assert.equal(url, `${baseUrl}/collection_listings`);
     assert.deepEqual(opts.headers, {
-      Authorization: `Basic ${base64ApiKey}`,
+      Authorization: `Basic ${base64AccessToken}`,
       'Content-Type': 'application/json',
       'X-SDK-Variant': 'javascript',
       'X-SDK-Version': version
@@ -109,13 +109,13 @@ test('it sends a GET, the correct url, and auth headers for fetchSingle to #ajax
 
   const id = 123;
 
-  adapter.config = { domain, appId, apiKey };
+  adapter.config = { domain, appId, accessToken };
 
   adapter.ajax = function (method, url, opts) {
     assert.equal(method, 'GET');
     assert.equal(url, `${baseUrl}/collection_listings/${id}`);
     assert.deepEqual(opts.headers, {
-      Authorization: `Basic ${base64ApiKey}`,
+      Authorization: `Basic ${base64AccessToken}`,
       'Content-Type': 'application/json',
       'X-SDK-Variant': 'javascript',
       'X-SDK-Version': version
@@ -133,14 +133,14 @@ test('it sends a GET, the correct url, and auth headers for fetchMultiple with q
   const ids = [123, 456, 789];
   const page = 88;
 
-  adapter.config = { domain, appId, apiKey };
+  adapter.config = { domain, appId, accessToken };
 
   adapter.ajax = function (method, url, opts) {
     // Should resolve with a promise
     assert.equal(method, 'GET');
     assert.equal(url, `${baseUrl}/collection_listings?collection_ids=${encodeURIComponent(ids.join(','))}&page=${page}`);
     assert.deepEqual(opts.headers, {
-      Authorization: `Basic ${base64ApiKey}`,
+      Authorization: `Basic ${base64AccessToken}`,
       'Content-Type': 'application/json',
       'X-SDK-Variant': 'javascript',
       'X-SDK-Version': version

--- a/tests/unit/api/config-test.js
+++ b/tests/unit/api/config-test.js
@@ -18,7 +18,7 @@ test('it throws an error with some but not all params', function (assert) {
   assert.expect(1);
 
   assert.throws(function () {
-    new Config({ apiKey: 123 });
+    new Config({ accessToken: 123 });
   }, 'some but not all required params should produce an error');
 });
 
@@ -26,8 +26,8 @@ test('it doesn\'t throw when all required params are specified', function (asser
   assert.expect(1);
 
   const config = new Config({
-    myShopifyDomain: 'krundle',
-    apiKey: 123,
+    domain: 'krundle.com',
+    accessToken: 123,
     appId: 6
   });
 
@@ -39,11 +39,11 @@ test('it should convert myShopifyDomain to domain', function (assert) {
 
   const config = new Config({
     myShopifyDomain: 'krundle',
-    apiKey: 123,
+    accessToken: 123,
     appId: 6
   });
 
-  assert.equal(config.domain, 'krundle.myshopify.com', 'domain should be myshopify.com domain');
+  assert.equal(config.domain, 'krundle.myshopify.com', 'domain should append myshopify.com');
 });
 
 test('it should output a deprecation warning when using myShopifyDomain', function (assert) {
@@ -58,7 +58,7 @@ test('it should output a deprecation warning when using myShopifyDomain', functi
 
   new Config({
     myShopifyDomain: 'krundle',
-    apiKey: 123,
+    accessToken: 123,
     appId: 6
   });
 
@@ -73,9 +73,43 @@ test('it should set domain', function (assert) {
 
   const config = new Config({
     domain: 'krundle.com',
-    apiKey: 123,
+    accessToken: 123,
     appId: 6
   });
 
   assert.equal(config.domain, 'krundle.com', 'domain should be krundle.com domain');
+});
+
+test('it should convert apiKey to accessToken', function (assert) {
+  assert.expect(1);
+
+  const config = new Config({
+    domain: 'krundle.com',
+    apiKey: 123,
+    appId: 6
+  });
+
+  assert.equal(config.accessToken, 123, 'accessToken should be 123 apiKey');
+});
+
+test('it should output a deprecation warning when using apiKey', function (assert) {
+  assert.expect(3);
+
+  const oldLog = logger.warn;
+  let output = [];
+
+  logger.warn = function () {
+    output = Array.prototype.slice.call(arguments);
+  };
+
+  new Config({
+    domain: 'krundle.com',
+    apiKey: 123,
+    appId: 6
+  });
+
+  assert.equal(output.length, 2, 'logging should have a tag for config');
+  assert.equal(output[0], 'Config - ', 'the deprecation warning should say it\'s from config');
+  assert.notEqual(output[1].indexOf('deprecated'), -1, 'the deprecation warning should describe the problem');
+  logger.warn = oldLog;
 });

--- a/tests/unit/api/shop-client-test.js
+++ b/tests/unit/api/shop-client-test.js
@@ -7,7 +7,7 @@ import GUID_KEY from 'shopify-buy/metal/guid-key';
 
 const configAttrs = {
   domain: 'buckets-o-stuff.myshopify.com',
-  apiKey: 123,
+  accessToken: 123,
   appId: 6
 };
 

--- a/tests/unit/models/cart-model-test.js
+++ b/tests/unit/models/cart-model-test.js
@@ -14,7 +14,7 @@ const { getItem, setItem, removeItem } = localStorage;
 const storage = {};
 const config = {
   domain: 'buckets-o-stuff.myshopify.com',
-  apiKey: 'abc123'
+  accessToken: 'abc123'
 };
 
 module('Unit | CartModel', {
@@ -315,7 +315,7 @@ test('it generates checkout permalinks', function (assert) {
   const baseUrl = `https://${config.domain}/cart`;
   const variantId = model.lineItems[0].variant_id;
   const quantity = model.lineItems[0].quantity;
-  const query = `access_token=${config.apiKey}&_fd=0`;
+  const query = `access_token=${config.accessToken}&_fd=0`;
 
   assert.equal(model.checkoutUrl, `${baseUrl}/${variantId}:${quantity}?${query}`);
 
@@ -344,7 +344,7 @@ test('it detects google analytics and appends the cross-domain linker param', fu
   const baseUrl = `https://${config.domain}/cart`;
   const variantId = model.lineItems[0].variant_id;
   const quantity = model.lineItems[0].quantity;
-  const query = `access_token=${config.apiKey}&_fd=0`;
+  const query = `access_token=${config.accessToken}&_fd=0`;
   const linkerParam = 'ga=some-linker-param';
 
   assert.equal(model.checkoutUrl, `${baseUrl}/${variantId}:${quantity}?${query}`);

--- a/tests/unit/models/product-variant-test.js
+++ b/tests/unit/models/product-variant-test.js
@@ -53,7 +53,7 @@ const baseAttrs = {
 
 const config = {
   domain: 'buckets-o-stuff.myshopify.com',
-  apiKey: 'abc123'
+  accessToken: 'abc123'
 };
 
 module('Unit | ProductVariantModel', {


### PR DESCRIPTION
This adds the `accessToken` config option and deprecates `apiKey`.

Changes:

* Code: 417aeaca4d21e002dd19ee6bca26bcaa4afc2841
* Docs: 5d168c256c1535f15ec130ed9db53a9f5bee215d

https://help.shopify.com/api/sdks/js-buy-sdk/getting-started#api-key will also need to updated separately.