### PR TITLE
Remove app id from product listings path

### DIFF
--- a/src/adapters/listings-adapter.js
+++ b/src/adapters/listings-adapter.js
@@ -15,9 +15,9 @@ const ListingsAdapter = CoreObject.extend({
   },
 
   get baseUrl() {
-    const { domain, appId } = this.config;
+    const { domain } = this.config;
 
-    return `https://${domain}/api/apps/${appId}`;
+    return `https://${domain}/api`;
   },
 
   get headers() {

--- a/tests/integration/shop-client-fetch-collection-test.js
+++ b/tests/integration/shop-client-fetch-collection-test.js
@@ -12,7 +12,7 @@ const configAttrs = {
 
 const config = new Config(configAttrs);
 
-const baseUrl = `https://${configAttrs.domain}/api/apps/${configAttrs.appId}`;
+const baseUrl = `https://${configAttrs.domain}/api`;
 
 function apiUrl(path) {
   return `${baseUrl}${path}`;

--- a/tests/integration/shop-client-fetch-product-test.js
+++ b/tests/integration/shop-client-fetch-product-test.js
@@ -12,7 +12,7 @@ const configAttrs = {
 
 const config = new Config(configAttrs);
 
-const baseUrl = `https://${configAttrs.domain}/api/apps/${configAttrs.appId}`;
+const baseUrl = `https://${configAttrs.domain}/api`;
 
 function apiUrl(path) {
   return `${baseUrl}${path}`;

--- a/tests/unit/adapters/listings-adapter-test.js
+++ b/tests/unit/adapters/listings-adapter-test.js
@@ -6,7 +6,7 @@ let adapter;
 
 const appId = 6;
 const domain = 'buckets-o-stuff.myshopify.com';
-const baseUrl = `https://${domain}/api/apps/${appId}`;
+const baseUrl = `https://${domain}/api`;
 const accessToken = 'abc123def456ghi';
 const base64AccessToken = btoa(accessToken);
 
@@ -39,7 +39,7 @@ test('it builds auth headers using the base64 encoded api key', function (assert
   adapter.config = {
     accessToken,
     ajaxHeaders: {
-      'test': 'test-string'
+      test: 'test-string'
     }
   };
 
@@ -48,7 +48,7 @@ test('it builds auth headers using the base64 encoded api key', function (assert
     'Content-Type': 'application/json',
     'X-SDK-Variant': 'javascript',
     'X-SDK-Version': version,
-    'test': 'test-string'
+    test: 'test-string'
   });
 });
 


### PR DESCRIPTION
This changes the listings path from `/api/apps/<id>/product_listings` to `/api/product_listings`, since the access token should tell us everything we need to know to resolve an app scope.

The app id is still necessary for know to differentiate local storage carts, in case someone has an implementation from two apps and the same shop on one page (not likely, but it's guarded against for now).