### PR TITLE
fix imageForSize to handle urls without query params

### DIFF
--- a/src/image-helpers.js
+++ b/src/image-helpers.js
@@ -16,7 +16,9 @@ export default {
    * @return {String} The image src for the resized image.
    */
   imageForSize(image, {maxHeight, maxWidth}) {
-    const [notQuery, query] = image.src.split('?');
+    const splitUrl = image.src.split('?');
+    const notQuery = splitUrl[0];
+    const query = splitUrl[1] ? `?${splitUrl[1]}` : '';
 
     // Use the section before the query
     const imageTokens = notQuery.split('.');
@@ -26,6 +28,6 @@ export default {
 
     imageTokens[imagePathIndex] = `${imageTokens[imagePathIndex]}_${maxHeight}x${maxWidth}`;
 
-    return `${imageTokens.join('.')}?${query}`;
+    return `${imageTokens.join('.')}${query}`;
   }
 };

--- a/test/image-helpers-test.js
+++ b/test/image-helpers-test.js
@@ -8,6 +8,12 @@ suite('image-helpers-test', () => {
     assert.equal(resizedImageSrc, 'https://cdn.shopify.com/s/files/1/1510/7238/products/cat_30x30.jpg?v=1489515038');
   });
 
+  test('it returns the correct url for an image without any url params', () => {
+    const resizedImageSrc = imageHelpers.imageForSize({src: 'https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg'}, {maxWidth: 30, maxHeight: 30});
+
+    assert.equal(resizedImageSrc, 'https://cdn.shopify.com/s/files/1/1510/7238/products/cat_30x30.jpg');
+  });
+
   test('it returns the correct url for filenames with .', () => {
     const resizedImageSrc = imageHelpers.imageForSize({src: 'https://cdn.shopify.com/s/files/1/1510/7238/products/cat.really.big.jpg?v=1489515038'}, {maxWidth: 30, maxHeight: 30});
 


### PR DESCRIPTION
using imageForSize would previously return `test.com/images/photo_200x200.jpg?undefined` if the original image url didn't include query params (`?`) 