### PR TITLE
fix variant checkoutUrl

### DIFF
--- a/src/models/product-variant-model.js
+++ b/src/models/product-variant-model.js
@@ -207,7 +207,7 @@ const ProductVariantModel = BaseModel.extend({
 
     const variantPath = `${this.id}:${parseInt(quantity, 10)}`;
 
-    const query = `api_key=${config.apiKey}`;
+    const query = `access_token=${config.apiKey}&_fd=0`;
 
     return `${baseUrl}/${variantPath}?${query}`;
   }

--- a/tests/unit/models/product-variant-test.js
+++ b/tests/unit/models/product-variant-test.js
@@ -162,7 +162,7 @@ test('it generates checkout permalinks from passed quantity', function (assert) 
   assert.expect(4);
 
   const baseUrl = `https://${config.domain}/cart`;
-  const query = `api_key=${config.apiKey}`;
+  const query = `access_token=${config.apiKey}&_fd=0`;
 
   assert.equal(model.checkoutUrl(), `${baseUrl}/${model.id}:1?${query}`, 'defaults to 1');
   assert.equal(model.checkoutUrl(27), `${baseUrl}/${model.id}:27?${query}`, 'respects passed quantity');


### PR DESCRIPTION
shops with custom domains won't redirect to checkout without the `fd` param because the custom domain redirect supercedes it. @tanema @minasmart 