### PR TITLE
Change classification to Library

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,4 +1,4 @@
 # https://services.shopify.io/services/js-buy-sdk/production
 director: stergios14
 owners: [minasmart, richgilbank]
-classification: tier2
+classification: library


### PR DESCRIPTION
Since this is a library and won't have an actual runtime (e.g. it doesn't need an oncall rotation, etc.), it is more accurately classified as such!

@minasmart @swalkinshaw 

cc @Shopify/operational-excellence 

<3