### PR TITLE
Publish to npm via Shipit

### DIFF
--- a/shipit.yml
+++ b/shipit.yml
@@ -3,4 +3,5 @@ deploy:
     - npm install --no-progress
     - npm run build
     - ejson decrypt -o secrets.json secrets.ejson
+    - npm publish
     - scripts/deploy


### PR DESCRIPTION
Shipit actually has support for npm now since it auto runs `npm publish`. But since we override deploy, it wasn't being run.

This PR ensures that when a new version is published to npm, the CDN versions are also updated.

Two options where:

1. Remove our override and use the standard npm scripts `prepublish` and `postpublish`
2. Just add `npm publish` to our overridden deploy task

The last option seemed like the simplest option for now to still support local publishing without having to need EJSON.