### PR TITLE
Switch from jsnext:main to module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0-alpha.2",
   "description": "The JS Buy SDK is a lightweight library that allows you to build ecommerce into any website. It is based on Shopify's API and provides the ability to retrieve products and collections from your shop, add products to a cart, and checkout.",
   "main": "index.js",
-  "jsnext:main": "index.es.js",
+  "module": "index.es.js",
   "repository": "git@github.com:Shopify/js-buy-sdk.git",
   "scripts": {
     "prepublish": "yarn run build",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "graphql-js-client": "0.4.2",
+    "graphql-js-client": "0.5.0",
     "graphql-js-schema": "0.5.0",
     "graphql-js-schema-fetch": "1.1.2",
     "rollup-plugin-remap": "0.0.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,8 +10,8 @@ const plugins = [
     targetPath: './optimized-types'
   }),
   nodeResolve({
-    jsnext: true,
-    main: true
+    main: true,
+    module: true
   }),
   babel()
 ];

--- a/scripts/rollup-tests.js
+++ b/scripts/rollup-tests.js
@@ -21,8 +21,8 @@ function envRollupInfo({browser, withDependencyTracking, withOptimizedTypes}) {
       ]
     }),
     nodeResolve({
-      jsnext: true,
       main: true,
+      module: true,
       preferBuiltins: !browser
     }),
     commonjs({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2511,9 +2511,9 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, 
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-graphql-js-client@0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/graphql-js-client/-/graphql-js-client-0.4.2.tgz#a5854df801a3447f7035bb0108b81322e324107f"
+graphql-js-client@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/graphql-js-client/-/graphql-js-client-0.5.0.tgz#791d7983619314dfb31995e5c31f0a78a434582b"
 
 graphql-js-schema-fetch@1.1.2:
   version "1.1.2"


### PR DESCRIPTION
`module` supersedes `jsnext:main`.

See https://github.com/rollup/rollup/wiki/pkg.module