### PR TITLE
Static namespaces

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -19,8 +19,8 @@ import variantQuery from './variant-query';
 import shopQuery from './shop-query';
 import domainQuery from './domain-query';
 import shopPolicyQuery from './shop-policy-query';
-import ProductHelpers from './product-helpers';
-import ImageHelpers from './image-helpers';
+import productHelpers from './product-helpers';
+import imageHelpers from './image-helpers';
 import {version} from '../package.json';
 
 export {default as Config} from './config';
@@ -77,27 +77,20 @@ function fetchResourcesForProducts(products, client) {
  * @class Client
  */
 export default class Client {
-  constructor(config, GraphQLClientClass = GraphQLJSClient) {
-    const apiUrl = `https://${config.domain}/api/graphql`;
+  static get Product() {
+    return {
+      Helpers: productHelpers
+    };
+  }
 
-    this.graphQLClient = new GraphQLClientClass(types, {
-      url: apiUrl,
-      fetcherOptions: {
-        headers: {
-          'X-SDK-Variant': 'javascript',
-          'X-SDK-Version': version,
-          'X-Shopify-Storefront-Access-Token': config.storefrontAccessToken
-        }
-      }
-    });
+  static get Image() {
+    return {
+      Helpers: imageHelpers
+    };
+  }
 
-    this.Product = {};
-    this.Product.Helpers = new ProductHelpers();
-
-    this.Image = {};
-    this.Image.Helpers = new ImageHelpers();
-
-    this.Queries = {
+  static get Queries() {
+    return {
       productNodeQuery,
       productConnectionQuery,
       collectionNodeQuery,
@@ -119,6 +112,21 @@ export default class Client {
       shopPolicyQuery,
       checkoutNodeQuery
     };
+  }
+
+  constructor(config, GraphQLClientClass = GraphQLJSClient) {
+    const apiUrl = `https://${config.domain}/api/graphql`;
+
+    this.graphQLClient = new GraphQLClientClass(types, {
+      url: apiUrl,
+      fetcherOptions: {
+        headers: {
+          'X-SDK-Variant': 'javascript',
+          'X-SDK-Version': version,
+          'X-Shopify-Storefront-Access-Token': config.storefrontAccessToken
+        }
+      }
+    });
   }
 
   fetchShopInfo(query = shopQuery()) {

--- a/src/image-helpers.js
+++ b/src/image-helpers.js
@@ -1,7 +1,7 @@
 /**
  * @class ImageHelpers
  */
-export default class ImageHelpers {
+export default {
 
   /**
    * Generates the image src for a resized image with maximum dimensions `maxWidth` and `maxHeight`.
@@ -27,4 +27,4 @@ export default class ImageHelpers {
 
     return `${imageTokens.join('.')}?${query}`;
   }
-}
+};

--- a/src/product-helpers.js
+++ b/src/product-helpers.js
@@ -1,4 +1,4 @@
-export default class ProductHelpers {
+export default {
   variantForOptions(product, options) {
     return product.variants.find((variant) => {
       return variant.selectedOptions.every((selectedOption) => {
@@ -6,4 +6,4 @@ export default class ProductHelpers {
       });
     });
   }
-}
+};

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -748,4 +748,10 @@ suite('client-test', () => {
       assert.equal(checkout.lineItems[0].variant.id, 'gid://shopify/ProductVariant/36607672003');
     });
   });
+
+  test('it has static helpers', () => {
+    assert.ok(Client.Product.Helpers);
+    assert.ok(Client.Image.Helpers);
+    assert.ok(Client.Queries);
+  });
 });

--- a/test/image-helpers-test.js
+++ b/test/image-helpers-test.js
@@ -1,9 +1,7 @@
 import assert from 'assert';
-import ImageHelpers from '../src/image-helpers';
+import imageHelpers from '../src/image-helpers';
 
 suite('image-helpers-test', () => {
-  const imageHelpers = new ImageHelpers();
-
   test('it returns the image src with the specified width and height', () => {
     const resizedImageSrc = imageHelpers.imageForSize({src: 'https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038'}, {maxWidth: 30, maxHeight: 30});
 

--- a/test/product-helpers-test.js
+++ b/test/product-helpers-test.js
@@ -1,12 +1,11 @@
 import assert from 'assert';
 import GraphQLJSClient, {decode} from 'graphql-js-client';
 import productNodeQuery from '../src/product-node-query';
-import ProductHelpers from '../src/product-helpers';
+import productHelpers from '../src/product-helpers';
 import singleProductFixture from '../fixtures/product-fixture';
 import types from '../types';
 
 suite('product-helpers-test', () => {
-  const productHelpers = new ProductHelpers();
   const query = productNodeQuery();
   const graphQLClient = new GraphQLJSClient(types, {url: 'https://sendmecats.myshopify.com/api/graphql'});
   const rootQuery = graphQLClient.query((root) => {


### PR DESCRIPTION
Namespaces should be static instead of tied to an instance of `Client`. 
Examples that use any of the helper methods will need to update `client.Product.Helpers.variantForOptions` to `Client.Product.Helpers.variantForOptions`.