### PR TITLE
[FEATURE] Query products/collections by specific fields

### DIFF
--- a/fixtures/query-collection-fixture.js
+++ b/fixtures/query-collection-fixture.js
@@ -1,0 +1,22 @@
+export default {
+  "data": {
+    "shop": {
+      "collections": {
+        "pageInfo": {
+          "hasNextPage": false,
+          "hasPreviousPage": false
+        },
+        "edges": [
+          {
+            "cursor": "eyJsYXN0X2lkIjozNjkzMTI1ODQsImxhc3RfdmFsdWUiOiIzNjkzMTI1ODQifQ==",
+            "node": {
+              "id": "gid://shopify/Collection/369312584",
+              "title": "Cat Collection",
+              "updatedAt": "2017-02-09T19:06:44Z"
+            }
+          }
+        ]
+      }
+    }
+  }
+};

--- a/fixtures/query-product-fixture.js
+++ b/fixtures/query-product-fixture.js
@@ -1,0 +1,24 @@
+export default {
+  "data": {
+    "shop": {
+      "products": {
+        "pageInfo": {
+          "hasNextPage": false,
+          "hasPreviousPage": false
+        },
+        "edges": [
+          {
+            "cursor": "eyJsYXN0X2lkIjo3ODU3OTg5Mzg0LCJsYXN0X3ZhbHVlIjoiNzg1Nzk4OTM4NCJ9",
+            "node": {
+              "id": "gid://shopify/Product/7857989384",
+              "updatedAt": "2017-02-17T19:56:02Z",
+              "createdAt": "2016-09-25T21:31:33Z",
+              "productType": "dog",
+              "title": "Cat"
+            }
+          }
+        ]
+      }
+    }
+  }
+};

--- a/fixtures/shop-with-sorted-collections-fixture.js
+++ b/fixtures/shop-with-sorted-collections-fixture.js
@@ -1,0 +1,35 @@
+export default {
+  "data": {
+    "shop": {
+      "collections": {
+        "pageInfo": {
+          "hasNextPage": false,
+          "hasPreviousPage": false
+        },
+        "edges": [
+          {
+            "cursor": "eyJsYXN0X2lkIjo0MTMwOTQ0NzIsImxhc3RfdmFsdWUiOiJUZXN0In0=",
+            "node": {
+              "id": "gid://shopify/Collection/413094472",
+              "title": "Test Collection"
+            }
+          },
+          {
+            "cursor": "eyJsYXN0X2lkIjozNjkzMTI1ODQsImxhc3RfdmFsdWUiOiJDYXQgQ29sbGVjdGlvbiJ9",
+            "node": {
+              "id": "gid://shopify/Collection/369312584",
+              "title": "Cat Collection"
+            }
+          },
+          {
+            "cursor": "eyJsYXN0X2lkIjozNjkzMTI1ODQsImxhc3RfdmFsDs1iOiJDYXQgQ29sbGVjdGiJ9",
+            "node": {
+              "id": "gid://shopify/Collection/591032593",
+              "title": "ABC Collection"
+            }
+          }
+        ]
+      }
+    }
+  }
+};

--- a/fixtures/shop-with-sorted-collections-fixture.js
+++ b/fixtures/shop-with-sorted-collections-fixture.js
@@ -8,10 +8,10 @@ export default {
         },
         "edges": [
           {
-            "cursor": "eyJsYXN0X2lkIjo0MTMwOTQ0NzIsImxhc3RfdmFsdWUiOiJUZXN0In0=",
+            "cursor": "eyJsYXN0X2lkIjozNjkzMTI1ODQsImxhc3RfdmFsDs1iOiJDYXQgQ29sbGVjdGiJ9",
             "node": {
-              "id": "gid://shopify/Collection/413094472",
-              "title": "Test Collection"
+              "id": "gid://shopify/Collection/591032593",
+              "title": "ABC Collection"
             }
           },
           {
@@ -22,10 +22,10 @@ export default {
             }
           },
           {
-            "cursor": "eyJsYXN0X2lkIjozNjkzMTI1ODQsImxhc3RfdmFsDs1iOiJDYXQgQ29sbGVjdGiJ9",
+            "cursor": "eyJsYXN0X2lkIjo0MTMwOTQ0NzIsImxhc3RfdmFsdWUiOiJUZXN0In0=",
             "node": {
-              "id": "gid://shopify/Collection/591032593",
-              "title": "ABC Collection"
+              "id": "gid://shopify/Collection/413094472",
+              "title": "Test Collection"
             }
           }
         ]

--- a/fixtures/shop-with-sorted-products-fixture.js
+++ b/fixtures/shop-with-sorted-products-fixture.js
@@ -1,0 +1,35 @@
+export default {
+  "data": {
+    "shop": {
+      "products": {
+        "pageInfo": {
+          "hasNextPage": false,
+          "hasPreviousPage": false
+        },
+        "edges": [
+          {
+            "cursor": "eyJsYXN0X2lkIjo4NjMxNzQ5NTc2LCJsYXN0X3ZhbHVlIjoiMjAxNy0wMi0xNyAxOTo1ODowMCJ9",
+            "node": {
+              "id": "gid://shopify/Product/8631749576",
+              "updatedAt": "2017-02-17T19:58:00Z"
+            }
+          },
+          {
+            "cursor": "eyJsYXN0X2lkIjo4NTMwMDMzNTQ0LCJsYXN0X3ZhbHVlIjoiMjAxNy0wMi0xNyAxOTo1NjozMyJ9",
+            "node": {
+              "id": "gid://shopify/Product/8530033544",
+              "updatedAt": "2017-02-17T19:56:33Z"
+            }
+          },
+          {
+            "cursor": "eyJsYXN0X2lkIjo3ODU3OTg5Mzg0LCJsYXN0X3ZhbHVlIjoiMjAxNy0wMi0xNyAxOTo1NjowMiJ9",
+            "node": {
+              "id": "gid://shopify/Product/7857989384",
+              "updatedAt": "2017-02-17T19:56:02Z"
+            }
+          }
+        ]
+      }
+    }
+  }
+};

--- a/src/client.js
+++ b/src/client.js
@@ -187,6 +187,35 @@ export default class Client {
     if (queryObject.limit) {
       options.first = queryObject.limit;
     }
+    if (queryObject.sortBy) {
+      let sortKey;
+
+      switch (queryObject.sortBy) {
+        case 'title-ascending':
+          sortKey = this.graphQLClient.enum('TITLE');
+          break;
+        case 'title-descending':
+          sortKey = this.graphQLClient.enum('TITLE');
+          options.reverse = true;
+          break;
+        case 'updated-ascending':
+          sortKey = this.graphQLClient.enum('UPDATED_AT');
+          break;
+        case 'updated-descending':
+          sortKey = this.graphQLClient.enum('UPDATED_AT');
+          options.reverse = true;
+          break;
+        case 'created-ascending':
+          sortKey = this.graphQLClient.enum('CREATED_AT');
+          break;
+        case 'created-descending':
+          sortKey = this.graphQLClient.enum('CREATED_AT');
+          options.reverse = true;
+          break;
+      }
+
+      options.sortKey = sortKey;
+    }
 
     options.query = queryArgStrings.join(' ');
 
@@ -228,6 +257,28 @@ export default class Client {
     }
     if (queryObject.limit) {
       options.first = queryObject.limit;
+    }
+    if (queryObject.sortBy) {
+      let sortKey;
+
+      switch (queryObject.sortBy) {
+        case 'title-ascending':
+          sortKey = this.graphQLClient.enum('TITLE');
+          break;
+        case 'title-descending':
+          sortKey = this.graphQLClient.enum('TITLE');
+          options.reverse = true;
+          break;
+        case 'updated-ascending':
+          sortKey = this.graphQLClient.enum('UPDATED_AT');
+          break;
+        case 'updated-descending':
+          sortKey = this.graphQLClient.enum('UPDATED_AT');
+          options.reverse = true;
+          break;
+      }
+
+      options.sortKey = sortKey;
     }
 
     options.query = queryArgStrings.join(' ');

--- a/src/client.js
+++ b/src/client.js
@@ -168,6 +168,81 @@ export default class Client {
     });
   }
 
+  fetchQueryProducts(queryObject = {}, query = productConnectionQuery()) {
+    const queryArgStrings = [];
+    const options = {};
+
+    if (queryObject.title) {
+      queryArgStrings.push(`title:'${queryObject.title}'`);
+    }
+    if (queryObject.updatedAtMin) {
+      queryArgStrings.push(`updated_at:>='${queryObject.updatedAtMin}'`);
+    }
+    if (queryObject.createdAtMin) {
+      queryArgStrings.push(`created_at:>='${queryObject.createdAtMin}'`);
+    }
+    if (queryObject.productType) {
+      queryArgStrings.push(`product_type:'${queryObject.productType}'`);
+    }
+    if (queryObject.limit) {
+      options.first = queryObject.limit;
+    }
+
+    options.query = queryArgStrings.join(' ');
+
+    const rootQuery = this.graphQLClient.query((root) => {
+      root.add('shop', (shop) => {
+        query(shop, 'products', options);
+      });
+    });
+
+    return this.graphQLClient.send(rootQuery).then(({model}) => {
+      const promises = model.shop.products.reduce((promiseAcc, product) => {
+        // Fetch the rest of the images and variants for this product
+        promiseAcc.push(this.graphQLClient.fetchAllPages(product.images, {pageSize: 250}).then((images) => {
+          product.attrs.images = images;
+        }));
+
+        promiseAcc.push(this.graphQLClient.fetchAllPages(product.variants, {pageSize: 250}).then((variants) => {
+          product.attrs.variants = variants;
+        }));
+
+        return promiseAcc;
+      }, []);
+
+      return Promise.all(promises).then(() => {
+        return model.shop.products;
+      });
+    });
+  }
+
+  fetchQueryCollections(queryObject = {}, query = collectionConnectionQuery()) {
+    const queryArgStrings = [];
+    const options = {};
+
+    if (queryObject.title) {
+      queryArgStrings.push(`title:'${queryObject.title}'`);
+    }
+    if (queryObject.updatedAtMin) {
+      queryArgStrings.push(`updated_at:>='${queryObject.updatedAtMin}'`);
+    }
+    if (queryObject.limit) {
+      options.first = queryObject.limit;
+    }
+
+    options.query = queryArgStrings.join(' ');
+
+    const rootQuery = this.graphQLClient.query((root) => {
+      root.add('shop', (shop) => {
+        query(shop, 'collections', options);
+      });
+    });
+
+    return this.graphQLClient.send(rootQuery).then((response) => {
+      return response.model.shop.collections;
+    });
+  }
+
   /**
    * Creates a checkout.
    *

--- a/src/client.js
+++ b/src/client.js
@@ -191,30 +191,21 @@ export default class Client {
       let sortKey;
 
       switch (queryObject.sortBy) {
-        case 'title-ascending':
+        case 'title':
           sortKey = this.graphQLClient.enum('TITLE');
           break;
-        case 'title-descending':
-          sortKey = this.graphQLClient.enum('TITLE');
-          options.reverse = true;
-          break;
-        case 'updated-ascending':
+        case 'updatedAt':
           sortKey = this.graphQLClient.enum('UPDATED_AT');
           break;
-        case 'updated-descending':
-          sortKey = this.graphQLClient.enum('UPDATED_AT');
-          options.reverse = true;
-          break;
-        case 'created-ascending':
+        case 'createdAt':
           sortKey = this.graphQLClient.enum('CREATED_AT');
-          break;
-        case 'created-descending':
-          sortKey = this.graphQLClient.enum('CREATED_AT');
-          options.reverse = true;
           break;
       }
 
       options.sortKey = sortKey;
+    }
+    if (queryObject.sortDirection === 'desc') {
+      options.reverse = true;
     }
 
     options.query = queryArgStrings.join(' ');
@@ -262,23 +253,18 @@ export default class Client {
       let sortKey;
 
       switch (queryObject.sortBy) {
-        case 'title-ascending':
+        case 'title':
           sortKey = this.graphQLClient.enum('TITLE');
           break;
-        case 'title-descending':
-          sortKey = this.graphQLClient.enum('TITLE');
-          options.reverse = true;
-          break;
-        case 'updated-ascending':
+        case 'updatedAt':
           sortKey = this.graphQLClient.enum('UPDATED_AT');
-          break;
-        case 'updated-descending':
-          sortKey = this.graphQLClient.enum('UPDATED_AT');
-          options.reverse = true;
           break;
       }
 
       options.sortKey = sortKey;
+    }
+    if (queryObject.sortDirection === 'desc') {
+      options.reverse = true;
     }
 
     options.query = queryArgStrings.join(' ');

--- a/src/collection-connection-query.js
+++ b/src/collection-connection-query.js
@@ -4,8 +4,8 @@ import addFields from './add-fields';
 const defaultFields = ['id', 'handle', 'updatedAt', 'title', ['image', imageQuery()]];
 
 export default function collectionConnectionQuery(fields = defaultFields) {
-  return function(parentSelection, fieldName) {
-    parentSelection.addConnection(fieldName, {args: {first: 20}}, (collections) => {
+  return function(parentSelection, fieldName, options) {
+    parentSelection.addConnection(fieldName, {args: Object.assign({first: 20}, options)}, (collections) => {
       addFields(collections, fields);
     });
   };

--- a/src/product-connection-query.js
+++ b/src/product-connection-query.js
@@ -21,8 +21,8 @@ const defaultFields = [
 ];
 
 export default function productConnectionQuery(fields = defaultFields) {
-  return function(parentSelection, fieldName) {
-    parentSelection.addConnection(fieldName, {args: {first: 20}}, (products) => {
+  return function(parentSelection, fieldName, options) {
+    parentSelection.addConnection(fieldName, {args: Object.assign({first: 20}, options)}, (products) => {
       addFields(products, fields);
     });
   };

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-unused-vars": ["error", { "varsIgnorePattern": "^_" }]
+  }
+}

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -382,6 +382,26 @@ suite('client-test', () => {
     fetchMock.postOnce('https://sorted-query.myshopify.com/api/graphql', shopWithSortedProductsFixture);
 
     return client.fetchQueryProducts({sortBy: 'updatedAt', sortDirection: 'desc'}, productConnectionQuery(['updatedAt'])).then((products) => {
+      const [_arg, {body}] = fetchMock.lastCall('https://sorted-query.myshopify.com/api/graphql');
+      const queryString = `query {
+        shop {
+          products (first: 20, sortKey: UPDATED_AT, reverse: true, query: "") {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+            }
+            edges {
+              cursor
+              node {
+                id
+                updatedAt
+              }
+            }
+          }
+        }
+      }`;
+
+      assert.deepEqual(tokens(JSON.parse(body).query), tokens(queryString));
       assert.equal(products.length, 3);
       assert.equal(products[0].updatedAt, shopWithSortedProductsFixture.data.shop.products.edges[0].node.updatedAt);
       assert.equal(products[1].updatedAt, shopWithSortedProductsFixture.data.shop.products.edges[1].node.updatedAt);
@@ -400,6 +420,26 @@ suite('client-test', () => {
     fetchMock.postOnce('https://sorted-query.myshopify.com/api/graphql', shopWithSortedCollectionsFixture);
 
     return client.fetchQueryCollections({sortBy: 'title'}, collectionConnectionQuery(['title'])).then((collections) => {
+      const [_arg, {body}] = fetchMock.lastCall('https://sorted-query.myshopify.com/api/graphql');
+      const queryString = `query {
+        shop {
+          collections (first: 20, sortKey: TITLE, query: "") {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+            }
+            edges {
+              cursor
+              node {
+                id
+                title
+              }
+            }
+          }
+        }
+      }`;
+
+      assert.deepEqual(tokens(JSON.parse(body).query), tokens(queryString));
       assert.equal(collections.length, 3);
       assert.equal(collections[0].title, shopWithSortedCollectionsFixture.data.shop.collections.edges[0].node.title);
       assert.equal(collections[1].title, shopWithSortedCollectionsFixture.data.shop.collections.edges[1].node.title);

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -16,6 +16,8 @@ import productWithPaginatedVariantsFixture from '../fixtures/product-with-pagina
 import {secondPageVariantsFixture, thirdPageVariantsFixture} from '../fixtures/paginated-variants-fixtures';
 import queryProductFixture from '../fixtures/query-product-fixture';
 import queryCollectionFixture from '../fixtures/query-collection-fixture';
+import shopWithSortedProductsFixture from '../fixtures/shop-with-sorted-products-fixture';
+import shopWithSortedCollectionsFixture from '../fixtures/shop-with-sorted-collections-fixture';
 import fetchMock from './isomorphic-fetch-mock'; // eslint-disable-line import/no-unresolved
 import productQuery from '../src/product-query';
 import imageQuery from '../src/image-query';
@@ -366,6 +368,42 @@ suite('client-test', () => {
       assert.equal(collections[0].title, queryCollectionFixture.data.shop.collections.edges[0].node.title);
       assert.equal(collections[0].updatedAt, queryCollectionFixture.data.shop.collections.edges[0].node.updatedAt);
       assert.ok(fetchMock.done());
+    });
+  });
+
+  test('it can return queried products sorted', () => {
+    const config = new Config({
+      domain: 'sorted-query.myshopify.com',
+      storefrontAccessToken: 'abc123'
+    });
+
+    const client = new Client(config);
+
+    fetchMock.postOnce('https://sorted-query.myshopify.com/api/graphql', shopWithSortedProductsFixture);
+
+    return client.fetchQueryProducts({sortBy: 'updated-descending'}, productConnectionQuery(['updatedAt'])).then((products) => {
+      assert.equal(products.length, 3);
+      assert.equal(products[0].updatedAt, shopWithSortedProductsFixture.data.shop.products.edges[0].node.updatedAt);
+      assert.equal(products[1].updatedAt, shopWithSortedProductsFixture.data.shop.products.edges[1].node.updatedAt);
+      assert.equal(products[2].updatedAt, shopWithSortedProductsFixture.data.shop.products.edges[2].node.updatedAt);
+    });
+  });
+
+  test('it can return queried collections sorted', () => {
+    const config = new Config({
+      domain: 'sorted-query.myshopify.com',
+      storefrontAccessToken: 'abc123'
+    });
+
+    const client = new Client(config);
+
+    fetchMock.postOnce('https://sorted-query.myshopify.com/api/graphql', shopWithSortedCollectionsFixture);
+
+    return client.fetchQueryCollections({sortBy: 'title-descending'}, collectionConnectionQuery(['title'])).then((collections) => {
+      assert.equal(collections.length, 3);
+      assert.equal(collections[0].title, shopWithSortedCollectionsFixture.data.shop.collections.edges[0].node.title);
+      assert.equal(collections[1].title, shopWithSortedCollectionsFixture.data.shop.collections.edges[1].node.title);
+      assert.equal(collections[2].title, shopWithSortedCollectionsFixture.data.shop.collections.edges[2].node.title);
     });
   });
 

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -20,6 +20,8 @@ import imageQuery from '../src/image-query';
 import imageConnectionQuery from '../src/image-connection-query';
 import optionQuery from '../src/option-query';
 import variantConnectionQuery from '../src/variant-connection-query';
+import productConnectionQuery from '../src/product-connection-query';
+import collectionConnectionQuery from '../src/collection-connection-query';
 import collectionQuery from '../src/collection-query';
 import checkoutFixture from '../fixtures/checkout-fixture';
 import checkoutWithPaginatedLineItemsFixture from '../fixtures/checkout-with-paginated-line-items-fixture';
@@ -269,6 +271,40 @@ suite('client-test', () => {
 
     return client.fetchProduct('7857989384', productQuery([['images', imageConnectionQuery()]])).then((product) => {
       assert.equal(product.images.length, 0);
+      assert.ok(fetchMock.done());
+    });
+  });
+
+  test('it can fetch products with the query arg', () => {
+    const config = new Config({
+      domain: 'query-products.myshopify.com',
+      storefrontAccessToken: 'abc123'
+    });
+
+    const client = new Client(config);
+
+    fetchMock.postOnce('https://query-products.myshopify.com/api/graphql', {data: {shop: {products: {edges: [{node: {title: 'Cat'}}], pageInfo: {hasNextPage: false, hasPreviousPage: false}}}}});
+
+    return client.fetchQueryProducts({title: 'Cat', limit: 10}, productConnectionQuery(['title'])).then((products) => {
+      assert.equal(products.length, 1);
+      assert.equal(products[0].title, 'Cat');
+      assert.ok(fetchMock.done());
+    });
+  });
+
+  test('it can fetch collections with the query arg', () => {
+    const config = new Config({
+      domain: 'query-collections.myshopify.com',
+      storefrontAccessToken: 'abc123'
+    });
+
+    const client = new Client(config);
+
+    fetchMock.postOnce('https://query-collections.myshopify.com/api/graphql', {data: {shop: {collections: {edges: [{node: {title: 'Cat Collection'}}], pageInfo: {hasNextPage: false, hasPreviousPage: false}}}}});
+
+    return client.fetchQueryCollections({title: 'Cat Collection', limit: 10}, collectionConnectionQuery(['title'])).then((collections) => {
+      assert.equal(collections.length, 1);
+      assert.equal(collections[0].title, 'Cat Collection');
       assert.ok(fetchMock.done());
     });
   });

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -381,7 +381,7 @@ suite('client-test', () => {
 
     fetchMock.postOnce('https://sorted-query.myshopify.com/api/graphql', shopWithSortedProductsFixture);
 
-    return client.fetchQueryProducts({sortBy: 'updated-descending'}, productConnectionQuery(['updatedAt'])).then((products) => {
+    return client.fetchQueryProducts({sortBy: 'updatedAt', sortDirection: 'desc'}, productConnectionQuery(['updatedAt'])).then((products) => {
       assert.equal(products.length, 3);
       assert.equal(products[0].updatedAt, shopWithSortedProductsFixture.data.shop.products.edges[0].node.updatedAt);
       assert.equal(products[1].updatedAt, shopWithSortedProductsFixture.data.shop.products.edges[1].node.updatedAt);
@@ -399,7 +399,7 @@ suite('client-test', () => {
 
     fetchMock.postOnce('https://sorted-query.myshopify.com/api/graphql', shopWithSortedCollectionsFixture);
 
-    return client.fetchQueryCollections({sortBy: 'title-descending'}, collectionConnectionQuery(['title'])).then((collections) => {
+    return client.fetchQueryCollections({sortBy: 'title'}, collectionConnectionQuery(['title'])).then((collections) => {
       assert.equal(collections.length, 3);
       assert.equal(collections[0].title, shopWithSortedCollectionsFixture.data.shop.collections.edges[0].node.title);
       assert.equal(collections[1].title, shopWithSortedCollectionsFixture.data.shop.collections.edges[1].node.title);

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -14,6 +14,8 @@ import productWithPaginatedImagesFixture from '../fixtures/product-with-paginate
 import {secondPageImagesFixture, thirdPageImagesFixture} from '../fixtures/paginated-images-fixtures';
 import productWithPaginatedVariantsFixture from '../fixtures/product-with-paginated-variants-fixture';
 import {secondPageVariantsFixture, thirdPageVariantsFixture} from '../fixtures/paginated-variants-fixtures';
+import queryProductFixture from '../fixtures/query-product-fixture';
+import queryCollectionFixture from '../fixtures/query-collection-fixture';
 import fetchMock from './isomorphic-fetch-mock'; // eslint-disable-line import/no-unresolved
 import productQuery from '../src/product-query';
 import imageQuery from '../src/image-query';
@@ -31,6 +33,12 @@ import shopInfoFixture from '../fixtures/shop-info-fixture';
 import shopPoliciesFixture from '../fixtures/shop-policies-fixture';
 
 suite('client-test', () => {
+  const querySplitter = /[\s,]+/;
+
+  function tokens(query) {
+    return query.split(querySplitter).filter((token) => Boolean(token));
+  }
+
   teardown(() => {
     fetchMock.restore();
   });
@@ -283,11 +291,39 @@ suite('client-test', () => {
 
     const client = new Client(config);
 
-    fetchMock.postOnce('https://query-products.myshopify.com/api/graphql', {data: {shop: {products: {edges: [{node: {title: 'Cat'}}], pageInfo: {hasNextPage: false, hasPreviousPage: false}}}}});
+    fetchMock.postOnce('https://query-products.myshopify.com/api/graphql', queryProductFixture);
 
-    return client.fetchQueryProducts({title: 'Cat', limit: 10}, productConnectionQuery(['title'])).then((products) => {
+    const query = {title: 'Cat', updatedAtMin: '2016-09-25T21:31:33', createdAtMin: '2016-09-25T21:31:33', productType: 'dog', limit: 10};
+
+    return client.fetchQueryProducts(query, productConnectionQuery(['updatedAt', 'createdAt', 'productType', 'title'])).then((products) => {
+      const [_arg, {body}] = fetchMock.lastCall('https://query-products.myshopify.com/api/graphql');
+      const queryString = `query {
+        shop {
+          products (first: 10 query: "title:'Cat' updated_at:>='2016-09-25T21:31:33' created_at:>='2016-09-25T21:31:33' product_type:'dog'") {
+            pageInfo {
+              hasNextPage,
+              hasPreviousPage
+            },
+            edges {
+              cursor,
+              node {
+                id,
+                updatedAt,
+                createdAt,
+                productType,
+                title
+              }
+            }
+          }
+        }
+      }`;
+
+      assert.deepEqual(tokens(JSON.parse(body).query), tokens(queryString));
       assert.equal(products.length, 1);
-      assert.equal(products[0].title, 'Cat');
+      assert.equal(products[0].title, queryProductFixture.data.shop.products.edges[0].node.title);
+      assert.equal(products[0].createdAt, queryProductFixture.data.shop.products.edges[0].node.createdAt);
+      assert.equal(products[0].updatedAt, queryProductFixture.data.shop.products.edges[0].node.updatedAt);
+      assert.equal(products[0].productType, queryProductFixture.data.shop.products.edges[0].node.productType);
       assert.ok(fetchMock.done());
     });
   });
@@ -300,11 +336,35 @@ suite('client-test', () => {
 
     const client = new Client(config);
 
-    fetchMock.postOnce('https://query-collections.myshopify.com/api/graphql', {data: {shop: {collections: {edges: [{node: {title: 'Cat Collection'}}], pageInfo: {hasNextPage: false, hasPreviousPage: false}}}}});
+    fetchMock.postOnce('https://query-collections.myshopify.com/api/graphql', queryCollectionFixture);
 
-    return client.fetchQueryCollections({title: 'Cat Collection', limit: 10}, collectionConnectionQuery(['title'])).then((collections) => {
+    const query = {title: 'Cat Collection', updatedAtMin: '2016-09-25T21:31:33', limit: 10};
+
+    return client.fetchQueryCollections(query, collectionConnectionQuery(['title', 'updatedAt'])).then((collections) => {
+      const [_arg, {body}] = fetchMock.lastCall('https://query-collections.myshopify.com/api/graphql');
+      const queryString = `query {
+        shop {
+          collections (first: 10 query: "title:'Cat Collection' updated_at:>='2016-09-25T21:31:33'") {
+            pageInfo {
+              hasNextPage,
+              hasPreviousPage
+            },
+            edges {
+              cursor,
+              node {
+                id,
+                title,
+                updatedAt
+              }
+            }
+          }
+        }
+      }`;
+
+      assert.deepEqual(tokens(JSON.parse(body).query), tokens(queryString));
       assert.equal(collections.length, 1);
-      assert.equal(collections[0].title, 'Cat Collection');
+      assert.equal(collections[0].title, queryCollectionFixture.data.shop.collections.edges[0].node.title);
+      assert.equal(collections[0].updatedAt, queryCollectionFixture.data.shop.collections.edges[0].node.updatedAt);
       assert.ok(fetchMock.done());
     });
   });


### PR DESCRIPTION
This PR adds `fetchQueryProducts` and `fetchQueryCollections` to loosely match the [REST versions](https://shopify.github.io/js-buy-sdk/api/classes/ShopClient.html#method-fetchQueryCollections). This acts as a layer over the `query` arg on products and collections so users can search by specific fields, like `title` and `updatedAt`.