### PR TITLE
[FIX] Don't paginate on empty sets

### DIFF
--- a/src-graphql/client.js
+++ b/src-graphql/client.js
@@ -24,11 +24,11 @@ function fetchAllProductResources(product, client) {
   const images = product.images;
   const variants = product.variants;
 
-  if (images && images[images.length - 1].hasNextPage.valueOf()) {
+  if (images && images.length && images[images.length - 1].hasNextPage.valueOf()) {
     promises.push(fetchAllPages(product.images, client));
   }
 
-  if (variants && variants[variants.length - 1].hasNextPage.valueOf()) {
+  if (variants && variants.length && variants[variants.length - 1].hasNextPage.valueOf()) {
     promises.push(fetchAllPages(product.variants, client));
   }
 

--- a/test-graphql/client-test.js
+++ b/test-graphql/client-test.js
@@ -250,4 +250,20 @@ suite('client-test', () => {
       assert.ok(fetchMock.done());
     });
   });
+
+  test('it does not fetch paginated images if the images query result was empty', () => {
+    const config = new Config({
+      domain: 'no-pagination.myshopify.com',
+      storefrontAccessToken: 'abc123'
+    });
+
+    const client = new Client(config);
+
+    fetchMock.postOnce('https://no-pagination.myshopify.com/api/graphql', {data: {node: {images: {edges: [], pageInfo: {hasNextPage: false, hasPreviousPage: false}}}}});
+
+    return client.fetchProduct('7857989384', productQuery([['images', imageConnectionQuery()]])).then((product) => {
+      assert.equal(product.images.length, 0);
+      assert.ok(fetchMock.done());
+    });
+  });
 });


### PR DESCRIPTION
If images or variants were empty, this would throw an error. Added a check to make sure we don't try to paginate on empty sets.