### PR TITLE
[FEATURE] Add Product helper to return variant based on options

### DIFF
--- a/fixtures/product-fixture.js
+++ b/fixtures/product-fixture.js
@@ -1,16 +1,19 @@
 export default {
   "data": {
     "node": {
+      "__typename": "Product",
       "id": "gid://shopify/Product/7857989384",
       "createdAt": "2016-09-25T21:31:33Z",
-      "updatedAt": "2017-01-16T15:42:21Z",
+      "updatedAt": "2017-03-14T18:12:08Z",
       "descriptionHtml": "send me this cat",
       "descriptionPlainSummary": "send me this cat",
       "handle": "cat",
-      "productType": "",
+      "productType": "cat",
       "title": "Cat",
       "vendor": "sendmecats",
-      "tags": [],
+      "tags": [
+        "vintage"
+      ],
       "publishedAt": "2016-09-25T21:29:00Z",
       "options": [
         {
@@ -20,6 +23,15 @@ export default {
             "Fluffy",
             "Extra Fluffy",
             "Mega Fluff"
+          ]
+        },
+        {
+          "id": "gid://shopify/ProductOption/10714078536",
+          "name": "Size",
+          "values": [
+            "Medium",
+            "Small",
+            "Large"
           ]
         }
       ],
@@ -33,15 +45,15 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
             "node": {
               "id": "gid://shopify/ProductImage/16306812680",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096",
-              "altText": null
+              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
+              "altText": "fettucine"
             }
           },
           {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
             "node": {
               "id": "gid://shopify/ProductImage/18217787592",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581332",
+              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
               "altText": null
             }
           },
@@ -49,7 +61,15 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc5MDY2NH0=",
             "node": {
               "id": "gid://shopify/ProductImage/18217790664",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1484581340",
+              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
+              "altText": null
+            }
+          },
+          {
+            "cursor": "eyJsYXN0X2lkIjoxOTYxNjczNjg0MH0=",
+            "node": {
+              "id": "gid://shopify/ProductImage/19616736840",
+              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
               "altText": null
             }
           }
@@ -65,7 +85,7 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNTk3Nn0=",
             "node": {
               "id": "gid://shopify/ProductVariant/25602235976",
-              "title": "Fluffy",
+              "title": "Fluffy / Medium",
               "price": "0.00",
               "weight": 18,
               "image": null,
@@ -73,6 +93,10 @@ export default {
                 {
                   "name": "Fur",
                   "value": "Fluffy"
+                },
+                {
+                  "name": "Size",
+                  "value": "Medium"
                 }
               ]
             }
@@ -81,7 +105,7 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNjA0MH0=",
             "node": {
               "id": "gid://shopify/ProductVariant/25602236040",
-              "title": "Extra Fluffy",
+              "title": "Extra Fluffy / Small",
               "price": "0.00",
               "weight": 18,
               "image": null,
@@ -89,6 +113,10 @@ export default {
                 {
                   "name": "Fur",
                   "value": "Extra Fluffy"
+                },
+                {
+                  "name": "Size",
+                  "value": "Small"
                 }
               ]
             }
@@ -97,7 +125,7 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNjEwNH0=",
             "node": {
               "id": "gid://shopify/ProductVariant/25602236104",
-              "title": "Mega Fluff",
+              "title": "Mega Fluff / Large",
               "price": "0.00",
               "weight": 0,
               "image": null,
@@ -105,6 +133,10 @@ export default {
                 {
                   "name": "Fur",
                   "value": "Mega Fluff"
+                },
+                {
+                  "name": "Size",
+                  "value": "Large"
                 }
               ]
             }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "@shopify/graphql-js-client": "0.3.0",
+    "@shopify/graphql-js-client": "0.3.2",
     "@shopify/graphql-js-schema": "0.2.3",
     "@shopify/graphql-js-schema-fetch": "1.1.0",
     "@shopify/rollup-plugin-remap": "0.0.3",

--- a/src-graphql/client.js
+++ b/src-graphql/client.js
@@ -6,6 +6,7 @@ import productQuery from './product-query';
 import productConnectionQuery from './product-connection-query';
 import collectionQuery from './collection-query';
 import collectionConnectionQuery from './collection-connection-query';
+import ProductHelpers from './product-helpers';
 
 function fetchAllPages(paginatedModels, client) {
   return client.fetchNextPage(paginatedModels).then(({model}) => {
@@ -48,6 +49,9 @@ export default class Client {
         }
       }
     });
+
+    this.Product = {};
+    this.Product.Helpers = new ProductHelpers();
   }
 
   fetchAllProducts(query = productConnectionQuery()) {

--- a/src-graphql/product-helpers.js
+++ b/src-graphql/product-helpers.js
@@ -1,17 +1,9 @@
 export default class ProductHelpers {
   variantForOptions(product, options) {
-    const [selectedVariant] = product.variants.reduce((variantAcc, variant) => {
-      const match = variant.selectedOptions.every((selectedOption) => {
+    return product.variants.find((variant) => {
+      return variant.selectedOptions.every((selectedOption) => {
         return options[selectedOption.name] === selectedOption.value.valueOf();
       });
-
-      if (match) {
-        variantAcc.push(variant);
-      }
-
-      return variantAcc;
-    }, []);
-
-    return selectedVariant;
+    });
   }
 }

--- a/src-graphql/product-helpers.js
+++ b/src-graphql/product-helpers.js
@@ -1,0 +1,17 @@
+export default class ProductHelpers {
+  variantForOptions(product, options) {
+    const [selectedVariant] = product.variants.reduce((variantAcc, variant) => {
+      const match = variant.selectedOptions.every((selectedOption) => {
+        return options[selectedOption.name] === selectedOption.value.valueOf();
+      });
+
+      if (match) {
+        variantAcc.push(variant);
+      }
+
+      return variantAcc;
+    }, []);
+
+    return selectedVariant;
+  }
+}

--- a/test-graphql/product-helpers-test.js
+++ b/test-graphql/product-helpers-test.js
@@ -1,0 +1,27 @@
+import assert from 'assert';
+import Config from '../src-graphql/config';
+import Client from '../src-graphql/client';
+import ProductHelpers from '../src-graphql/product-helpers';
+import singleProductFixture from '../fixtures/product-fixture';
+import fetchMock from './isomorphic-fetch-mock'; // eslint-disable-line import/no-unresolved
+
+suite('product-helpers-test', () => {
+  const productHelpers = new ProductHelpers();
+
+  test('it returns the variant based on options given', () => {
+    const config = new Config({
+      domain: 'single-product.myshopify.com',
+      storefrontAccessToken: 'abc123'
+    });
+
+    const client = new Client(config);
+
+    fetchMock.postOnce('https://single-product.myshopify.com/api/graphql', singleProductFixture);
+
+    return client.fetchProduct('7857989384').then((product) => {
+      const variant = productHelpers.variantForOptions(product, {Fur: 'Fluffy', Size: 'Medium'});
+
+      assert.equal(variant.id, 'gid://shopify/ProductVariant/25602235976');
+    });
+  });
+});

--- a/test-graphql/product-helpers-test.js
+++ b/test-graphql/product-helpers-test.js
@@ -7,21 +7,32 @@ import fetchMock from './isomorphic-fetch-mock'; // eslint-disable-line import/n
 
 suite('product-helpers-test', () => {
   const productHelpers = new ProductHelpers();
+  const config = new Config({
+    domain: 'single-product.myshopify.com',
+    storefrontAccessToken: 'abc123'
+  });
+
+  const client = new Client(config);
 
   test('it returns the variant based on options given', () => {
-    const config = new Config({
-      domain: 'single-product.myshopify.com',
-      storefrontAccessToken: 'abc123'
-    });
-
-    const client = new Client(config);
-
     fetchMock.postOnce('https://single-product.myshopify.com/api/graphql', singleProductFixture);
 
     return client.fetchProduct('7857989384').then((product) => {
       const variant = productHelpers.variantForOptions(product, {Fur: 'Fluffy', Size: 'Medium'});
 
       assert.equal(variant.id, 'gid://shopify/ProductVariant/25602235976');
+      assert.ok(fetchMock.done());
+    });
+  });
+
+  test('it returns undefined if the variant does not exist', () => {
+    fetchMock.postOnce('https://single-product.myshopify.com/api/graphql', singleProductFixture);
+
+    return client.fetchProduct('7857989384').then((product) => {
+      const variant = productHelpers.variantForOptions(product, {Fur: 'Fluffy', Size: 'Small'});
+
+      assert.equal(typeof variant, 'undefined');
+      assert.ok(fetchMock.done());
     });
   });
 });


### PR DESCRIPTION
This PR adds a Product helper to return the variant of a product based on the options selected. 
Usage:
```js
client.Product.Helpers.variantForOptions(product, {Fur: 'Fluffy', Size: 'Medium'});
```

I'll be adding `client.Checkout.Mutation` functions in a later PR following a similar structure.