### PR TITLE
use imagemodel for line item images

### DIFF
--- a/src/models/cart-line-item-model.js
+++ b/src/models/cart-line-item-model.js
@@ -64,6 +64,7 @@ const CartLineItemModel = BaseModel.extend({
     if (!this.attrs.image) {
       return null;
     }
+
     return new ImageModel(this.attrs.image);
   },
 

--- a/src/models/cart-line-item-model.js
+++ b/src/models/cart-line-item-model.js
@@ -1,4 +1,5 @@
 import BaseModel from './base-model';
+import ImageModel from './image-model';
 import GUID_KEY from '../metal/guid-key';
 
 /**
@@ -60,7 +61,10 @@ const CartLineItemModel = BaseModel.extend({
    * @type {Object}
    */
   get image() {
-    return this.attrs.image;
+    if (!this.attrs.image) {
+      return null;
+    }
+    return new ImageModel(this.attrs.image);
   },
 
   /**
@@ -84,7 +88,11 @@ const CartLineItemModel = BaseModel.extend({
     * @type {Array}
   */
   get imageVariants() {
-    return this.attrs.image_variants;
+    if (!this.image) {
+      return [];
+    }
+
+    return this.image.variants;
   },
 
   /**

--- a/src/models/image-model.js
+++ b/src/models/image-model.js
@@ -1,6 +1,6 @@
 import CoreObject from '../metal/core-object';
 
-const variants = [
+export const variants = [
   { name: 'pico', dimension: '16x16' },
   { name: 'icon', dimension: '32x32' },
   { name: 'thumb', dimension: '50x50' },

--- a/tests/unit/models/cart-line-item-model-test.js
+++ b/tests/unit/models/cart-line-item-model-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import CartLineItemModel from 'shopify-buy/models/cart-line-item-model';
+import { variants } from 'shopify-buy/models/image-model';
 import assign from 'shopify-buy/metal/assign';
 import GUID_KEY from 'shopify-buy/metal/guid-key';
 import BaseModel from 'shopify-buy/models/base-model';
@@ -124,7 +125,7 @@ test('it proxies values in attrs that we would like to expose', function (assert
   assert.equal(model.variant_id, model.attrs.variant_id);
   assert.equal(model.product_id, model.attrs.product_id);
   assert.equal(model.image.id, model.attrs.image.id);
-  assert.equal(model.imageVariants.length, 10);
+  assert.equal(model.imageVariants.length, variants.length);
   assert.equal(model.title, model.attrs.title);
   assert.equal(model.variant_title, model.attrs.variant_title);
   assert.equal(model.price, model.attrs.price);

--- a/tests/unit/models/cart-line-item-model-test.js
+++ b/tests/unit/models/cart-line-item-model-test.js
@@ -7,10 +7,9 @@ import BaseModel from 'shopify-buy/models/base-model';
 let model;
 
 const lineItemFixture = {
-  image: 'http://google.com/image.png',
-  image_variants: [
-    'http://google.com/image.png',
-  ],
+  image: {
+    src: 'http://google.com/image.png',
+  },
   variant_id: 12345,
   product_id: 45678,
   title: 'Some Product',
@@ -124,8 +123,8 @@ test('it proxies values in attrs that we would like to expose', function (assert
   assert.equal(model.id, model.attrs[GUID_KEY]);
   assert.equal(model.variant_id, model.attrs.variant_id);
   assert.equal(model.product_id, model.attrs.product_id);
-  assert.equal(model.image, model.attrs.image);
-  assert.equal(model.imageVariants, model.attrs.image_variants);
+  assert.equal(model.image.id, model.attrs.image.id);
+  assert.equal(model.imageVariants.length, 10);
   assert.equal(model.title, model.attrs.title);
   assert.equal(model.variant_title, model.attrs.variant_title);
   assert.equal(model.price, model.attrs.price);


### PR DESCRIPTION
should fix https://github.com/Shopify/buy-button/issues/2152 and let me remove some code in buy-button-js. 

@minasmart @mikkoh 