### PR TITLE
[FIX] Move query root so collection and product connections can be nested

### DIFF
--- a/src-graphql/client.js
+++ b/src-graphql/client.js
@@ -51,7 +51,13 @@ export default class Client {
   }
 
   fetchAllProducts(query = productConnectionQuery()) {
-    return this.graphQLClient.send(query(this.graphQLClient)).then(({model}) => {
+    const rootQuery = this.graphQLClient.query((root) => {
+      root.add('shop', (shop) => {
+        query(shop, 'products');
+      });
+    });
+
+    return this.graphQLClient.send(rootQuery).then(({model}) => {
       const promises = model.shop.products.reduce((promiseAcc, product) => {
         // Fetch the rest of the images and variants for this product
         return promiseAcc.concat(fetchAllProductResources(product, this.graphQLClient));
@@ -64,7 +70,11 @@ export default class Client {
   }
 
   fetchProduct(id, query = productQuery()) {
-    return this.graphQLClient.send(query(this.graphQLClient, id)).then(({model}) => {
+    const rootQuery = this.graphQLClient.query((root) => {
+      query(root, 'node', id);
+    });
+
+    return this.graphQLClient.send(rootQuery).then(({model}) => {
       // Fetch the rest of the images and variants for this product
       const promises = fetchAllProductResources(model.node, this.graphQLClient);
 
@@ -75,13 +85,23 @@ export default class Client {
   }
 
   fetchAllCollections(query = collectionConnectionQuery()) {
-    return this.graphQLClient.send(query(this.graphQLClient)).then((response) => {
+    const rootQuery = this.graphQLClient.query((root) => {
+      root.add('shop', (shop) => {
+        query(shop, 'collections');
+      });
+    });
+
+    return this.graphQLClient.send(rootQuery).then((response) => {
       return response.model.shop.collections;
     });
   }
 
   fetchCollection(id, query = collectionQuery()) {
-    return this.graphQLClient.send(query(this.graphQLClient, id)).then((response) => {
+    const rootQuery = this.graphQLClient.query((root) => {
+      query(root, 'node', id);
+    });
+
+    return this.graphQLClient.send(rootQuery).then((response) => {
       return response.model.node;
     });
   }

--- a/src-graphql/collection-connection-query.js
+++ b/src-graphql/collection-connection-query.js
@@ -4,13 +4,9 @@ import addFields from './add-fields';
 const defaultFields = ['id', 'handle', 'updatedAt', 'title', ['image', imageQuery()]];
 
 export default function collectionConnectionQuery(fields = defaultFields) {
-  return function(client) {
-    return client.query((root) => {
-      root.add('shop', (shop) => {
-        shop.addConnection('collections', {args: {first: 20}}, (collections) => {
-          addFields(collections, fields);
-        });
-      });
+  return function(parentSelection, fieldName) {
+    parentSelection.addConnection(fieldName, {args: {first: 20}}, (collections) => {
+      addFields(collections, fields);
     });
   };
 }

--- a/src-graphql/collection-query.js
+++ b/src-graphql/collection-query.js
@@ -5,12 +5,10 @@ import addFields from './add-fields';
 const defaultFields = ['id', 'handle', 'updatedAt', 'title', ['image', imageQuery()]];
 
 export default function collectionQuery(fields = defaultFields) {
-  return function(client, id) {
-    return client.query((root) => {
-      root.add('node', {args: {id: createGid('Collection', id)}}, (node) => {
-        node.addInlineFragmentOn('Collection', (collection) => {
-          addFields(collection, fields);
-        });
+  return function(parentSelection, fieldName, id) {
+    parentSelection.add('node', {args: {id: createGid('Collection', id)}}, (node) => {
+      node.addInlineFragmentOn('Collection', (collection) => {
+        addFields(collection, fields);
       });
     });
   };

--- a/src-graphql/product-connection-query.js
+++ b/src-graphql/product-connection-query.js
@@ -7,13 +7,9 @@ const defaultFields = ['id', 'createdAt', 'updatedAt', 'descriptionHtml', 'descr
   'publishedAt', ['options', optionQuery()], ['images', imageConnectionQuery()], ['variants', variantConnectionQuery()]];
 
 export default function productConnectionQuery(fields = defaultFields) {
-  return function(client) {
-    return client.query((root) => {
-      root.add('shop', (shop) => {
-        shop.addConnection('products', {args: {first: 20}}, (products) => {
-          addFields(products, fields);
-        });
-      });
+  return function(parentSelection, fieldName) {
+    parentSelection.addConnection(fieldName, {args: {first: 20}}, (products) => {
+      addFields(products, fields);
     });
   };
 }

--- a/src-graphql/product-query.js
+++ b/src-graphql/product-query.js
@@ -8,12 +8,10 @@ const defaultFields = ['id', 'createdAt', 'updatedAt', 'descriptionHtml', 'descr
   'publishedAt', ['options', optionQuery()], ['images', imageConnectionQuery()], ['variants', variantConnectionQuery()]];
 
 export default function productQuery(fields = defaultFields) {
-  return function(client, id) {
-    return client.query((root) => {
-      root.add('node', {args: {id: createGid('Product', id)}}, (node) => {
-        node.addInlineFragmentOn('Product', (product) => {
-          addFields(product, fields);
-        });
+  return function(parentSelection, fieldName, id) {
+    parentSelection.add(fieldName, {args: {id: createGid('Product', id)}}, (node) => {
+      node.addInlineFragmentOn('Product', (product) => {
+        addFields(product, fields);
       });
     });
   };

--- a/test-graphql/query-test.js
+++ b/test-graphql/query-test.js
@@ -7,6 +7,7 @@ import variantConnectionQuery from '../src-graphql/variant-connection-query';
 import optionQuery from '../src-graphql/option-query';
 import imageQuery from '../src-graphql/image-query';
 import imageConnectionQuery from '../src-graphql/image-connection-query';
+import collectionQuery from '../src-graphql/collection-query';
 
 suite('query-test', () => {
   const querySplitter = /[\s,]+/;
@@ -23,7 +24,13 @@ suite('query-test', () => {
   const client = new Client(config);
 
   test('it creates product queries with defaults', () => {
-    const query = productConnectionQuery();
+    const defaultQuery = productConnectionQuery();
+    const query = client.graphQLClient.query((root) => {
+      root.add('shop', (shop) => {
+        defaultQuery(shop, 'products');
+      });
+    });
+
     const queryString = `query {
       shop {
         products (first: 20) {
@@ -89,11 +96,17 @@ suite('query-test', () => {
       }
     }`;
 
-    assert.deepEqual(tokens(query(client.graphQLClient).toString()), tokens(queryString));
+    assert.deepEqual(tokens(query.toString()), tokens(queryString));
   });
 
   test('it creates product queries with specified fields', () => {
-    const query = productConnectionQuery(['id', 'tags', 'vendor', ['images', imageConnectionQuery(['src'])], ['options', optionQuery(['name'])], ['variants', variantConnectionQuery(['id', 'title'])]]);
+    const customQuery = productConnectionQuery(['id', 'tags', 'vendor', ['images', imageConnectionQuery(['src'])], ['options', optionQuery(['name'])], ['variants', variantConnectionQuery(['id', 'title'])]]);
+    const query = client.graphQLClient.query((root) => {
+      root.add('shop', (shop) => {
+        customQuery(shop, 'products');
+      });
+    });
+
     const queryString = `query {
       shop {
         products (first: 20) {
@@ -142,11 +155,17 @@ suite('query-test', () => {
       }
     }`;
 
-    assert.deepEqual(tokens(query(client.graphQLClient).toString()), tokens(queryString));
+    assert.deepEqual(tokens(query.toString()), tokens(queryString));
   });
 
   test('it creates collection queries with defaults', () => {
-    const query = collectionConnectionQuery();
+    const defaultQuery = collectionConnectionQuery();
+    const query = client.graphQLClient.query((root) => {
+      root.add('shop', (shop) => {
+        defaultQuery(shop, 'collections');
+      });
+    });
+
     const queryString = `query {
       shop {
         collections (first: 20) {
@@ -172,11 +191,18 @@ suite('query-test', () => {
       }
     }`;
 
-    assert.deepEqual(tokens(query(client.graphQLClient).toString()), tokens(queryString));
+    assert.deepEqual(tokens(query.toString()), tokens(queryString));
   });
 
   test('it creates collection queries with specified fields', () => {
-    const query = collectionConnectionQuery(['handle', 'updatedAt', 'title', ['image', imageQuery(['id'])]]);
+    const customQuery = collectionConnectionQuery(['handle', 'updatedAt', 'title', ['image', imageQuery(['id'])]]);
+    const query = client.graphQLClient.query((root) => {
+      root.add('shop', (shop) => {
+        customQuery(shop, 'collections');
+      });
+    });
+
+
     const queryString = `query {
       shop {
         collections (first: 20) {
@@ -200,6 +226,82 @@ suite('query-test', () => {
       }
     }`;
 
-    assert.deepEqual(tokens(query(client.graphQLClient).toString()), tokens(queryString));
+    assert.deepEqual(tokens(query.toString()), tokens(queryString));
+  });
+
+  test('it can create a nested product connection query', () => {
+    const customQuery = collectionQuery([['products', productConnectionQuery()]]);
+    const query = client.graphQLClient.query((root) => {
+      customQuery(root, 'node', '1');
+    });
+
+    const queryString = `query {
+      node (id: "gid://shopify/Collection/1") {
+        __typename,
+        ... on Collection {
+          id,products (first: 20) {
+            pageInfo {
+              hasNextPage,hasPreviousPage
+            },
+            edges {
+              cursor,
+              node {
+                id,
+                createdAt,
+                updatedAt,
+                descriptionHtml,
+                descriptionPlainSummary,
+                handle,
+                productType,
+                title,
+                vendor,
+                tags,
+                publishedAt,
+                options {
+                  id,
+                  name,
+                  values
+                },
+                images (first: 250) {
+                  pageInfo {
+                    hasNextPage,
+                    hasPreviousPage
+                  },
+                  edges {
+                    cursor,
+                    node {
+                      id,
+                      src,
+                      altText
+                    }
+                  }
+                },
+                variants (first: 250) {
+                  pageInfo {
+                    hasNextPage,
+                    hasPreviousPage
+                  },
+                  edges {
+                    cursor,
+                    node {
+                      id,
+                      title,
+                      price,
+                      weight,
+                      selectedOptions {
+                        name,
+                        value
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }`;
+
+    assert.deepEqual(tokens(query.toString()), tokens(queryString));
   });
 });


### PR DESCRIPTION
This PR moves the root query builder outside of the product and collection connection queries so we can nest product connection queries (see last test in `query-test.js`).