### PR TITLE
Opaque IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ client.fetchCollectionWithProducts('123456').then((collection) => {
 client.createCheckout().then((checkout) => {
   const checkoutId = checkout.id;
   const lineItemsToAdd = [
-    {variantId: 'gid://shopify/ProductVariant/12345', quantity: 5}
+    {variantId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjAyMjc5Mg==', quantity: 5}
   ];
 
   // Add an item to the checkout

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -295,7 +295,7 @@ Creates a checkout.
 ```js
 const input = {
   lineItems: [
-    {variantId: 'gid://shopify/ProductVariant/2', quantity: 5}
+    {variantId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjAyMjc5Mg==', quantity: 5}
   ]
 };
 
@@ -319,8 +319,8 @@ Adds line items to an existing checkout.
 
 **Example**  
 ```js
-const checkoutId = 'gid://shopify/Checkout/abc123';
-const lineItems = [{variantId: 'gid://shopify/ProductVariant/2', quantity: 5}];
+const checkoutId = 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9kMTZmM2EzMDM4Yjc4N';
+const lineItems = [{variantId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjAyMjc5Mg==', quantity: 5}];
 
 client.addLineItems(checkoutId, lineItems).then((checkout) => {
   // Do something with the updated checkout
@@ -342,8 +342,8 @@ Removes line items from an existing checkout.
 
 **Example**  
 ```js
-const checkoutId = 'gid://shopify/Checkout/abc123';
-const lineItemIds = ['gid://shopify/CheckoutLineItem/def456'];
+const checkoutId = 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9kMTZmM2EzMDM4Yjc4N=';
+const lineItemIds = ['TViZGE5Y2U1ZDFhY2FiMmM2YT9rZXk9NTc2YjBhODcwNWIxYzg0YjE5ZjRmZGQ5NjczNGVkZGU='];
 
 client.removeLineItems(checkoutId, lineItemIds).then((checkout) => {
   // Do something with the updated checkout
@@ -365,12 +365,12 @@ Updates line items on an existing checkout.
 
 **Example**  
 ```js
-const checkoutId = 'gid://shopify/Checkout/abc123';
+const checkoutId = 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9kMTZmM2EzMDM4Yjc4N=';
 const lineItems = [
   {
-    id: 'gid://shopify/CheckoutLineItem/def456',
+    id: 'TViZGE5Y2U1ZDFhY2FiMmM2YT9rZXk9NTc2YjBhODcwNWIxYzg0YjE5ZjRmZGQ5NjczNGVkZGU=',
     quantity: 5,
-    variantId: 'gid://shopify/ProductVariant/2'
+    variantId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjAyMjc5Mg=='
   }
 ];
 

--- a/fixtures/checkout-create-with-paginated-line-items-fixture.js
+++ b/fixtures/checkout-create-with-paginated-line-items-fixture.js
@@ -7,7 +7,7 @@ export default {
         "ready": true,
         "lineItems": {
           "pageInfo": {
-            "hasNextPage": false,
+            "hasNextPage": true,
             "hasPreviousPage": false
           },
           "edges": [
@@ -16,7 +16,7 @@ export default {
               "node": {
                 "title": "Intelligent Granite Table",
                 "variant": {
-                  "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
+                  "id": "gid://shopify/ProductVariant/1",
                   "title": "Awesome Copper Bench",
                   "price": "64.99",
                   "weight": 4.5,
@@ -34,36 +34,14 @@ export default {
             }
           ]
         },
-        "shippingAddress": {
-          "address1": "123 Cat Road",
-          "address2": null,
-          "city": "Cat Land",
-          "company": "Catmart",
-          "country": "Canada",
-          "firstName": "Meow",
-          "formatted": [
-            "Catmart",
-            "123 Cat Road",
-            "Cat Land ON M3O 0W1",
-            "Canada"
-          ],
-          "lastName": "Meowington",
-          "latitude": null,
-          "longitude": null,
-          "phone": "4161234566",
-          "province": "Ontario",
-          "zip": "M3O 0W1",
-          "name": "Meow Meowington",
-          "countryCode": "CA",
-          "provinceCode": "ON",
-          "id": "Z2lkOi8vc2hvcGlmeS9QcmdfnAU8nakdWMnAbh890hyOTEwNjA2NDU4NA=="
-        },
+        "shippingAddress": null,
         "shippingLine": null,
         "requiresShipping": true,
         "customAttributes": [],
         "note": null,
         "paymentDue": "367.19",
         "webUrl": "https://checkout.myshopify.io/1/checkouts/c4abf4bf036239ab5e3d0bf93c642c96",
+        "order": null,
         "orderStatusUrl": null,
         "taxExempt": false,
         "taxesIncluded": false,

--- a/fixtures/checkout-fixture.js
+++ b/fixtures/checkout-fixture.js
@@ -2,7 +2,7 @@ export default {
   "data": {
     "node": {
       "__typename": "Checkout",
-      "id": "gid://shopify/Checkout/df400853e4dcf6732995195d50f999b1?key=da88309409dfc67d5957752a4c313dba",
+      "id": "Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",
       "ready": true,
       "lineItems": {
         "pageInfo": {

--- a/fixtures/checkout-line-items-add-fixture.js
+++ b/fixtures/checkout-line-items-add-fixture.js
@@ -3,7 +3,7 @@ export default {
     "checkoutLineItemsAdd": {
       "userErrors": [],
       "checkout": {
-        "id": "gid://shopify/Checkout/89427726abd2543894550baae32065d6",
+        "id": "Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",
         "createdAt": "2017-03-17T16:00:40Z",
         "updatedAt": "2017-03-17T16:00:40Z",
         "requiresShipping": true,
@@ -30,7 +30,7 @@ export default {
           "name": "Meow Meowington",
           "countryCode": "CA",
           "provinceCode": "ON",
-          "id": "gid://shopify/MailingAddress/1?model_name=Address"
+          "id": "291dC9lM2JkNzHJnnf8a89njNJNKAhu1gn7lMzM5MzFlZj9rZXk9NDcwOTJ=="
         },
         "lineItems": {
           "pageInfo": {
@@ -43,7 +43,7 @@ export default {
               "node": {
                 "title": "Intelligent Granite Table",
                 "variant": {
-                  "id": "gid://shopify/ProductVariant/1"
+                  "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA=="
                 },
                 "quantity": 5,
                 "customAttributes": []
@@ -54,7 +54,7 @@ export default {
               "node": {
                 "title": "Intelligent Marble Table",
                 "variant": {
-                  "id": "gid://shopify/ProductVariant/2"
+                  "id": "ZNc0vnIOijnJabh4873nNQnfb9B0QhnFyvk9Wfh87oNBeqBHGQNA5a=="
                 },
                 "quantity": 5,
                 "customAttributes": []
@@ -65,7 +65,7 @@ export default {
               "node": {
                 "title": "Intelligent Wooden Table",
                 "variant": {
-                  "id": "gid://shopify/ProductVariant/3"
+                  "id": "Zad7JHnbf32JHna087juBQn8faB84Ba28VnqjF87Qynaw8MnDhNA3W=="
                 },
                 "quantity": 5,
                 "customAttributes": []

--- a/fixtures/checkout-line-items-remove-fixture.js
+++ b/fixtures/checkout-line-items-remove-fixture.js
@@ -3,37 +3,14 @@ export default {
     "checkoutLineItemsRemove": {
       "userErrors": [],
       "checkout": {
-        "id": "gid://shopify/Checkout/89427726abd2543894550baae32065d6",
+        "id": "Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",
         "ready": true,
         "lineItems": {
           "pageInfo": {
             "hasNextPage": false,
             "hasPreviousPage": false
           },
-          "edges": [
-            {
-              "cursor": "eyJsYXN0X2lkIjoiZDUyZWU5ZTEwYmQxMWE0NDlkNmQzMWNkMzBhMGFjNzMifQ==",
-              "node": {
-                "id": "gid://shopify/CheckoutLineItem/04f4964352dd74ga101e36dfa8m22d73094?checkout=dcf154c3feb78e585b9e88571cc383fa",
-                "title": "Intelligent Granite Table",
-                "variant": {
-                  "id": "gid://shopify/ProductVariant/1",
-                  "title": "Awesome Copper Bench",
-                  "price": "64.99",
-                  "weight": 4.5,
-                  "image": null,
-                  "selectedOptions": [
-                    {
-                      "name": "Color or something",
-                      "value": "Awesome Copper Bench"
-                    }
-                  ]
-                },
-                "quantity": 5,
-                "customAttributes": []
-              }
-            }
-          ]
+          "edges": []
         },
         "shippingAddress": {
           "address1": "123 Cat Road",
@@ -57,7 +34,7 @@ export default {
           "name": "Meow Meowington",
           "countryCode": "CA",
           "provinceCode": "ON",
-          "id": "gid://shopify/MailingAddress/12?model_name=Address"
+          "id": "Z2lkOi8vc2hvcGlmeSsiujh8aQJbnkl9Qcm9kdWN0VmaJKN8flqAnq8TEwNjA2NDU4NA=="
         },
         "shippingLine": null,
         "requiresShipping": true,

--- a/fixtures/checkout-line-items-update-fixture.js
+++ b/fixtures/checkout-line-items-update-fixture.js
@@ -5,7 +5,7 @@ export default {
 
          ],
          "checkout":{
-            "id":"gid://shopify/Checkout/e28b55a3205f8d129a9b7223287ec95a?key=191add76e8eba90b93cfe4d5d261c4cb",
+            "id":"Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",
             "ready":true,
             "lineItems":{
                "pageInfo":{
@@ -16,15 +16,15 @@ export default {
                   {
                      "cursor":"eyJsYXN0X2lkIjoiZmI3MTEwMmYwZDM4ZGU0NmUwMzdiMzBmODE3ZTlkYjUifQ==",
                      "node":{
-                        "id":"gid://shopify/CheckoutLineItem/fb71102f0d38de46e037b30f817e9db5?checkout=e28b55a3205f8d129a9b7223287ec95a",
+                        "id":"zUzNzQ1ZjU0OTVlZjIyYzIxYzVkZj9rZXk9MTlkMjljZDgwYjg3MGMxNmRmNjNjM2JjODUzYjY3MTY=",
                         "title":"Arena Zip Boot",
                         "variant":{
-                           "id":"gid://shopify/ProductVariant/36607672003",
+                           "id":"Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
                            "title":"Black / 8",
                            "price":"188.00",
                            "weight":0,
                            "image": {
-                              "id":"gid://shopify/ProductImage/21253957763",
+                              "id":"Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
                               "src":"https://cdn.shopify.com/s/files/1/1312/0893/products/003_3e206539-20d3-49c0-8bff-006e449906ca.jpg?v=1491850970",
                               "altText":null
                            },

--- a/fixtures/checkout-with-paginated-line-items-fixture.js
+++ b/fixtures/checkout-with-paginated-line-items-fixture.js
@@ -1,58 +1,55 @@
 export default {
   "data": {
-    "checkoutCreate": {
-      "userErrors": [],
-      "checkout": {
-        "id": "gid://shopify/Checkout/c4abf4bf036239ab5e3d0bf93c642c96",
-        "ready": true,
-        "lineItems": {
-          "pageInfo": {
-            "hasNextPage": true,
-            "hasPreviousPage": false
-          },
-          "edges": [
-            {
-              "cursor": "eyJsYXN0X2lkIjoiZDUyZWU5ZTEwYmQxMWE0NDlkNmQzMWNkMzBhMGFjNzMifQ==",
-              "node": {
-                "title": "Intelligent Granite Table",
-                "variant": {
-                  "id": "gid://shopify/ProductVariant/1",
-                  "title": "Awesome Copper Bench",
-                  "price": "64.99",
-                  "weight": 4.5,
-                  "image": null,
-                  "selectedOptions": [
-                    {
-                      "name": "Color or something",
-                      "value": "Awesome Copper Bench"
-                    }
-                  ]
-                },
-                "quantity": 5,
-                "customAttributes": []
-              }
-            }
-          ]
+    "node": {
+      "id": "Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",
+      "ready": true,
+      "lineItems": {
+        "pageInfo": {
+          "hasNextPage": true,
+          "hasPreviousPage": false
         },
-        "shippingAddress": null,
-        "shippingLine": null,
-        "requiresShipping": true,
-        "customAttributes": [],
-        "note": null,
-        "paymentDue": "367.19",
-        "webUrl": "https://checkout.myshopify.io/1/checkouts/c4abf4bf036239ab5e3d0bf93c642c96",
-        "order": null,
-        "orderStatusUrl": null,
-        "taxExempt": false,
-        "taxesIncluded": false,
-        "currencyCode": "CAD",
-        "totalTax": "42.24",
-        "subtotalPrice": "324.95",
-        "totalPrice": "367.19",
-        "completedAt": null,
-        "createdAt": "2017-03-28T16:58:31Z",
-        "updatedAt": "2017-03-28T16:58:31Z"
-      }
+        "edges": [
+          {
+            "cursor": "eyJsYXN0X2lkIjoiZDUyZWU5ZTEwYmQxMWE0NDlkNmQzMWNkMzBhMGFjNzMifQ==",
+            "node": {
+              "title": "Intelligent Granite Table",
+              "variant": {
+                "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
+                "title": "Awesome Copper Bench",
+                "price": "64.99",
+                "weight": 4.5,
+                "image": null,
+                "selectedOptions": [
+                  {
+                    "name": "Color or something",
+                    "value": "Awesome Copper Bench"
+                  }
+                ]
+              },
+              "quantity": 5,
+              "customAttributes": []
+            }
+          }
+        ]
+      },
+      "shippingAddress": null,
+      "shippingLine": null,
+      "requiresShipping": true,
+      "customAttributes": [],
+      "note": null,
+      "paymentDue": "367.19",
+      "webUrl": "https://checkout.myshopify.io/1/checkouts/c4abf4bf036239ab5e3d0bf93c642c96",
+      "order": null,
+      "orderStatusUrl": null,
+      "taxExempt": false,
+      "taxesIncluded": false,
+      "currencyCode": "CAD",
+      "totalTax": "42.24",
+      "subtotalPrice": "324.95",
+      "totalPrice": "367.19",
+      "completedAt": null,
+      "createdAt": "2017-03-28T16:58:31Z",
+      "updatedAt": "2017-03-28T16:58:31Z"
     }
   }
 };

--- a/fixtures/collection-fixture.js
+++ b/fixtures/collection-fixture.js
@@ -1,7 +1,7 @@
 export default {
   "data": {
     "node": {
-      "id": "gid://shopify/Collection/369312584",
+      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
       "handle": "frontpage",
       "updatedAt": "2017-01-16T15:49:34Z",
       "title": "Cat Collection",

--- a/fixtures/collection-with-products-fixture.js
+++ b/fixtures/collection-with-products-fixture.js
@@ -2,8 +2,10 @@ export default {
   "data": {
     "node": {
       "__typename": "Collection",
-      "id": "gid://shopify/Collection/369312584",
+      "id": "Z2lkOi8vc2hvcGlmeS9Db2xsZWN0aW9uLzM2OTMxMjU4NA==",
       "handle": "frontpage",
+      "description": "",
+      "descriptionHtml": "",
       "updatedAt": "2017-03-29T15:30:02Z",
       "title": "Cat Collection",
       "image": null,
@@ -16,7 +18,7 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjo3ODU3OTg5Mzg0LCJsYXN0X3ZhbHVlIjoiNzg1Nzk4OTM4NCJ9",
             "node": {
-              "id": "gid://shopify/Product/7857989384",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
               "createdAt": "2016-09-25T21:31:33Z",
               "updatedAt": "2017-03-29T15:25:32Z",
               "descriptionHtml": "send me this cat",
@@ -31,7 +33,7 @@ export default {
               "publishedAt": "2017-01-12T19:44:42Z",
               "options": [
                 {
-                  "id": "gid://shopify/ProductOption/9417004808",
+                  "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0T3B0aW9uLzk0MTcwMDQ4MDg=",
                   "name": "Fur",
                   "values": [
                     "Fluffy",
@@ -40,7 +42,7 @@ export default {
                   ]
                 },
                 {
-                  "id": "gid://shopify/ProductOption/10714078536",
+                  "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0T3B0aW9uLzEwNzE0MDc4NTM2",
                   "name": "Size",
                   "values": [
                     "Medium",
@@ -58,7 +60,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
                     "node": {
-                      "id": "gid://shopify/ProductImage/16306812680",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTYzMDY4MTI2ODA=",
                       "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
                       "altText": "fettucine"
                     }
@@ -66,7 +68,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
                     "node": {
-                      "id": "gid://shopify/ProductImage/18217787592",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
                       "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
                       "altText": null
                     }
@@ -74,7 +76,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoxODIxNzc5MDY2NH0=",
                     "node": {
-                      "id": "gid://shopify/ProductImage/18217790664",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
                       "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
                       "altText": null
                     }
@@ -82,7 +84,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoxOTYxNjczNjg0MH0=",
                     "node": {
-                      "id": "gid://shopify/ProductImage/19616736840",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
                       "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
                       "altText": null
                     }
@@ -98,12 +100,12 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNTk3Nn0=",
                     "node": {
-                      "id": "gid://shopify/ProductVariant/25602235976",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNTk3Ng==",
                       "title": "Fluffy / Medium",
                       "price": "0.00",
                       "weight": 18,
                       "image": {
-                        "id": "gid://shopify/ProductImage/19616736840",
+                        "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
                         "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
                         "altText": null
                       },
@@ -122,12 +124,12 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNjA0MH0=",
                     "node": {
-                      "id": "gid://shopify/ProductVariant/25602236040",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNjA0MA==",
                       "title": "Extra Fluffy / Small",
                       "price": "0.00",
                       "weight": 18,
                       "image": {
-                        "id": "gid://shopify/ProductImage/18217787592",
+                        "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
                         "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
                         "altText": null
                       },
@@ -146,12 +148,12 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNjEwNH0=",
                     "node": {
-                      "id": "gid://shopify/ProductVariant/25602236104",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNjEwNA==",
                       "title": "Mega Fluff / Large",
                       "price": "0.00",
                       "weight": 0,
                       "image": {
-                        "id": "gid://shopify/ProductImage/18217790664",
+                        "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
                         "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
                         "altText": null
                       },
@@ -174,7 +176,7 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjo4NjMxNzQ5NTc2LCJsYXN0X3ZhbHVlIjoiODYzMTc0OTU3NiJ9",
             "node": {
-              "id": "gid://shopify/Product/8631749576",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzg2MzE3NDk1NzY=",
               "createdAt": "2017-02-03T18:52:27Z",
               "updatedAt": "2017-03-30T18:27:00Z",
               "descriptionHtml": "alternative cat",
@@ -189,7 +191,7 @@ export default {
               "publishedAt": "2017-02-03T18:52:27Z",
               "options": [
                 {
-                  "id": "gid://shopify/ProductOption/10373760392",
+                  "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0T3B0aW9uLzEwMzczNzYwMzky",
                   "name": "Title",
                   "values": [
                     "Default Title"
@@ -205,7 +207,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoyMDE0MzA0MTg2NH0=",
                     "node": {
-                      "id": "gid://shopify/ProductImage/20143041864",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjAxNDMwNDE4NjQ=",
                       "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/image.dots.morethings.jpg?v=1490898420",
                       "altText": null
                     }
@@ -221,7 +223,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoyOTkzNzExMjEzNn0=",
                     "node": {
-                      "id": "gid://shopify/ProductVariant/29937112136",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTkzNzExMjEzNg==",
                       "title": "Default Title",
                       "price": "0.00",
                       "weight": 0,

--- a/fixtures/dynamic-collection-fixture.js
+++ b/fixtures/dynamic-collection-fixture.js
@@ -1,6 +1,7 @@
 export default {
   "data": {
     "node": {
+      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
       "title": "Cat Collection",
       "updatedAt": "2017-01-16T15:49:34Z",
       "image": null

--- a/fixtures/dynamic-product-fixture.js
+++ b/fixtures/dynamic-product-fixture.js
@@ -2,7 +2,7 @@ export default {
   "data": {
     "node": {
       "__typename": "Product",
-      "id": "gid://shopify/Product/7857989384",
+      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
       "handle": "cat",
       "title": "Cat",
       "updatedAt": "2017-01-16T15:42:21Z",
@@ -15,21 +15,21 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
             "node": {
-              "id": "gid://shopify/ProductImage/16306812680",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTYzMDY4MTI2ODA=",
               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096"
             }
           },
           {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
             "node": {
-              "id": "gid://shopify/ProductImage/18217787592",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581332"
             }
           },
           {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc5MDY2NH0=",
             "node": {
-              "id": "gid://shopify/ProductImage/18217790664",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1484581340"
             }
           }
@@ -37,7 +37,7 @@ export default {
       },
       "options": [
         {
-          "id": "gid://shopify/ProductOption/9417004808",
+          "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjAxNDMwNDE4NjQ=",
           "name": "Fur"
         }
       ],
@@ -50,7 +50,7 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNTk3Nn0=",
             "node": {
-              "id": "gid://shopify/ProductVariant/25602235976",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NTk3MjA=",
               "price": "0.00",
               "weight": 18
             }
@@ -58,7 +58,7 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNjA0MH0=",
             "node": {
-              "id": "gid://shopify/ProductVariant/25602236040",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
               "price": "0.00",
               "weight": 18
             }
@@ -66,7 +66,7 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNjEwNH0=",
             "node": {
-              "id": "gid://shopify/ProductVariant/25602236104",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI4MjkzODQ=",
               "price": "0.00",
               "weight": 0
             }

--- a/fixtures/paginated-images-fixtures.js
+++ b/fixtures/paginated-images-fixtures.js
@@ -2,7 +2,7 @@ export const secondPageImagesFixture = {
   "data": {
     "node": {
       "__typename": "Product",
-      "id": "gid://shopify/Product/7857989384",
+      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
       "images": {
         "pageInfo": {
           "hasNextPage": true,
@@ -12,7 +12,7 @@ export const secondPageImagesFixture = {
           {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
             "node": {
-              "id": "gid://shopify/ProductImage/18217787592",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTYzMDY4MTI2ODA=",
               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581332",
               "altText": null
             }
@@ -27,7 +27,7 @@ export const thirdPageImagesFixture = {
   "data": {
     "node": {
       "__typename": "Product",
-      "id": "gid://shopify/Product/7857989384",
+      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
       "images": {
         "pageInfo": {
           "hasNextPage": false,
@@ -37,7 +37,7 @@ export const thirdPageImagesFixture = {
           {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc5MDY2NH0=",
             "node": {
-              "id": "gid://shopify/ProductImage/18217790664",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4MTk0MDA=",
               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1484581340",
               "altText": null
             }
@@ -52,7 +52,7 @@ export const fourthPageImagesFixture = {
   "data": {
     "node": {
       "__typename": "Product",
-      "id": "gid://shopify/Product/7857989384",
+      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzg2MzE3NDk1NzY=",
       "images": {
         "pageInfo": {
           "hasNextPage": false,
@@ -62,7 +62,7 @@ export const fourthPageImagesFixture = {
           {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
             "node": {
-              "id": "gid://shopify/ProductImage/18217787592",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI4MjkzODQ=",
               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581340",
               "altText": null
             }
@@ -77,7 +77,7 @@ export const fifthPageImagesFixture = {
   "data": {
     "node": {
       "__typename": "Product",
-      "id": "gid://shopify/Product/7857989384",
+      "id": "Z2lkOi8vc2hvcGlmeS9Db2xsZWN0aW9uLzQxMzA5NDQ3Mg==",
       "images": {
         "pageInfo": {
           "hasNextPage": false,
@@ -87,7 +87,7 @@ export const fifthPageImagesFixture = {
           {
             "cursor": "eyJsYXN0X2lkIjoxOTYxNjczNjg0MH0=",
             "node": {
-              "id": "gid://shopify/ProductImage/19616736840",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
               "altText": null
             }

--- a/fixtures/paginated-line-items-fixture.js
+++ b/fixtures/paginated-line-items-fixture.js
@@ -2,7 +2,7 @@ export const secondPageLineItemsFixture = {
   "data": {
     "node": {
       "__typename": "Checkout",
-      "id": "gid://shopify/Checkout/89427726abd2543894550baae32065d6",
+      "id": "Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",
       "lineItems": {
         "pageInfo": {
           "hasNextPage": true,
@@ -14,7 +14,7 @@ export const secondPageLineItemsFixture = {
             "node": {
               "title": "Cat",
               "variant": {
-                "id": "gid://shopify/ProductVariant/2"
+                "id": "ZNc0vnIOijnJabh4873nNQnfb9B0QhnFyvk9Wfh87oNBeqBHGQNA5a=="
               },
               "quantity": 10,
               "customAttributes": []
@@ -30,7 +30,7 @@ export const thirdPageLineItemsFixture = {
   "data": {
     "node": {
       "__typename": "Checkout",
-      "id": "gid://shopify/Checkout/89427726abd2543894550baae32065d6",
+      "id": "Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",
       "lineItems": {
         "pageInfo": {
           "hasNextPage": false,
@@ -42,7 +42,7 @@ export const thirdPageLineItemsFixture = {
             "node": {
               "title": "Extravagant Tissue Box",
               "variant": {
-                "id": "gid://shopify/ProductVariant/3"
+                "id": "Zad7JHnbf32JHna087juBQn8faB84Ba28VnqjF87Qynaw8MnDhNA3W=="
               },
               "quantity": 15,
               "customAttributes": []

--- a/fixtures/paginated-variants-fixtures.js
+++ b/fixtures/paginated-variants-fixtures.js
@@ -2,7 +2,7 @@ export const secondPageVariantsFixture = {
   "data": {
     "node": {
       "__typename": "Product",
-      "id": "gid://shopify/Product/7857989384",
+      "id": "Z2lkOi8vc2hvcGlmeS9Db2xsZWN0aW9uLzM2OTMxMjU4NA==",
       "variants": {
         "pageInfo": {
           "hasNextPage": true,
@@ -12,7 +12,7 @@ export const secondPageVariantsFixture = {
           {
             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNjA0MH0=",
             "node": {
-              "id": "gid://shopify/ProductVariant/25602236040",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
               "title": "Extra Fluffy",
               "price": "0.00",
               "weight": 18,
@@ -35,7 +35,7 @@ export const thirdPageVariantsFixture = {
   "data": {
     "node": {
       "__typename": "Product",
-      "id": "gid://shopify/Product/7857989384",
+      "id": "Z2lkOi8vc2hvcGlmeS9Db2xsZWN0aW9uLzM2OTMxMjU4NA==",
       "variants": {
         "pageInfo": {
           "hasNextPage": false,
@@ -45,7 +45,7 @@ export const thirdPageVariantsFixture = {
           {
             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNjEwNH0=",
             "node": {
-              "id": "gid://shopify/ProductVariant/25602236104",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NTk3MjA=",
               "title": "Mega Fluff",
               "price": "0.00",
               "weight": 0,

--- a/fixtures/product-fixture.js
+++ b/fixtures/product-fixture.js
@@ -2,7 +2,7 @@ export default {
   "data": {
     "node": {
       "__typename": "Product",
-      "id": "gid://shopify/Product/7857989384",
+      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
       "createdAt": "2016-09-25T21:31:33Z",
       "updatedAt": "2017-03-29T15:25:32Z",
       "descriptionHtml": "send me this cat",
@@ -17,7 +17,7 @@ export default {
       "publishedAt": "2017-01-12T19:44:42Z",
       "options": [
         {
-          "id": "gid://shopify/ProductOption/9417004808",
+          "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
           "name": "Fur",
           "values": [
             "Fluffy",
@@ -26,7 +26,7 @@ export default {
           ]
         },
         {
-          "id": "gid://shopify/ProductOption/10714078536",
+          "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
           "name": "Size",
           "values": [
             "Medium",
@@ -44,7 +44,7 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
             "node": {
-              "id": "gid://shopify/ProductImage/16306812680",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
               "altText": "fettucine"
             }
@@ -52,7 +52,7 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
             "node": {
-              "id": "gid://shopify/ProductImage/18217787592",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
               "altText": null
             }
@@ -60,7 +60,7 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc5MDY2NH0=",
             "node": {
-              "id": "gid://shopify/ProductImage/18217790664",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
               "altText": null
             }
@@ -68,7 +68,7 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjoxOTYxNjczNjg0MH0=",
             "node": {
-              "id": "gid://shopify/ProductImage/19616736840",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
               "altText": null
             }
@@ -84,12 +84,12 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNTk3Nn0=",
             "node": {
-              "id": "gid://shopify/ProductVariant/25602235976",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
               "title": "Fluffy / Medium",
               "price": "0.00",
               "weight": 18,
               "image": {
-                "id": "gid://shopify/ProductImage/19616736840",
+                "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                 "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
                 "altText": null
               },
@@ -108,12 +108,12 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNjA0MH0=",
             "node": {
-              "id": "gid://shopify/ProductVariant/25602236040",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
               "title": "Extra Fluffy / Small",
               "price": "0.00",
               "weight": 18,
               "image": {
-                "id": "gid://shopify/ProductImage/18217787592",
+                "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                 "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
                 "altText": null
               },
@@ -132,12 +132,12 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNjEwNH0=",
             "node": {
-              "id": "gid://shopify/ProductVariant/25602236104",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
               "title": "Mega Fluff / Large",
               "price": "0.00",
               "weight": 0,
               "image": {
-                "id": "gid://shopify/ProductImage/18217790664",
+                "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                 "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
                 "altText": null
               },

--- a/fixtures/product-with-paginated-images-fixture.js
+++ b/fixtures/product-with-paginated-images-fixture.js
@@ -10,7 +10,7 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjo3ODU3OTg5Mzg0LCJsYXN0X3ZhbHVlIjoiNzg1Nzk4OTM4NCJ9",
             "node": {
-              "id": "gid://shopify/Product/7857989384",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
               "createdAt": "2016-09-25T21:31:33Z",
               "updatedAt": "2017-01-16T15:42:21Z",
               "descriptionHtml": "send me this cat",
@@ -23,7 +23,7 @@ export default {
               "publishedAt": "2016-09-25T21:29:00Z",
               "options": [
                 {
-                  "id": "gid://shopify/ProductOption/9417004808",
+                  "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI4MjkzODQ=",
                   "name": "Fur",
                   "values": [
                     "Fluffy",
@@ -41,7 +41,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
                     "node": {
-                      "id": "gid://shopify/ProductImage/16306812680",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
                       "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096",
                       "altText": null
                     }
@@ -57,7 +57,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNTk3Nn0=",
                     "node": {
-                      "id": "gid://shopify/ProductVariant/25602235976",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
                       "title": "Fluffy",
                       "price": "0.00",
                       "weight": 18,

--- a/fixtures/product-with-paginated-variants-fixture.js
+++ b/fixtures/product-with-paginated-variants-fixture.js
@@ -2,7 +2,7 @@ export default {
   "data": {
     "node": {
       "__typename": "Product",
-      "id": "gid://shopify/Product/7857989384",
+      "id": "Z2lkOi8vc2hvcGlmeS9Db2xsZWN0aW9uLzM2OTMxMjU4NA==",
       "handle": "cat",
       "title": "Cat",
       "updatedAt": "2017-01-16T15:42:21Z",
@@ -15,7 +15,7 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
             "node": {
-              "id": "gid://shopify/ProductImage/16306812680",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTYzMDY4MTI2ODA=",
               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096"
             }
           }
@@ -23,7 +23,7 @@ export default {
       },
       "options": [
         {
-          "id": "gid://shopify/ProductOption/9417004808",
+          "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
           "name": "Fur"
         }
       ],
@@ -36,7 +36,7 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNTk3Nn0=",
             "node": {
-              "id": "gid://shopify/ProductVariant/25602235976",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4MTk0MDA=",
               "price": "0.00",
               "weight": 18
             }

--- a/fixtures/query-collection-fixture.js
+++ b/fixtures/query-collection-fixture.js
@@ -10,9 +10,9 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjozNjkzMTI1ODQsImxhc3RfdmFsdWUiOiIzNjkzMTI1ODQifQ==",
             "node": {
-              "id": "gid://shopify/Collection/369312584",
+              "id": "Z2lkOi8vc2hvcGlmeS9Db2xsZWN0aW9uLzM2OTMxMjU4NA==",
               "title": "Cat Collection",
-              "updatedAt": "2017-02-09T19:06:44Z"
+              "updatedAt": "2017-03-29T15:30:02Z"
             }
           }
         ]

--- a/fixtures/query-product-fixture.js
+++ b/fixtures/query-product-fixture.js
@@ -10,7 +10,7 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjo3ODU3OTg5Mzg0LCJsYXN0X3ZhbHVlIjoiNzg1Nzk4OTM4NCJ9",
             "node": {
-              "id": "gid://shopify/Product/7857989384",
+              "id": "Z2lkOi8v9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
               "updatedAt": "2017-02-17T19:56:02Z",
               "createdAt": "2016-09-25T21:31:33Z",
               "productType": "dog",

--- a/fixtures/shop-policies-fixture.js
+++ b/fixtures/shop-policies-fixture.js
@@ -2,19 +2,19 @@ export default {
   "data": {
     "shop": {
       "privacyPolicy": {
-        "id": "gid://shopify/ShopPolicy/33216712",
+        "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjAxNDMwNDE4NjQ=",
         "title": "Privacy Policy",
         "url": "https://checkout.shopify.com/15107238/policies/2310921.html",
         "body": "privacy things"
       },
       "termsOfService": {
-        "id": "gid://shopify/ShopPolicy/33216776",
+        "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
         "title": "Terms of Service",
         "url": "https://checkout.shopify.com/15107238/policies/2341235.html",
         "body": "terms of service things"
       },
       "refundPolicy": {
-        "id": "gid://shopify/ShopPolicy/33216648",
+        "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
         "title": "Refund Policy",
         "url": "https://checkout.shopify.com/15107238/policies/13412543.html",
         "body": "refund things"

--- a/fixtures/shop-with-collections-fixture.js
+++ b/fixtures/shop-with-collections-fixture.js
@@ -10,7 +10,7 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjozNjkzMTI1ODQsImxhc3RfdmFsdWUiOiIzNjkzMTI1ODQifQ==",
             "node": {
-              "id": "gid://shopify/Collection/369312584",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
               "handle": "frontpage",
               "updatedAt": "2017-01-16T15:49:34Z",
               "title": "Cat Collection",
@@ -20,7 +20,7 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjo0MTMwOTQ0NzIsImxhc3RfdmFsdWUiOiI0MTMwOTQ0NzIifQ==",
             "node": {
-              "id": "gid://shopify/Collection/413094472",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzg1MzAwMzM1NDQ=",
               "handle": "test",
               "updatedAt": "2017-01-16T15:51:51Z",
               "title": "Test",

--- a/fixtures/shop-with-collections-with-pagination-fixture.js
+++ b/fixtures/shop-with-collections-with-pagination-fixture.js
@@ -10,8 +10,10 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjozNjkzMTI1ODQsImxhc3RfdmFsdWUiOiIzNjkzMTI1ODQifQ==",
             "node": {
-              "id": "gid://shopify/Collection/369312584",
+              "id": "Z2lkOi8vc2hvcGlmeS9Db2xsZWN0aW9uLzM2OTMxMjU4NA==",
               "handle": "frontpage",
+              "description": "",
+              "descriptionHtml": "",
               "updatedAt": "2017-03-29T15:30:02Z",
               "title": "Cat Collection",
               "image": null,
@@ -24,7 +26,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjo3ODU3OTg5Mzg0LCJsYXN0X3ZhbHVlIjoiNzg1Nzk4OTM4NCJ9",
                     "node": {
-                      "id": "gid://shopify/Product/7857989384",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                       "createdAt": "2016-09-25T21:31:33Z",
                       "updatedAt": "2017-03-29T15:25:32Z",
                       "descriptionHtml": "send me this cat",
@@ -39,7 +41,7 @@ export default {
                       "publishedAt": "2017-01-12T19:44:42Z",
                       "options": [
                         {
-                          "id": "gid://shopify/ProductOption/9417004808",
+                          "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0T3B0aW9uLzk0MTcwMDQ4MDg=",
                           "name": "Fur",
                           "values": [
                             "Fluffy",
@@ -48,7 +50,7 @@ export default {
                           ]
                         },
                         {
-                          "id": "gid://shopify/ProductOption/10714078536",
+                          "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0T3B0aW9uLzEwNzE0MDc4NTM2",
                           "name": "Size",
                           "values": [
                             "Medium",
@@ -66,7 +68,7 @@ export default {
                           {
                             "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
                             "node": {
-                              "id": "gid://shopify/ProductImage/16306812680",
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTYzMDY4MTI2ODA=",
                               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
                               "altText": "fettucine"
                             }
@@ -78,14 +80,87 @@ export default {
                           "hasNextPage": false,
                           "hasPreviousPage": false
                         },
-                        "edges": []
+                        "edges": [
+                          {
+                            "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNTk3Nn0=",
+                            "node": {
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNTk3Ng==",
+                              "title": "Fluffy / Medium",
+                              "price": "0.00",
+                              "weight": 18,
+                              "image": {
+                                "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
+                                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
+                                "altText": null
+                              },
+                              "selectedOptions": [
+                                {
+                                  "name": "Fur",
+                                  "value": "Fluffy"
+                                },
+                                {
+                                  "name": "Size",
+                                  "value": "Medium"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNjA0MH0=",
+                            "node": {
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNjA0MA==",
+                              "title": "Extra Fluffy / Small",
+                              "price": "0.00",
+                              "weight": 18,
+                              "image": {
+                                "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
+                                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
+                                "altText": null
+                              },
+                              "selectedOptions": [
+                                {
+                                  "name": "Fur",
+                                  "value": "Extra Fluffy"
+                                },
+                                {
+                                  "name": "Size",
+                                  "value": "Small"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNjEwNH0=",
+                            "node": {
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNjEwNA==",
+                              "title": "Mega Fluff / Large",
+                              "price": "0.00",
+                              "weight": 0,
+                              "image": {
+                                "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
+                                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
+                                "altText": null
+                              },
+                              "selectedOptions": [
+                                {
+                                  "name": "Fur",
+                                  "value": "Mega Fluff"
+                                },
+                                {
+                                  "name": "Size",
+                                  "value": "Large"
+                                }
+                              ]
+                            }
+                          }
+                        ]
                       }
                     }
                   },
                   {
                     "cursor": "eyJsYXN0X2lkIjo4NjMxNzQ5NTc2LCJsYXN0X3ZhbHVlIjoiODYzMTc0OTU3NiJ9",
                     "node": {
-                      "id": "gid://shopify/Product/8631749576",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzg2MzE3NDk1NzY=",
                       "createdAt": "2017-02-03T18:52:27Z",
                       "updatedAt": "2017-03-30T18:27:00Z",
                       "descriptionHtml": "alternative cat",
@@ -100,7 +175,7 @@ export default {
                       "publishedAt": "2017-02-03T18:52:27Z",
                       "options": [
                         {
-                          "id": "gid://shopify/ProductOption/10373760392",
+                          "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0T3B0aW9uLzEwMzczNzYwMzky",
                           "name": "Title",
                           "values": [
                             "Default Title"
@@ -116,7 +191,7 @@ export default {
                           {
                             "cursor": "eyJsYXN0X2lkIjoyMDE0MzA0MTg2NH0=",
                             "node": {
-                              "id": "gid://shopify/ProductImage/20143041864",
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjAxNDMwNDE4NjQ=",
                               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/image.dots.morethings.jpg?v=1490898420",
                               "altText": null
                             }
@@ -128,7 +203,24 @@ export default {
                           "hasNextPage": false,
                           "hasPreviousPage": false
                         },
-                        "edges": []
+                        "edges": [
+                          {
+                            "cursor": "eyJsYXN0X2lkIjoyOTkzNzExMjEzNn0=",
+                            "node": {
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTkzNzExMjEzNg==",
+                              "title": "Default Title",
+                              "price": "0.00",
+                              "weight": 0,
+                              "image": null,
+                              "selectedOptions": [
+                                {
+                                  "name": "Title",
+                                  "value": "Default Title"
+                                }
+                              ]
+                            }
+                          }
+                        ]
                       }
                     }
                   }
@@ -139,8 +231,10 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjo0MTMwOTQ0NzIsImxhc3RfdmFsdWUiOiI0MTMwOTQ0NzIifQ==",
             "node": {
-              "id": "gid://shopify/Collection/413094472",
+              "id": "Z2lkOi8vc2hvcGlmeS9Db2xsZWN0aW9uLzQxMzA5NDQ3Mg==",
               "handle": "test",
+              "description": "",
+              "descriptionHtml": "",
               "updatedAt": "2017-03-29T15:30:02Z",
               "title": "Test",
               "image": null,
@@ -153,7 +247,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjo4NTMwMDMzNTQ0LCJsYXN0X3ZhbHVlIjoiODUzMDAzMzU0NCJ9",
                     "node": {
-                      "id": "gid://shopify/Product/8530033544",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzg1MzAwMzM1NDQ=",
                       "createdAt": "2017-01-16T15:43:38Z",
                       "updatedAt": "2017-04-06T17:30:25Z",
                       "descriptionHtml": "do not send",
@@ -166,7 +260,7 @@ export default {
                       "publishedAt": "2017-01-16T15:43:38Z",
                       "options": [
                         {
-                          "id": "gid://shopify/ProductOption/10244315208",
+                          "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0T3B0aW9uLzEwMjQ0MzE1MjA4",
                           "name": "Size",
                           "values": [
                             "small",
@@ -184,7 +278,7 @@ export default {
                           {
                             "cursor": "eyJsYXN0X2lkIjoxODIxNzgxOTQwMH0=",
                             "node": {
-                              "id": "gid://shopify/ProductImage/18217819400",
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4MTk0MDA=",
                               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/notcat.jpeg?v=1490363658",
                               "altText": null
                             }
@@ -196,7 +290,68 @@ export default {
                           "hasNextPage": false,
                           "hasPreviousPage": false
                         },
-                        "edges": []
+                        "edges": [
+                          {
+                            "cursor": "eyJsYXN0X2lkIjoyOTEwNjAyMjc5Mn0=",
+                            "node": {
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjAyMjc5Mg==",
+                              "title": "small",
+                              "price": "0.00",
+                              "weight": 0,
+                              "image": {
+                                "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
+                                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/054cca77f1be90654f4f70db263a3822.jpg?v=1490363658",
+                                "altText": null
+                              },
+                              "selectedOptions": [
+                                {
+                                  "name": "Size",
+                                  "value": "small"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "cursor": "eyJsYXN0X2lkIjoyOTEwNjA2NDU4NH0=",
+                            "node": {
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
+                              "title": "large",
+                              "price": "0.00",
+                              "weight": 0,
+                              "image": {
+                                "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NTk3MjA=",
+                                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/23695_pets_vertical_store_dogs_small_tile_8._CB312176604.jpg?v=1490363658",
+                                "altText": null
+                              },
+                              "selectedOptions": [
+                                {
+                                  "name": "Size",
+                                  "value": "large"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "cursor": "eyJsYXN0X2lkIjoyOTEwNjA2NDY0OH0=",
+                            "node": {
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDY0OA==",
+                              "title": "very large",
+                              "price": "0.00",
+                              "weight": 0,
+                              "image": {
+                                "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI4MjkzODQ=",
+                                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/original.jpg?v=1490363713",
+                                "altText": null
+                              },
+                              "selectedOptions": [
+                                {
+                                  "name": "Size",
+                                  "value": "very large"
+                                }
+                              ]
+                            }
+                          }
+                        ]
                       }
                     }
                   }

--- a/fixtures/shop-with-collections-with-products-fixture.js
+++ b/fixtures/shop-with-collections-with-products-fixture.js
@@ -10,8 +10,10 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjozNjkzMTI1ODQsImxhc3RfdmFsdWUiOiIzNjkzMTI1ODQifQ==",
             "node": {
-              "id": "gid://shopify/Collection/369312584",
+              "id": "Z2lkOi8vc2hvcGlmeS9Db2xsZWN0aW9uLzM2OTMxMjU4NA==",
               "handle": "frontpage",
+              "description": "",
+              "descriptionHtml": "",
               "updatedAt": "2017-03-29T15:30:02Z",
               "title": "Cat Collection",
               "image": null,
@@ -24,7 +26,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjo3ODU3OTg5Mzg0LCJsYXN0X3ZhbHVlIjoiNzg1Nzk4OTM4NCJ9",
                     "node": {
-                      "id": "gid://shopify/Product/7857989384",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                       "createdAt": "2016-09-25T21:31:33Z",
                       "updatedAt": "2017-03-29T15:25:32Z",
                       "descriptionHtml": "send me this cat",
@@ -39,7 +41,7 @@ export default {
                       "publishedAt": "2017-01-12T19:44:42Z",
                       "options": [
                         {
-                          "id": "gid://shopify/ProductOption/9417004808",
+                          "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0T3B0aW9uLzk0MTcwMDQ4MDg=",
                           "name": "Fur",
                           "values": [
                             "Fluffy",
@@ -48,7 +50,7 @@ export default {
                           ]
                         },
                         {
-                          "id": "gid://shopify/ProductOption/10714078536",
+                          "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0T3B0aW9uLzEwNzE0MDc4NTM2",
                           "name": "Size",
                           "values": [
                             "Medium",
@@ -66,7 +68,7 @@ export default {
                           {
                             "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
                             "node": {
-                              "id": "gid://shopify/ProductImage/16306812680",
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTYzMDY4MTI2ODA=",
                               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
                               "altText": "fettucine"
                             }
@@ -74,7 +76,7 @@ export default {
                           {
                             "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
                             "node": {
-                              "id": "gid://shopify/ProductImage/18217787592",
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
                               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
                               "altText": null
                             }
@@ -82,7 +84,7 @@ export default {
                           {
                             "cursor": "eyJsYXN0X2lkIjoxODIxNzc5MDY2NH0=",
                             "node": {
-                              "id": "gid://shopify/ProductImage/18217790664",
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
                               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
                               "altText": null
                             }
@@ -90,7 +92,7 @@ export default {
                           {
                             "cursor": "eyJsYXN0X2lkIjoxOTYxNjczNjg0MH0=",
                             "node": {
-                              "id": "gid://shopify/ProductImage/19616736840",
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
                               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
                               "altText": null
                             }
@@ -106,12 +108,12 @@ export default {
                           {
                             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNTk3Nn0=",
                             "node": {
-                              "id": "gid://shopify/ProductVariant/25602235976",
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNTk3Ng==",
                               "title": "Fluffy / Medium",
                               "price": "0.00",
                               "weight": 18,
                               "image": {
-                                "id": "gid://shopify/ProductImage/19616736840",
+                                "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
                                 "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
                                 "altText": null
                               },
@@ -130,12 +132,12 @@ export default {
                           {
                             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNjA0MH0=",
                             "node": {
-                              "id": "gid://shopify/ProductVariant/25602236040",
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNjA0MA==",
                               "title": "Extra Fluffy / Small",
                               "price": "0.00",
                               "weight": 18,
                               "image": {
-                                "id": "gid://shopify/ProductImage/18217787592",
+                                "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
                                 "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
                                 "altText": null
                               },
@@ -154,12 +156,12 @@ export default {
                           {
                             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNjEwNH0=",
                             "node": {
-                              "id": "gid://shopify/ProductVariant/25602236104",
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNjEwNA==",
                               "title": "Mega Fluff / Large",
                               "price": "0.00",
                               "weight": 0,
                               "image": {
-                                "id": "gid://shopify/ProductImage/18217790664",
+                                "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
                                 "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
                                 "altText": null
                               },
@@ -182,7 +184,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjo4NjMxNzQ5NTc2LCJsYXN0X3ZhbHVlIjoiODYzMTc0OTU3NiJ9",
                     "node": {
-                      "id": "gid://shopify/Product/8631749576",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzg2MzE3NDk1NzY=",
                       "createdAt": "2017-02-03T18:52:27Z",
                       "updatedAt": "2017-03-30T18:27:00Z",
                       "descriptionHtml": "alternative cat",
@@ -197,7 +199,7 @@ export default {
                       "publishedAt": "2017-02-03T18:52:27Z",
                       "options": [
                         {
-                          "id": "gid://shopify/ProductOption/10373760392",
+                          "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0T3B0aW9uLzEwMzczNzYwMzky",
                           "name": "Title",
                           "values": [
                             "Default Title"
@@ -213,7 +215,7 @@ export default {
                           {
                             "cursor": "eyJsYXN0X2lkIjoyMDE0MzA0MTg2NH0=",
                             "node": {
-                              "id": "gid://shopify/ProductImage/20143041864",
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjAxNDMwNDE4NjQ=",
                               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/image.dots.morethings.jpg?v=1490898420",
                               "altText": null
                             }
@@ -229,7 +231,7 @@ export default {
                           {
                             "cursor": "eyJsYXN0X2lkIjoyOTkzNzExMjEzNn0=",
                             "node": {
-                              "id": "gid://shopify/ProductVariant/29937112136",
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTkzNzExMjEzNg==",
                               "title": "Default Title",
                               "price": "0.00",
                               "weight": 0,
@@ -253,8 +255,10 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjo0MTMwOTQ0NzIsImxhc3RfdmFsdWUiOiI0MTMwOTQ0NzIifQ==",
             "node": {
-              "id": "gid://shopify/Collection/413094472",
+              "id": "Z2lkOi8vc2hvcGlmeS9Db2xsZWN0aW9uLzQxMzA5NDQ3Mg==",
               "handle": "test",
+              "description": "",
+              "descriptionHtml": "",
               "updatedAt": "2017-03-29T15:30:02Z",
               "title": "Test",
               "image": null,
@@ -267,7 +271,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjo4NTMwMDMzNTQ0LCJsYXN0X3ZhbHVlIjoiODUzMDAzMzU0NCJ9",
                     "node": {
-                      "id": "gid://shopify/Product/8530033544",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzg1MzAwMzM1NDQ=",
                       "createdAt": "2017-01-16T15:43:38Z",
                       "updatedAt": "2017-04-06T17:30:25Z",
                       "descriptionHtml": "do not send",
@@ -280,7 +284,7 @@ export default {
                       "publishedAt": "2017-01-16T15:43:38Z",
                       "options": [
                         {
-                          "id": "gid://shopify/ProductOption/10244315208",
+                          "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0T3B0aW9uLzEwMjQ0MzE1MjA4",
                           "name": "Size",
                           "values": [
                             "small",
@@ -298,7 +302,7 @@ export default {
                           {
                             "cursor": "eyJsYXN0X2lkIjoxODIxNzgxOTQwMH0=",
                             "node": {
-                              "id": "gid://shopify/ProductImage/18217819400",
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4MTk0MDA=",
                               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/notcat.jpeg?v=1490363658",
                               "altText": null
                             }
@@ -306,7 +310,7 @@ export default {
                           {
                             "cursor": "eyJsYXN0X2lkIjoxODIxNzg0NzYyNH0=",
                             "node": {
-                              "id": "gid://shopify/ProductImage/18217847624",
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NDc2MjQ=",
                               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/hqdefault.jpg?v=1490363658",
                               "altText": null
                             }
@@ -314,7 +318,7 @@ export default {
                           {
                             "cursor": "eyJsYXN0X2lkIjoxODIxNzg1OTcyMH0=",
                             "node": {
-                              "id": "gid://shopify/ProductImage/18217859720",
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NTk3MjA=",
                               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/23695_pets_vertical_store_dogs_small_tile_8._CB312176604.jpg?v=1490363658",
                               "altText": null
                             }
@@ -322,7 +326,7 @@ export default {
                           {
                             "cursor": "eyJsYXN0X2lkIjoxOTg5Mjc4MzU2MH0=",
                             "node": {
-                              "id": "gid://shopify/ProductImage/19892783560",
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
                               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/054cca77f1be90654f4f70db263a3822.jpg?v=1490363658",
                               "altText": null
                             }
@@ -330,7 +334,7 @@ export default {
                           {
                             "cursor": "eyJsYXN0X2lkIjoxOTg5MjgyOTM4NH0=",
                             "node": {
-                              "id": "gid://shopify/ProductImage/19892829384",
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI4MjkzODQ=",
                               "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/original.jpg?v=1490363713",
                               "altText": null
                             }
@@ -346,12 +350,12 @@ export default {
                           {
                             "cursor": "eyJsYXN0X2lkIjoyOTEwNjAyMjc5Mn0=",
                             "node": {
-                              "id": "gid://shopify/ProductVariant/29106022792",
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjAyMjc5Mg==",
                               "title": "small",
                               "price": "0.00",
                               "weight": 0,
                               "image": {
-                                "id": "gid://shopify/ProductImage/19892783560",
+                                "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
                                 "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/054cca77f1be90654f4f70db263a3822.jpg?v=1490363658",
                                 "altText": null
                               },
@@ -366,12 +370,12 @@ export default {
                           {
                             "cursor": "eyJsYXN0X2lkIjoyOTEwNjA2NDU4NH0=",
                             "node": {
-                              "id": "gid://shopify/ProductVariant/29106064584",
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
                               "title": "large",
                               "price": "0.00",
                               "weight": 0,
                               "image": {
-                                "id": "gid://shopify/ProductImage/18217859720",
+                                "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NTk3MjA=",
                                 "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/23695_pets_vertical_store_dogs_small_tile_8._CB312176604.jpg?v=1490363658",
                                 "altText": null
                               },
@@ -386,12 +390,12 @@ export default {
                           {
                             "cursor": "eyJsYXN0X2lkIjoyOTEwNjA2NDY0OH0=",
                             "node": {
-                              "id": "gid://shopify/ProductVariant/29106064648",
+                              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDY0OA==",
                               "title": "very large",
                               "price": "0.00",
                               "weight": 0,
                               "image": {
-                                "id": "gid://shopify/ProductImage/19892829384",
+                                "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI4MjkzODQ=",
                                 "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/original.jpg?v=1490363713",
                                 "altText": null
                               },

--- a/fixtures/shop-with-products-fixture.js
+++ b/fixtures/shop-with-products-fixture.js
@@ -10,7 +10,7 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjo3ODU3OTg5Mzg0LCJsYXN0X3ZhbHVlIjoiNzg1Nzk4OTM4NCJ9",
             "node": {
-              "id": "gid://shopify/Product/7857989384",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
               "createdAt": "2016-09-25T21:31:33Z",
               "updatedAt": "2017-01-16T15:42:21Z",
               "descriptionHtml": "send me this cat",
@@ -23,7 +23,7 @@ export default {
               "publishedAt": "2016-09-25T21:29:00Z",
               "options": [
                 {
-                  "id": "gid://shopify/ProductOption/9417004808",
+                  "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                   "name": "Fur",
                   "values": [
                     "Fluffy",
@@ -41,7 +41,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
                     "node": {
-                      "id": "gid://shopify/ProductImage/16306812680",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                       "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096",
                       "altText": null
                     }
@@ -49,7 +49,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
                     "node": {
-                      "id": "gid://shopify/ProductImage/18217787592",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                       "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581332",
                       "altText": null
                     }
@@ -57,7 +57,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoxODIxNzc5MDY2NH0=",
                     "node": {
-                      "id": "gid://shopify/ProductImage/18217790664",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                       "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1484581340",
                       "altText": null
                     }
@@ -73,7 +73,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNTk3Nn0=",
                     "node": {
-                      "id": "gid://shopify/ProductVariant/25602235976",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                       "title": "Fluffy",
                       "price": "0.00",
                       "weight": 18,
@@ -89,7 +89,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNjA0MH0=",
                     "node": {
-                      "id": "gid://shopify/ProductVariant/25602236040",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                       "title": "Extra Fluffy",
                       "price": "0.00",
                       "weight": 18,
@@ -105,7 +105,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNjEwNH0=",
                     "node": {
-                      "id": "gid://shopify/ProductVariant/25602236104",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                       "title": "Mega Fluff",
                       "price": "0.00",
                       "weight": 0,
@@ -125,7 +125,7 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjo4NTMwMDMzNTQ0LCJsYXN0X3ZhbHVlIjoiODUzMDAzMzU0NCJ9",
             "node": {
-              "id": "gid://shopify/Product/8530033544",
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
               "createdAt": "2017-01-16T15:43:38Z",
               "updatedAt": "2017-01-16T15:46:08Z",
               "descriptionHtml": "do not send",
@@ -138,7 +138,7 @@ export default {
               "publishedAt": "2017-01-16T15:42:00Z",
               "options": [
                 {
-                  "id": "gid://shopify/ProductOption/10244315208",
+                  "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                   "name": "Size",
                   "values": [
                     "small",
@@ -156,7 +156,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoxODIxNzgxOTQwMH0=",
                     "node": {
-                      "id": "gid://shopify/ProductImage/18217819400",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                       "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/notcat.jpeg?v=1484581419",
                       "altText": null
                     }
@@ -164,7 +164,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoxODIxNzg0NzYyNH0=",
                     "node": {
-                      "id": "gid://shopify/ProductImage/18217847624",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                       "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/hqdefault.jpg?v=1484581502",
                       "altText": null
                     }
@@ -172,7 +172,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoxODIxNzg1OTcyMH0=",
                     "node": {
-                      "id": "gid://shopify/ProductImage/18217859720",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                       "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/23695_pets_vertical_store_dogs_small_tile_8._CB312176604.jpg?v=1484581539",
                       "altText": null
                     }
@@ -180,7 +180,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoxODIxNzg2ODQ4OH0=",
                     "node": {
-                      "id": "gid://shopify/ProductImage/18217868488",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                       "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/images.jpg?v=1484581568",
                       "altText": null
                     }
@@ -196,7 +196,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoyOTEwNjAyMjc5Mn0=",
                     "node": {
-                      "id": "gid://shopify/ProductVariant/29106022792",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                       "title": "small",
                       "price": "0.00",
                       "weight": 0,
@@ -211,7 +211,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoyOTEwNjA2NDU4NH0=",
                     "node": {
-                      "id": "gid://shopify/ProductVariant/29106064584",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                       "title": "large",
                       "price": "0.00",
                       "weight": 0,
@@ -226,7 +226,7 @@ export default {
                   {
                     "cursor": "eyJsYXN0X2lkIjoyOTEwNjA2NDY0OH0=",
                     "node": {
-                      "id": "gid://shopify/ProductVariant/29106064648",
+                      "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                       "title": "very large",
                       "price": "0.00",
                       "weight": 0,

--- a/fixtures/shop-with-sorted-collections-fixture.js
+++ b/fixtures/shop-with-sorted-collections-fixture.js
@@ -10,22 +10,22 @@ export default {
           {
             "cursor": "eyJsYXN0X2lkIjozNjkzMTI1ODQsImxhc3RfdmFsDs1iOiJDYXQgQ29sbGVjdGiJ9",
             "node": {
-              "id": "gid://shopify/Collection/591032593",
+              "id": "Z2lN8vnQv9fhvcGlmeS9Db2xsZWN0aW9uLzM2OvNa98ngA==",
               "title": "ABC Collection"
             }
           },
           {
             "cursor": "eyJsYXN0X2lkIjozNjkzMTI1ODQsImxhc3RfdmFsdWUiOiJDYXQgQ29sbGVjdGlvbiJ9",
             "node": {
-              "id": "gid://shopify/Collection/369312584",
+              "id": "Z2lkOi8vc2hvcGlmeS9Db2xsZWN0aW9uLzM2OTMxMjU4NA==",
               "title": "Cat Collection"
             }
           },
           {
             "cursor": "eyJsYXN0X2lkIjo0MTMwOTQ0NzIsImxhc3RfdmFsdWUiOiJUZXN0In0=",
             "node": {
-              "id": "gid://shopify/Collection/413094472",
-              "title": "Test Collection"
+              "id": "Z2lkOi8vc2hvcGlmeS9Db2xsZWN0aW9uLzQxMzA5NDQ3Mg==",
+              "title": "Test"
             }
           }
         ]

--- a/fixtures/shop-with-sorted-products-fixture.js
+++ b/fixtures/shop-with-sorted-products-fixture.js
@@ -8,24 +8,24 @@ export default {
         },
         "edges": [
           {
-            "cursor": "eyJsYXN0X2lkIjo4NjMxNzQ5NTc2LCJsYXN0X3ZhbHVlIjoiMjAxNy0wMi0xNyAxOTo1ODowMCJ9",
+            "cursor": "eyJsYXN0X2lkIjo4NTMwMDMzNTQ0LCJsYXN0X3ZhbHVlIjoiMjAxNy0wNC0wNiAxNzozMDoyNSJ9",
             "node": {
-              "id": "gid://shopify/Product/8631749576",
-              "updatedAt": "2017-02-17T19:58:00Z"
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzg1MzAwMzM1NDQ=",
+              "updatedAt": "2017-04-06T17:30:25Z"
             }
           },
           {
-            "cursor": "eyJsYXN0X2lkIjo4NTMwMDMzNTQ0LCJsYXN0X3ZhbHVlIjoiMjAxNy0wMi0xNyAxOTo1NjozMyJ9",
+            "cursor": "eyJsYXN0X2lkIjo4NjMxNzQ5NTc2LCJsYXN0X3ZhbHVlIjoiMjAxNy0wMy0zMCAxODoyNzowMCJ9",
             "node": {
-              "id": "gid://shopify/Product/8530033544",
-              "updatedAt": "2017-02-17T19:56:33Z"
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzg2MzE3NDk1NzY=",
+              "updatedAt": "2017-03-30T18:27:00Z"
             }
           },
           {
-            "cursor": "eyJsYXN0X2lkIjo3ODU3OTg5Mzg0LCJsYXN0X3ZhbHVlIjoiMjAxNy0wMi0xNyAxOTo1NjowMiJ9",
+            "cursor": "eyJsYXN0X2lkIjo3ODU3OTg5Mzg0LCJsYXN0X3ZhbHVlIjoiMjAxNy0wMy0yOSAxNToyNTozMiJ9",
             "node": {
-              "id": "gid://shopify/Product/7857989384",
-              "updatedAt": "2017-02-17T19:56:02Z"
+              "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
+              "updatedAt": "2017-03-29T15:25:32Z"
             }
           }
         ]

--- a/src/client.js
+++ b/src/client.js
@@ -212,7 +212,7 @@ class Client {
    * Fetches a single product by ID on the shop.
    *
    * @example
-   * client.fetchProduct('123456').then((product) => {
+   * client.fetchProduct('Xk9lM2JkNzFmNzIQ4NTIY4ZDFi9DaGVja291dC9lM2JkN==').then((product) => {
    *   // Do something with the product
    * });
    *
@@ -300,7 +300,7 @@ class Client {
    * To fetch the collection with products use [fetchCollectionWithProducts]{@link Client#fetchCollectionWithProducts}.
    *
    * @example
-   * client.fetchCollection('123456').then((collection) => {
+   * client.fetchCollection('Xk9lM2JkNzFmNzIQ4NTIY4ZDFiZTUyZTUwNTE2MDNhZjg==').then((collection) => {
    *   // Do something with the collection
    * });
    *
@@ -322,7 +322,7 @@ class Client {
    * Fetches a single collection by ID on the shop, including products.
    *
    * @example
-   * client.fetchCollectionWithProducts('123456').then((collection) => {
+   * client.fetchCollectionWithProducts('Xk9lM2JkNzFmNzIQ4NTIY4ZDFiZTUyZTUwNTE2MDNhZjg==').then((collection) => {
    *   // Do something with the collection
    * });
    *
@@ -346,7 +346,7 @@ class Client {
    * Fetches a checkout by ID.
    *
    * @example
-   * client.fetchCheckout('123456').then((checkout) => {
+   * client.fetchCheckout('FlZj9rZXlN5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=').then((checkout) => {
    *   // Do something with the checkout
    * });
    *
@@ -359,8 +359,13 @@ class Client {
       query(root, 'node', id);
     });
 
-    return this.graphQLClient.send(rootQuery).then((response) => {
-      return response.model.node;
+    return this.graphQLClient.send(rootQuery).then((result) => {
+      // Fetch all paginated line items
+      return this.graphQLClient.fetchAllPages(result.model.node.lineItems, {pageSize: 250}).then((lineItems) => {
+        result.model.node.attrs.lineItems = lineItems;
+
+        return result.model.node;
+      });
     });
   }
 
@@ -520,7 +525,7 @@ class Client {
    * @example
    * const input = {
    *   lineItems: [
-   *     {variantId: 'gid://shopify/ProductVariant/2', quantity: 5}
+   *     {variantId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjAyMjc5Mg==', quantity: 5}
    *   ]
    * };
    *
@@ -545,8 +550,8 @@ class Client {
    * Adds line items to an existing checkout.
    *
    * @example
-   * const checkoutId = 'gid://shopify/Checkout/abc123';
-   * const lineItems = [{variantId: 'gid://shopify/ProductVariant/2', quantity: 5}];
+   * const checkoutId = 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9kMTZmM2EzMDM4Yjc4N';
+   * const lineItems = [{variantId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjAyMjc5Mg==', quantity: 5}];
    *
    * client.addLineItems(checkoutId, lineItems).then((checkout) => {
    *   // Do something with the updated checkout
@@ -565,8 +570,8 @@ class Client {
    * Removes line items from an existing checkout.
    *
    * @example
-   * const checkoutId = 'gid://shopify/Checkout/abc123';
-   * const lineItemIds = ['gid://shopify/CheckoutLineItem/def456'];
+   * const checkoutId = 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9kMTZmM2EzMDM4Yjc4N=';
+   * const lineItemIds = ['TViZGE5Y2U1ZDFhY2FiMmM2YT9rZXk9NTc2YjBhODcwNWIxYzg0YjE5ZjRmZGQ5NjczNGVkZGU='];
    *
    * client.removeLineItems(checkoutId, lineItemIds).then((checkout) => {
    *   // Do something with the updated checkout
@@ -585,12 +590,12 @@ class Client {
    * Updates line items on an existing checkout.
    *
    * @example
-   * const checkoutId = 'gid://shopify/Checkout/abc123';
+   * const checkoutId = 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9kMTZmM2EzMDM4Yjc4N=';
    * const lineItems = [
    *   {
-   *     id: 'gid://shopify/CheckoutLineItem/def456',
+   *     id: 'TViZGE5Y2U1ZDFhY2FiMmM2YT9rZXk9NTc2YjBhODcwNWIxYzg0YjE5ZjRmZGQ5NjczNGVkZGU=',
    *     quantity: 5,
-   *     variantId: 'gid://shopify/ProductVariant/2'
+   *     variantId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjAyMjc5Mg=='
    *   }
    * ];
    *

--- a/src/create-gid.js
+++ b/src/create-gid.js
@@ -1,3 +1,0 @@
-export default function createGid(type, id) {
-  return `gid://shopify/${type}/${id}`;
-}

--- a/src/node-query.js
+++ b/src/node-query.js
@@ -1,9 +1,8 @@
 import addFields from './add-fields';
-import createGid from './create-gid';
 
 export default function nodeQuery(type, fields) {
   return function(parentSelection, fieldName, id) {
-    parentSelection.add(fieldName, {args: {id: createGid(type, id)}}, (node) => {
+    parentSelection.add(fieldName, {args: {id}}, (node) => {
       node.addInlineFragmentOn(type, (product) => {
         addFields(product, fields);
       });

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -29,6 +29,7 @@ import collectionNodeQuery from '../src/collection-node-query';
 import checkoutFixture from '../fixtures/checkout-fixture';
 import checkoutCreateFixture from '../fixtures/checkout-create-fixture';
 import checkoutWithPaginatedLineItemsFixture from '../fixtures/checkout-with-paginated-line-items-fixture';
+import checkoutCreateWithPaginatedLineItemsFixture from '../fixtures/checkout-create-with-paginated-line-items-fixture';
 import {secondPageLineItemsFixture, thirdPageLineItemsFixture} from '../fixtures/paginated-line-items-fixture';
 import checkoutLineItemsAddFixture from '../fixtures/checkout-line-items-add-fixture';
 import shopInfoFixture from '../fixtures/shop-info-fixture';
@@ -126,9 +127,9 @@ suite('client-test', () => {
 
     fetchMock.postOnce('https://single-product.myshopify.com/api/graphql', singleProductFixture);
 
-    return client.fetchProduct('7857989384').then((product) => {
+    return client.fetchProduct('Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=').then((product) => {
       assert.ok(Array.isArray(product) === false, 'product is not an array');
-      assert.equal(product.id, singleProductFixture.data.node.id);
+      assert.equal(product.id, 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=');
       assert.ok(fetchMock.done());
     });
   });
@@ -166,9 +167,9 @@ suite('client-test', () => {
 
     fetchMock.postOnce('https://single-collection.myshopify.com/api/graphql', singleCollectionFixture);
 
-    return client.fetchCollection('369312584').then((collection) => {
+    return client.fetchCollection('Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=').then((collection) => {
       assert.ok(Array.isArray(collection) === false, 'collection is not an array');
-      assert.equal(collection.id, singleCollectionFixture.data.node.id);
+      assert.equal(collection.id, 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=');
       assert.ok(fetchMock.done());
     });
   });
@@ -185,7 +186,7 @@ suite('client-test', () => {
 
     const queryFields = ['id', 'handle', 'title', 'updatedAt', ['images', imageConnectionQuery(['id', 'src'])], ['options', optionQuery(['name'])], ['variants', variantConnectionQuery(['price', 'weight'])]];
 
-    return client.fetchProduct('7857989384', productNodeQuery(queryFields)).then((product) => {
+    return client.fetchProduct('Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=', productNodeQuery(queryFields)).then((product) => {
       assert.ok(Array.isArray(product) === false, 'product is not an array');
       assert.equal(product.id, dynamicProductFixture.data.node.id);
       assert.equal(typeof product.createdAt, 'undefined', 'unspecified fields are not queried');
@@ -203,10 +204,10 @@ suite('client-test', () => {
 
     fetchMock.postOnce('https://dynamic-collection-fields.myshopify.com/api/graphql', dynamicCollectionFixture);
 
-    return client.fetchCollection('369312584', collectionNodeQuery(['title', 'updatedAt', ['image', imageQuery(['src'])]])).then((collection) => {
+    return client.fetchCollection('Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=', collectionNodeQuery(['title', 'updatedAt', ['image', imageQuery(['src'])]])).then((collection) => {
       assert.ok(Array.isArray(collection) === false, 'collection is not an array');
       assert.equal(collection.updatedAt, dynamicCollectionFixture.data.node.updatedAt);
-      assert.equal(typeof collection.id, 'undefined', 'unspecified fields are not queried');
+      assert.equal(typeof collection.createdAt, 'undefined', 'unspecified fields are not queried');
       assert.ok(fetchMock.done());
     });
   });
@@ -269,7 +270,7 @@ suite('client-test', () => {
 
     const client = new Client(config);
 
-    fetchMock.postOnce('https://no-pagination.myshopify.com/api/graphql', {data: {node: {id: 'gid://shopify/Product/7857989384'}}});
+    fetchMock.postOnce('https://no-pagination.myshopify.com/api/graphql', {data: {node: {id: 'Z2lkOi8vc2hvcGlmeS9Db2xsZWN0aW9uLzM2OTMxMjU4NA=='}}});
 
     return client.fetchProduct('7857989384', productNodeQuery(['id'])).then((product) => {
       assert.equal(typeof product.images, 'undefined', 'images are not queried');
@@ -465,7 +466,7 @@ suite('client-test', () => {
 
     const input = {
       lineItems: [
-        {variantId: 'gid://shopify/ProductVariant/1', quantity: 5, customAttributes: [{key: 'hi', value: 'bye'}]}
+        {variantId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==', quantity: 5, customAttributes: [{key: 'hi', value: 'bye'}]}
       ],
       shippingAddress: {
         address1: '123 Cat Road',
@@ -491,7 +492,7 @@ suite('client-test', () => {
     });
   });
 
-  test('it fetches all paginated line items on the checkout', () => {
+  test('it fetches all paginated line items on the checkout on a mutation', () => {
     const config = new Config({
       domain: 'paginated-checkout.myshopify.com',
       storefrontAccessToken: 'abc123'
@@ -501,19 +502,40 @@ suite('client-test', () => {
 
     const input = {
       lineItems: [
-        {variantId: 'gid://shopify/ProductVariant/1', quantity: 5, customAttributes: [{key: 'hi', value: 'bye'}]},
-        {variantId: 'gid://shopify/ProductVariant/2', quantity: 10, customAttributes: [{key: 'bye', value: 'hi'}]},
-        {variantId: 'gid://shopify/ProductVariant/3', quantity: 15, customAttributes: [{key: 'bing', value: 'bong'}]}
+        {variantId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==', quantity: 5, customAttributes: [{key: 'hi', value: 'bye'}]},
+        {variantId: 'ZNc0vnIOijnJabh4873nNQnfb9B0QhnFyvk9Wfh87oNBeqBHGQNA5a==', quantity: 10, customAttributes: [{key: 'bye', value: 'hi'}]},
+        {variantId: 'Zad7JHnbf32JHna087juBQn8faB84Ba28VnqjF87Qynaw8MnDhNA3W==', quantity: 15, customAttributes: [{key: 'bing', value: 'bong'}]}
       ]
     };
 
-    fetchMock.postOnce('https://paginated-checkout.myshopify.com/api/graphql', checkoutWithPaginatedLineItemsFixture)
+    fetchMock.postOnce('https://paginated-checkout.myshopify.com/api/graphql', checkoutCreateWithPaginatedLineItemsFixture)
       .postOnce('https://paginated-checkout.myshopify.com/api/graphql', secondPageLineItemsFixture)
       .postOnce('https://paginated-checkout.myshopify.com/api/graphql', thirdPageLineItemsFixture);
 
     return client.createCheckout(input).then((checkout) => {
       assert.equal(checkout.lineItems.length, 3, 'all three pages of line items are returned');
-      assert.equal(checkout.lineItems[0].variant.id, checkoutWithPaginatedLineItemsFixture.data.checkoutCreate.checkout.lineItems.edges[0].node.variant.id);
+      assert.equal(checkout.lineItems[0].variant.id, checkoutCreateWithPaginatedLineItemsFixture.data.checkoutCreate.checkout.lineItems.edges[0].node.variant.id);
+      assert.equal(checkout.lineItems[1].variant.id, secondPageLineItemsFixture.data.node.lineItems.edges[0].node.variant.id);
+      assert.equal(checkout.lineItems[2].variant.id, thirdPageLineItemsFixture.data.node.lineItems.edges[0].node.variant.id);
+      assert.ok(fetchMock.done());
+    });
+  });
+
+  test('it fetches all paginated line items on the checkout', () => {
+    const config = new Config({
+      domain: 'paginated-checkout.myshopify.com',
+      storefrontAccessToken: 'abc123'
+    });
+
+    const client = new Client(config);
+
+    fetchMock.postOnce('https://paginated-checkout.myshopify.com/api/graphql', checkoutWithPaginatedLineItemsFixture)
+      .postOnce('https://paginated-checkout.myshopify.com/api/graphql', secondPageLineItemsFixture)
+      .postOnce('https://paginated-checkout.myshopify.com/api/graphql', thirdPageLineItemsFixture);
+
+    return client.fetchCheckout('Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=').then((checkout) => {
+      assert.equal(checkout.lineItems.length, 3, 'all three pages of line items are returned');
+      assert.equal(checkout.lineItems[0].variant.id, checkoutWithPaginatedLineItemsFixture.data.node.lineItems.edges[0].node.variant.id);
       assert.equal(checkout.lineItems[1].variant.id, secondPageLineItemsFixture.data.node.lineItems.edges[0].node.variant.id);
       assert.equal(checkout.lineItems[2].variant.id, thirdPageLineItemsFixture.data.node.lineItems.edges[0].node.variant.id);
       assert.ok(fetchMock.done());
@@ -528,19 +550,19 @@ suite('client-test', () => {
 
     const client = new Client(config);
 
-    const checkoutId = 'gid://shopify/Checkout/89427726abd2543894550baae32065d6';
+    const checkoutId = 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=';
     const lineItems = [
-      {variantId: 'gid://shopify/ProductVariant/2', quantity: 5, customAttributes: [{key: 'hi', value: 'bye'}]},
-      {variantId: 'gid://shopify/ProductVariant/3', quantity: 5}
+      {variantId: 'ZNc0vnIOijnJabh4873nNQnfb9B0QhnFyvk9Wfh87oNBeqBHGQNA5a==', quantity: 5, customAttributes: [{key: 'hi', value: 'bye'}]},
+      {variantId: 'Zad7JHnbf32JHna087juBQn8faB84Ba28VnqjF87Qynaw8MnDhNA3W==', quantity: 5}
     ];
 
     fetchMock.postOnce('https://add-line-items.myshopify.com/api/graphql', checkoutLineItemsAddFixture);
 
     return client.addLineItems(checkoutId, lineItems).then((checkout) => {
       assert.equal(checkout.lineItems.length, 3, 'two more line items were added');
-      assert.equal(checkout.id, 'gid://shopify/Checkout/89427726abd2543894550baae32065d6');
-      assert.equal(checkout.lineItems[1].variant.id, 'gid://shopify/ProductVariant/2');
-      assert.equal(checkout.lineItems[2].variant.id, 'gid://shopify/ProductVariant/3');
+      assert.equal(checkout.id, 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=');
+      assert.equal(checkout.lineItems[1].variant.id, 'ZNc0vnIOijnJabh4873nNQnfb9B0QhnFyvk9Wfh87oNBeqBHGQNA5a==');
+      assert.equal(checkout.lineItems[2].variant.id, 'Zad7JHnbf32JHna087juBQn8faB84Ba28VnqjF87Qynaw8MnDhNA3W==');
       assert.ok(fetchMock.done());
     });
   });
@@ -573,7 +595,7 @@ suite('client-test', () => {
 
     const input = {
       lineItems: [
-        {variantId: 'gid://shopify/ProductVariant/1234', quantity: 5}
+        {variantId: 'invalidId', quantity: 5}
       ]
     };
 
@@ -631,7 +653,7 @@ suite('client-test', () => {
 
     fetchMock.postOnce('https://checkout.myshopify.com/api/graphql', checkoutFixture);
 
-    return client.fetchCheckout('7857989384').then((checkout) => {
+    return client.fetchCheckout('Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=').then((checkout) => {
       assert.equal(checkout.id, checkoutFixture.data.node.id);
       assert.ok(fetchMock.done());
     });
@@ -647,12 +669,12 @@ suite('client-test', () => {
 
     fetchMock.postOnce('https://remove-line-items.myshopify.com/api/graphql', checkoutLineItemsRemoveFixture);
 
-    const checkoutId = 'gid://shopify/Checkout/dcf154c3feb78e585b9e88571cc383fa';
-    const lineItemIds = ['gid://shopify/CheckoutLineItem/04f496222dd7fa7c01e3626a22d73094?checkout=dcf154c3feb78e585b9e88571cc383fa'];
+    const checkoutId = 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=';
+    const lineItemIds = ['zUzNzQ1ZjU0OTVlZjIyYzIxYzVkZj9rZXk9MTlkMjljZDgwYjg3MGMxNmRmNjNjM2JjODUzYjY3MTY='];
 
     return client.removeLineItems(checkoutId, lineItemIds).then((checkout) => {
       assert.equal(checkout.lineItems.some((lineItem) => {
-        return lineItem.id === 'gid://shopify/CheckoutLineItem/04f496222dd7fa7c01e3626a22d73094?checkout=dcf154c3feb78e585b9e88571cc383fa';
+        return lineItem.id === 'zUzNzQ1ZjU0OTVlZjIyYzIxYzVkZj9rZXk9MTlkMjljZDgwYjg3MGMxNmRmNjNjM2JjODUzYjY3MTY=';
       }), false, 'the line item is removed');
     });
   });
@@ -733,19 +755,19 @@ suite('client-test', () => {
 
     fetchMock.postOnce('https://update-line-items.myshopify.com/api/graphql', checkoutLineItemsUpdateFixture);
 
-    const checkoutId = 'gid://shopify/Checkout/e28b55a3205f8d129a9b7223287ec95a?key=191add76e8eba90b93cfe4d5d261c4cb';
+    const checkoutId = 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=';
     const lineItems = [
       {
-        id: 'gid://shopify/CheckoutLineItem/fb71102f0d38de46e037b30f817e9db5?checkout=e28b55a3205f8d129a9b7223287ec95a',
+        id: 'zUzNzQ1ZjU0OTVlZjIyYzIxYzVkZj9rZXk9MTlkMjljZDgwYjg3MGMxNmRmNjNjM2JjODUzYjY3MTY=',
         quantity: 2,
-        variantId: 'gid://shopify/ProductVariant/36607672003'
+        variantId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA=='
       }
     ];
 
     return client.updateLineItems(checkoutId, lineItems).then((checkout) => {
       assert.equal(checkout.lineItems[0].id, checkoutLineItemsUpdateFixture.data.checkoutLineItemsUpdate.checkout.lineItems.edges[0].node.id);
       assert.equal(checkout.lineItems[0].quantity, 2);
-      assert.equal(checkout.lineItems[0].variant.id, 'gid://shopify/ProductVariant/36607672003');
+      assert.equal(checkout.lineItems[0].variant.id, 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==');
     });
   });
 

--- a/test/product-helpers-test.js
+++ b/test/product-helpers-test.js
@@ -9,14 +9,14 @@ suite('product-helpers-test', () => {
   const query = productNodeQuery();
   const graphQLClient = new GraphQLJSClient(types, {url: 'https://sendmecats.myshopify.com/api/graphql'});
   const rootQuery = graphQLClient.query((root) => {
-    query(root, 'node', '7857989384');
+    query(root, 'node', 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=');
   });
   const productModel = decode(rootQuery, singleProductFixture.data);
 
   test('it returns the variant based on options given', () => {
     const variant = productHelpers.variantForOptions(productModel.node, {Fur: 'Fluffy', Size: 'Medium'});
 
-    assert.equal(variant.id, 'gid://shopify/ProductVariant/25602235976');
+    assert.equal(variant.id, 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=');
   });
 
   test('it returns undefined if the variant does not exist', () => {

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -247,11 +247,11 @@ suite('query-test', () => {
   test('it can create a nested product connection query', () => {
     const customQuery = collectionNodeQuery([['products', productConnectionQuery()]]);
     const query = client.graphQLClient.query((root) => {
-      customQuery(root, 'node', '1');
+      customQuery(root, 'node', 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjAxNDMwNDE4NjQ=');
     });
 
     const queryString = `query {
-      node (id: "gid://shopify/Collection/1") {
+      node (id: "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjAxNDMwNDE4NjQ=") {
         __typename,
         ... on Collection {
           id,products (first: 20) {
@@ -329,7 +329,7 @@ suite('query-test', () => {
     const defaultQuery = checkoutQuery();
     const input = {
       lineItems: [
-        {variantId: 'gid://shopify/ProductVariant/1', quantity: 5}
+        {variantId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjAxNDMwNDE4NjQ=', quantity: 5}
       ]
     };
     const query = client.graphQLClient.mutation((root) => {
@@ -339,7 +339,7 @@ suite('query-test', () => {
     });
 
     const queryString = `mutation {
-      checkoutCreate (input: {lineItems: [{variantId: "gid://shopify/ProductVariant/1", quantity: 5}]}) {
+      checkoutCreate (input: {lineItems: [{variantId: "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjAxNDMwNDE4NjQ=", quantity: 5}]}) {
         checkout {
           id
           ready
@@ -500,7 +500,7 @@ suite('query-test', () => {
       ['lineItems', lineItemConnectionQuery(['title', ['customAttributes', customAttributeQuery(['value'])]])]]);
     const input = {
       lineItems: [
-        {variantId: 'gid://shopify/ProductVariant/1', quantity: 5}
+        {variantId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjAxNDMwNDE4NjQ=', quantity: 5}
       ]
     };
     const query = client.graphQLClient.mutation((root) => {
@@ -510,7 +510,7 @@ suite('query-test', () => {
     });
 
     const queryString = `mutation {
-      checkoutCreate (input: {lineItems: [{variantId: "gid://shopify/ProductVariant/1" quantity: 5}]}) {
+      checkoutCreate (input: {lineItems: [{variantId: "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjAxNDMwNDE4NjQ=" quantity: 5}]}) {
         checkout {
           id
           createdAt


### PR DESCRIPTION
- Updated all fixtures and tests to use opaque ids
- Also noticed that pagination wasn't on `fetchCheckout` so I just quickly added it in. Works the same way as the pagination on the checkout mutations (see https://github.com/Shopify/js-buy-sdk/compare/v1.0alpha...opaque-ids?expand=1#diff-cf27c1d543e886c89cd9ac8b8aeaf05bR364)