### PR TITLE
[FEATURE] Update line items

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,33 +88,38 @@ client.fetchCollectionWithProducts('123456').then((collection) => {
 });
 ```
 
-### Creating, Adding and Removing Items from a Checkout
+### Creating, Adding, Updating, and Removing Items from a Checkout
 ```javascript
 // Create an empty checkout
 client.createCheckout().then((checkout) => {
-  const addLineItemsInput = {
-    checkoutId: checkout.id,
-    lineItems: [
-      {variantId: 'gid://shopify/ProductVariant/12345', quantity: 5}
-    ]
-  };
+  const checkoutId = checkout.id;
+  const lineItemsToAdd = [
+    {variantId: 'gid://shopify/ProductVariant/12345', quantity: 5}
+  ];
 
   // Add an item to the checkout
-  client.addLineItems(addLineItemsInput).then((checkoutWithAddedLineItems) => {
+  client.addLineItems(checkoutId, lineItemsToAdd).then((checkoutWithAddedLineItems) => {
     // Do something with the updated checkout
     console.log(checkoutWithAddedLineItems.lineItems); // Array with one line item
 
-    const removeLineItemsInput = {
-      checkoutId: checkoutWithAddedLineItems.id,
-      lineItemIds: [
-        checkoutWithAddedLineItems.lineItems[0].id
-      ]
-    };
+    const lineItemsToUpdate = [
+      {id: checkoutWithAddedLineItems.lineItems[0].id, quantity: 2}
+    ];
 
-    // Remove an item from the checkout
-    client.removeLineItems(removeLineItemsInput).then((checkoutWithRemovedLineItems) => {
+    // Update the line item on the checkout (change the quantity or variant)
+    client.updateLineItems(checkoutId, lineItemsToUpdate).then((checkoutWithUpdatedLineItems) => {
       // Do something with the updated checkout
-      console.log(checkoutWithRemovedLineItems.lineItems); // Empty array
+      console.log(checkoutWithUpdatedLineItems.lineItems); // Quantity of line item is now 2 instead of 5
+
+      const lineItemIdsToRemove = [
+        checkoutWithUpdatedLineItems.lineItems[0].id
+      ];
+
+      // Remove an item from the checkout
+      client.removeLineItems(checkoutId, lineItemIdsToRemove).then((checkoutWithRemovedLineItems) => {
+        // Do something with the updated checkout
+        console.log(checkoutWithRemovedLineItems.lineItems); // Empty array
+      });
     });
   });
 });

--- a/fixtures/checkout-line-items-update-fixture.js
+++ b/fixtures/checkout-line-items-update-fixture.js
@@ -1,0 +1,73 @@
+export default {
+   "data":{
+      "checkoutLineItemsUpdate":{
+         "userErrors":[
+
+         ],
+         "checkout":{
+            "id":"gid://shopify/Checkout/e28b55a3205f8d129a9b7223287ec95a?key=191add76e8eba90b93cfe4d5d261c4cb",
+            "ready":true,
+            "lineItems":{
+               "pageInfo":{
+                  "hasNextPage":false,
+                  "hasPreviousPage":false
+               },
+               "edges": [
+                  {
+                     "cursor":"eyJsYXN0X2lkIjoiZmI3MTEwMmYwZDM4ZGU0NmUwMzdiMzBmODE3ZTlkYjUifQ==",
+                     "node":{
+                        "id":"gid://shopify/CheckoutLineItem/fb71102f0d38de46e037b30f817e9db5?checkout=e28b55a3205f8d129a9b7223287ec95a",
+                        "title":"Arena Zip Boot",
+                        "variant":{
+                           "id":"gid://shopify/ProductVariant/36607672003",
+                           "title":"Black / 8",
+                           "price":"188.00",
+                           "weight":0,
+                           "image": {
+                              "id":"gid://shopify/ProductImage/21253957763",
+                              "src":"https://cdn.shopify.com/s/files/1/1312/0893/products/003_3e206539-20d3-49c0-8bff-006e449906ca.jpg?v=1491850970",
+                              "altText":null
+                           },
+                           "selectedOptions":[
+                              {
+                                 "name":"Color",
+                                 "value":"Black"
+                              },
+                              {
+                                 "name":"Size",
+                                 "value":"8"
+                              }
+                           ]
+                        },
+                        "quantity":2,
+                        "customAttributes":[
+
+                        ]
+                     }
+                  }
+               ]
+            },
+            "shippingAddress":null,
+            "shippingLine":null,
+            "requiresShipping":true,
+            "customAttributes":[
+
+            ],
+            "note":null,
+            "paymentDue":"376.00",
+            "webUrl":"https://checkout.shopify.com/13120893/checkouts/e28b55a3205f8d129a9b7223287ec95a?key=191add76e8eba90b93cfe4d5d261c4cb",
+            "order":null,
+            "orderStatusUrl":null,
+            "taxExempt":false,
+            "taxesIncluded":false,
+            "currencyCode":"CAD",
+            "totalTax":"0.00",
+            "subtotalPrice":"376.00",
+            "totalPrice":"376.00",
+            "completedAt":null,
+            "createdAt":"2017-04-13T21:54:16Z",
+            "updatedAt":"2017-04-13T21:54:17Z"
+         }
+      }
+   }
+};

--- a/profiled-types.json
+++ b/profiled-types.json
@@ -9,6 +9,7 @@
     "CheckoutLineItemEdge",
     "CheckoutLineItemsAddPayload",
     "CheckoutLineItemsRemovePayload",
+    "CheckoutLineItemsUpdatePayload",
     "Collection",
     "CollectionConnection",
     "CollectionEdge",

--- a/schema.json
+++ b/schema.json
@@ -2976,7 +2976,7 @@
                     "name": "OrderSortKeys",
                     "ofType": null
                   },
-                  "defaultValue": "\"ID\""
+                  "defaultValue": "ID"
                 },
                 {
                   "name": "reverse",
@@ -4948,7 +4948,7 @@
                     "name": "CollectionSortKeys",
                     "ofType": null
                   },
-                  "defaultValue": "\"ID\""
+                  "defaultValue": "ID"
                 },
                 {
                   "name": "reverse",
@@ -5107,7 +5107,7 @@
                     "name": "ProductSortKeys",
                     "ofType": null
                   },
-                  "defaultValue": "\"ID\""
+                  "defaultValue": "ID"
                 },
                 {
                   "name": "reverse",
@@ -5422,6 +5422,20 @@
               "description": "Updates the attributes of a checkout.",
               "args": [
                 {
+                  "name": "checkoutId",
+                  "description": "The ID of the checkout.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "input",
                   "description": null,
                   "type": {
@@ -5557,14 +5571,28 @@
               "description": "Associates a customer to the checkout.",
               "args": [
                 {
-                  "name": "input",
-                  "description": null,
+                  "name": "checkoutId",
+                  "description": "The ID of the checkout.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "CheckoutCustomerAssociateInput",
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "customerAccessToken",
+                  "description": "The customer access token of the customer to associate.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
                       "ofType": null
                     }
                   },
@@ -5584,14 +5612,14 @@
               "description": "Disassociates the current checkout customer from the checkout.",
               "args": [
                 {
-                  "name": "input",
-                  "description": null,
+                  "name": "checkoutId",
+                  "description": "The ID of the checkout.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "CheckoutCustomerDisassociateInput",
+                      "kind": "SCALAR",
+                      "name": "ID",
                       "ofType": null
                     }
                   },
@@ -5611,14 +5639,28 @@
               "description": "Updates the email on an existing checkout.",
               "args": [
                 {
-                  "name": "input",
-                  "description": null,
+                  "name": "checkoutId",
+                  "description": "The ID of the checkout.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "CheckoutEmailUpdateInput",
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "email",
+                  "description": "The email to update the checkout with.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
                       "ofType": null
                     }
                   },
@@ -5665,14 +5707,32 @@
               "description": null,
               "args": [
                 {
-                  "name": "input",
-                  "description": null,
+                  "name": "lineItems",
+                  "description": "A list of line item objects to add to the checkout.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "CheckoutLineItemInput",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "checkoutId",
+                  "description": "The ID of the checkout.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "CheckoutLineItemsAddInput",
+                      "kind": "SCALAR",
+                      "name": "ID",
                       "ofType": null
                     }
                   },
@@ -5692,15 +5752,37 @@
               "description": "Removes line items from an existing checkout",
               "args": [
                 {
-                  "name": "input",
-                  "description": null,
+                  "name": "checkoutId",
+                  "description": "the checkout on which to remove line items",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
                     "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "CheckoutLineItemsRemoveInput",
+                      "kind": "SCALAR",
+                      "name": "ID",
                       "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "lineItemIds",
+                  "description": "line item ids to remove",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "ID",
+                          "ofType": null
+                        }
+                      }
                     }
                   },
                   "defaultValue": null
@@ -6156,18 +6238,6 @@
               "deprecationReason": null
             },
             {
-              "name": "clientMutationId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Relay is moving away from requiring this field"
-            },
-            {
               "name": "userErrors",
               "description": null,
               "args": [],
@@ -6250,30 +6320,6 @@
           "description": "Specifies the fields required to update a checkout's attributes.\n",
           "fields": null,
           "inputFields": [
-            {
-              "name": "clientMutationId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "checkoutId",
-              "description": "The ID of the checkout.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
             {
               "name": "note",
               "description": "The text of an optional note that a shop owner can attach to the checkout.",
@@ -7370,18 +7416,6 @@
               "deprecationReason": null
             },
             {
-              "name": "clientMutationId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Relay is moving away from requiring this field"
-            },
-            {
               "name": "userErrors",
               "description": null,
               "args": [],
@@ -7417,16 +7451,6 @@
           "description": "Specifies the fields required to create a checkout.\n",
           "fields": null,
           "inputFields": [
-            {
-              "name": "clientMutationId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
             {
               "name": "email",
               "description": "The email with which the customer wants to checkout.",
@@ -7587,18 +7611,6 @@
               "deprecationReason": null
             },
             {
-              "name": "clientMutationId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Relay is moving away from requiring this field"
-            },
-            {
               "name": "userErrors",
               "description": null,
               "args": [],
@@ -7625,55 +7637,6 @@
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "CheckoutCustomerAssociateInput",
-          "description": "Specifies the fields required to associate a customer to a checkout.\n",
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "clientMutationId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "checkoutId",
-              "description": "The ID of the checkout.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "customerAccessToken",
-              "description": "The customer access token of the customer to associate.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -7699,18 +7662,6 @@
               "deprecationReason": null
             },
             {
-              "name": "clientMutationId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Relay is moving away from requiring this field"
-            },
-            {
               "name": "userErrors",
               "description": null,
               "args": [],
@@ -7737,41 +7688,6 @@
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "CheckoutCustomerDisassociateInput",
-          "description": "Specifies the fields required to disassociate the customer from a checkout.\n",
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "clientMutationId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "checkoutId",
-              "description": "The ID of the checkout.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -7797,18 +7713,6 @@
               "deprecationReason": null
             },
             {
-              "name": "clientMutationId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Relay is moving away from requiring this field"
-            },
-            {
               "name": "userErrors",
               "description": null,
               "args": [],
@@ -7835,55 +7739,6 @@
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "CheckoutEmailUpdateInput",
-          "description": "Specifies the fields required to update the email of a checkout.\n",
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "clientMutationId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "checkoutId",
-              "description": "The ID of the checkout.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "email",
-              "description": "The email to update the checkout with.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -8017,18 +7872,6 @@
               "deprecationReason": null
             },
             {
-              "name": "clientMutationId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Relay is moving away from requiring this field"
-            },
-            {
               "name": "userErrors",
               "description": null,
               "args": [],
@@ -8055,59 +7898,6 @@
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "CheckoutLineItemsAddInput",
-          "description": "Specifies the fields required to add line items to a checkout.\n",
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "clientMutationId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "lineItems",
-              "description": "A list of line item objects to add to the checkout.",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "CheckoutLineItemInput",
-                    "ofType": null
-                  }
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "checkoutId",
-              "description": "The ID of the checkout.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -8129,18 +7919,6 @@
               "deprecationReason": null
             },
             {
-              "name": "clientMutationId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Relay is moving away from requiring this field"
-            },
-            {
               "name": "userErrors",
               "description": null,
               "args": [],
@@ -8167,63 +7945,6 @@
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "CheckoutLineItemsRemoveInput",
-          "description": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "clientMutationId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "checkoutId",
-              "description": "the checkout on which to remove line items",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "lineItemIds",
-              "description": "line item ids to remove",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "ID",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },

--- a/schema.json
+++ b/schema.json
@@ -5554,7 +5554,7 @@
             },
             {
               "name": "checkoutCustomerAssociate",
-              "description": null,
+              "description": "Associates a customer to the checkout.",
               "args": [
                 {
                   "name": "input",
@@ -5581,7 +5581,7 @@
             },
             {
               "name": "checkoutCustomerDisassociate",
-              "description": null,
+              "description": "Disassociates the current checkout customer from the checkout.",
               "args": [
                 {
                   "name": "input",
@@ -5608,7 +5608,7 @@
             },
             {
               "name": "checkoutEmailUpdate",
-              "description": null,
+              "description": "Updates the email on an existing checkout.",
               "args": [
                 {
                   "name": "input",
@@ -5635,7 +5635,7 @@
             },
             {
               "name": "checkoutGiftCardApply",
-              "description": null,
+              "description": "Applies a gift card to an existing checkout using a gift card code.",
               "args": [
                 {
                   "name": "input",
@@ -5709,6 +5709,55 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "CheckoutLineItemsRemovePayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "checkoutLineItemsUpdate",
+              "description": "Update line items on a checkout",
+              "args": [
+                {
+                  "name": "checkoutId",
+                  "description": "the checkout on which to update line items",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "lineItems",
+                  "description": "line items to update",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "INPUT_OBJECT",
+                          "name": "CheckoutLineItemUpdateInput",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CheckoutLineItemsUpdatePayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -6198,7 +6247,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "CheckoutAttributesUpdateInput",
-          "description": null,
+          "description": "Specifies the fields required to update a checkout's attributes.\n",
           "fields": null,
           "inputFields": [
             {
@@ -6369,7 +6418,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "CheckoutCompleteFree",
-          "description": null,
+          "description": "Specifies the fields required to complete a free checkout.\n",
           "fields": null,
           "inputFields": [
             {
@@ -6894,7 +6943,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "CheckoutCompleteWithCreditCardInput",
-          "description": null,
+          "description": "Specifies the fields required to complete a checkout with\na Shopify vaulted credit card ID.\n",
           "fields": null,
           "inputFields": [
             {
@@ -7181,7 +7230,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "CheckoutCompleteWithTokenizedPaymentInput",
-          "description": null,
+          "description": "Specifies the fields required to complete a checkout with\na tokenized payment.\n",
           "fields": null,
           "inputFields": [
             {
@@ -7365,7 +7414,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "CheckoutCreateInput",
-          "description": null,
+          "description": "Specifies the fields required to create a checkout.\n",
           "fields": null,
           "inputFields": [
             {
@@ -7523,7 +7572,7 @@
           "fields": [
             {
               "name": "checkout",
-              "description": null,
+              "description": "The updated checkout object.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -7582,7 +7631,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "CheckoutCustomerAssociateInput",
-          "description": null,
+          "description": "Specifies the fields required to associate a customer to a checkout.\n",
           "fields": null,
           "inputFields": [
             {
@@ -7597,7 +7646,7 @@
             },
             {
               "name": "checkoutId",
-              "description": null,
+              "description": "The ID of the checkout.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -7611,7 +7660,7 @@
             },
             {
               "name": "customerAccessToken",
-              "description": null,
+              "description": "The customer access token of the customer to associate.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -7635,7 +7684,7 @@
           "fields": [
             {
               "name": "checkout",
-              "description": null,
+              "description": "The updated checkout object.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -7694,7 +7743,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "CheckoutCustomerDisassociateInput",
-          "description": null,
+          "description": "Specifies the fields required to disassociate the customer from a checkout.\n",
           "fields": null,
           "inputFields": [
             {
@@ -7709,7 +7758,7 @@
             },
             {
               "name": "checkoutId",
-              "description": null,
+              "description": "The ID of the checkout.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -7733,7 +7782,7 @@
           "fields": [
             {
               "name": "checkout",
-              "description": null,
+              "description": "The checkout object with the updated email.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -7792,7 +7841,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "CheckoutEmailUpdateInput",
-          "description": null,
+          "description": "Specifies the fields required to update the email of a checkout.\n",
           "fields": null,
           "inputFields": [
             {
@@ -7807,7 +7856,7 @@
             },
             {
               "name": "checkoutId",
-              "description": null,
+              "description": "The ID of the checkout.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -7821,7 +7870,7 @@
             },
             {
               "name": "email",
-              "description": null,
+              "description": "The email to update the checkout with.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -7845,7 +7894,7 @@
           "fields": [
             {
               "name": "checkout",
-              "description": null,
+              "description": "The updated checkout object.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -7904,7 +7953,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "CheckoutGiftCardApplyInput",
-          "description": null,
+          "description": "Specifies the fields required to apply a gift card to a checkout.\n",
           "fields": null,
           "inputFields": [
             {
@@ -7919,7 +7968,7 @@
             },
             {
               "name": "giftCardCode",
-              "description": null,
+              "description": "The code of the gift card to apply on the checkout.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -7933,7 +7982,7 @@
             },
             {
               "name": "checkoutId",
-              "description": null,
+              "description": "The ID of the checkout.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -8012,7 +8061,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "CheckoutLineItemsAddInput",
-          "description": null,
+          "description": "Specifies the fields required to add line items to a checkout.\n",
           "fields": null,
           "inputFields": [
             {
@@ -8180,12 +8229,118 @@
         },
         {
           "kind": "OBJECT",
-          "name": "CheckoutShippingAddressUpdatePayload",
+          "name": "CheckoutLineItemsUpdatePayload",
           "description": null,
           "fields": [
             {
               "name": "checkout",
               "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Checkout",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "userErrors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "UserError",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CheckoutLineItemUpdateInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "variantId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "quantity",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "customAttributes",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AttributeInput",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CheckoutShippingAddressUpdatePayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "checkout",
+              "description": "The updated checkout object.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -8244,7 +8399,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "CheckoutShippingAddressUpdateInput",
-          "description": null,
+          "description": "Specifies the input fields required to update the shipping address for a checkout.\n",
           "fields": null,
           "inputFields": [
             {
@@ -8259,7 +8414,7 @@
             },
             {
               "name": "shippingAddress",
-              "description": null,
+              "description": "The shipping address to where the line items will be shipped.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -8273,7 +8428,7 @@
             },
             {
               "name": "checkoutId",
-              "description": null,
+              "description": "The ID of the checkout.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -8297,7 +8452,7 @@
           "fields": [
             {
               "name": "checkout",
-              "description": null,
+              "description": "The updated checkout object.",
               "args": [],
               "type": {
                 "kind": "OBJECT",
@@ -8352,7 +8507,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "CheckoutShippingLineUpdateInput",
-          "description": null,
+          "description": "Specifies the fields required to update a Checkout’s shipping line.\n",
           "fields": null,
           "inputFields": [
             {
@@ -8367,7 +8522,7 @@
             },
             {
               "name": "checkoutId",
-              "description": null,
+              "description": "The ID of the checkout.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -8381,7 +8536,7 @@
             },
             {
               "name": "shippingRateHandle",
-              "description": null,
+              "description": "A concatenation of a Checkout’s shipping provider, price, and title, enabling the customer to select the availableShippingRates.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,

--- a/src/client.js
+++ b/src/client.js
@@ -33,7 +33,7 @@ const shopPolicies = [
 
 function checkoutMutation(type, input, query, client) {
   const mutation = client.mutation((root) => {
-    root.add(type, {args: {input}}, (checkoutMutationField) => {
+    root.add(type, {args: input}, (checkoutMutationField) => {
       checkoutMutationField.add('userErrors', (userErrors) => {
         userErrors.add('message');
         userErrors.add('field');
@@ -371,7 +371,7 @@ export default class Client {
    * @return {Promise|GraphModel} A promise resolving with the created checkout.
    */
   createCheckout(input = {}, query = checkoutQuery()) {
-    return checkoutMutation('checkoutCreate', input, query, this.graphQLClient);
+    return checkoutMutation('checkoutCreate', {input}, query, this.graphQLClient);
   }
 
   /**
@@ -385,14 +385,13 @@ export default class Client {
    *
    * @method addLineItems
    * @public
-   * @param {Object} input An input object containing:
-   *   @param {String} input.checkoutId The ID of the checkout to add line items to
-   *   @param {Array} [input.lineItems] A list of line items to add to the checkout
+   * @param {String} checkoutId The ID of the checkout to add line items to
+   * @param {Array} lineItems A list of line items to add to the checkout
    * @param {Function} [query] Callback function to specify fields to query on the checkout returned
    * @return {Promise|GraphModel} A promise resolving with the updated checkout.
    */
-  addLineItems(input, query = checkoutQuery()) {
-    return checkoutMutation('checkoutLineItemsAdd', input, query, this.graphQLClient);
+  addLineItems(checkoutId, lineItems, query = checkoutQuery()) {
+    return checkoutMutation('checkoutLineItemsAdd', {input: {checkoutId, lineItems}}, query, this.graphQLClient);
   }
 
   /**
@@ -406,13 +405,32 @@ export default class Client {
    *
    * @method removeLineItems
    * @public
-   * @param {Object} input An input object containing:
-   *   @param {String} input.checkoutId The ID of the checkout to remove line items from
-   *   @param {Array} input.lineItemIds A list of the ids of line items to remove from the checkout
+   * @param {String} checkoutId The ID of the checkout to remove line items from
+   * @param {Array} lineItemIds A list of the ids of line items to remove from the checkout
    * @param {Function} [query] Callback function to specify fields to query on the checkout returned
    * @return {Promise|GraphModel} A promise resolving with the updated checkout.
    */
-  removeLineItems(input, query = checkoutQuery()) {
-    return checkoutMutation('checkoutLineItemsRemove', input, query, this.graphQLClient);
+  removeLineItems(checkoutId, lineItemIds, query = checkoutQuery()) {
+    return checkoutMutation('checkoutLineItemsRemove', {input: {checkoutId, lineItemIds}}, query, this.graphQLClient);
+  }
+
+  /**
+   * Updates line items on an existing checkout.
+   *
+   * ```javascript
+   * client.updateLineItem({checkoutId: ..., lineItems:{ ... }}).then(checkout => {
+   *   // do something with the updated checkout
+   * });
+   * ```
+   *
+   * @method updateLineItems
+   * @public
+   * @param {String} checkoutId The ID of the checkout to update a line item on.=
+   * @param {Array} lineItems An array of line items to update
+   * @param {Function} [query] Callback function to specify fields to query on the checkout returned
+   * @return {Promise|GraphModel} A promise resolving with the updated checkout.
+   */
+  updateLineItems(checkoutId, lineItems, query = checkoutQuery()) {
+    return checkoutMutation('checkoutLineItemsUpdate', {checkoutId, lineItems}, query, this.graphQLClient);
   }
 }

--- a/src/client.js
+++ b/src/client.js
@@ -391,7 +391,7 @@ export default class Client {
    * @return {Promise|GraphModel} A promise resolving with the updated checkout.
    */
   addLineItems(checkoutId, lineItems, query = checkoutQuery()) {
-    return checkoutMutation('checkoutLineItemsAdd', {input: {checkoutId, lineItems}}, query, this.graphQLClient);
+    return checkoutMutation('checkoutLineItemsAdd', {checkoutId, lineItems}, query, this.graphQLClient);
   }
 
   /**
@@ -411,7 +411,7 @@ export default class Client {
    * @return {Promise|GraphModel} A promise resolving with the updated checkout.
    */
   removeLineItems(checkoutId, lineItemIds, query = checkoutQuery()) {
-    return checkoutMutation('checkoutLineItemsRemove', {input: {checkoutId, lineItemIds}}, query, this.graphQLClient);
+    return checkoutMutation('checkoutLineItemsRemove', {checkoutId, lineItemIds}, query, this.graphQLClient);
   }
 
   /**


### PR DESCRIPTION
This PR adds the update line item mutation. 
Also separates the single input field and updates to the new checkout mutations. This will require an update on the examples, but it should be quick.