### PR TITLE
Add X-SDK-Version and X-SDK-Variant headers

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,5 +15,11 @@
   ],
   "globals": {
     "fetch": true
+  },
+  "settings": {
+    "import/ignore": [
+      "node_modules",
+      ".json$"
+    ]
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,10 +1,12 @@
 /* eslint-env node */
 import {readFileSync} from 'fs';
 import babel from 'rollup-plugin-babel';
+import json from 'rollup-plugin-json';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import remap from 'rollup-plugin-remap';
 
 const plugins = [
+  json(),
   remap({
     originalPath: './types',
     targetPath: './optimized-types'

--- a/src/client.js
+++ b/src/client.js
@@ -21,6 +21,7 @@ import domainQuery from './domain-query';
 import shopPolicyQuery from './shop-policy-query';
 import ProductHelpers from './product-helpers';
 import ImageHelpers from './image-helpers';
+import {version} from '../package.json';
 
 export {default as Config} from './config';
 
@@ -83,6 +84,8 @@ export default class Client {
       url: apiUrl,
       fetcherOptions: {
         headers: {
+          'X-SDK-Variant': 'javascript',
+          'X-SDK-Version': version,
           'X-Shopify-Storefront-Access-Token': config.storefrontAccessToken
         }
       }

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -38,6 +38,7 @@ import shopWithCollectionsWithProductsFixture from '../fixtures/shop-with-collec
 import collectionWithProductsFixture from '../fixtures/collection-with-products-fixture';
 import shopWithCollectionsWithPaginationFixture from '../fixtures/shop-with-collections-with-pagination-fixture';
 import checkoutLineItemsUpdateFixture from '../fixtures/checkout-line-items-update-fixture';
+import {version} from '../package.json';
 
 suite('client-test', () => {
   const querySplitter = /[\s,]+/;
@@ -74,6 +75,8 @@ suite('client-test', () => {
     assert.equal(passedUrl, 'https://sendmecats.myshopify.com/api/graphql');
     assert.deepEqual(passedFetcherOptions, {
       headers: {
+        'X-SDK-Variant': 'javascript',
+        'X-SDK-Version': version,
         'X-Shopify-Storefront-Access-Token': config.storefrontAccessToken
       }
     });


### PR DESCRIPTION
These headers are required for tracking usage of our SDKs.

Note: v0.x also added the commit SHA to the version. I'm just skipping that for now in favour of the simplest implementation. If it really matters, we can add it back.