### PR TITLE
Add description as a default field to collection

### DIFF
--- a/src/collection-node-query.js
+++ b/src/collection-node-query.js
@@ -1,7 +1,7 @@
 import imageQuery from './image-query';
 import nodeQuery from './node-query';
 
-export const defaultFields = ['id', 'handle', 'updatedAt', 'title', ['image', imageQuery()]];
+export const defaultFields = ['id', 'handle', 'description', 'descriptionHtml', 'updatedAt', 'title', ['image', imageQuery()]];
 
 export default function collectionNodeQuery(fields = defaultFields) {
   return nodeQuery('Collection', fields);

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -191,6 +191,8 @@ suite('query-test', () => {
             node {
               id,
               handle,
+              description,
+              descriptionHtml,
               updatedAt,
               title,
               image {


### PR DESCRIPTION
`Collection` queries should provide `description` and `descriptionHtml` as default query fields like `Product` queries do since they'll probably be commonly used. Nothing should be affected by this.