### PR TITLE
add availability to variants

### DIFF
--- a/src/variant-query.js
+++ b/src/variant-query.js
@@ -7,6 +7,7 @@ export const defaultFields = [
   'title',
   'price',
   'weight',
+  'available',
   ['image', imageQuery()],
   ['selectedOptions', selectedOptionQuery()]
 ];
@@ -26,6 +27,7 @@ export const defaultFields = [
  *     <li>`'title'`</li>
  *     <li>`'price'`</li>
  *     <li>`'weight'`</li>
+ *     <li>`'available'`</li>
  *     <li>`['image', imageQuery()]`</li>
  *     <li>`['selectedOptions', selectedOptionQuery()]`</li>
  *   </ul>

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -91,6 +91,7 @@ suite('query-test', () => {
                     title,
                     price,
                     weight,
+                    available,
                     image {
                       id,
                       src,
@@ -303,6 +304,7 @@ suite('query-test', () => {
                       title,
                       price,
                       weight,
+                      available,
                       image {
                         id,
                         src,
@@ -358,6 +360,7 @@ suite('query-test', () => {
                   title
                   price
                   weight
+                  available
                   image {
                     id
                     src
@@ -458,6 +461,7 @@ suite('query-test', () => {
                     title
                     price
                     weight
+                    available
                     image {
                       id
                       src


### PR DESCRIPTION
variant query was previously missing the `available` field.

i've tested the change through buy-button-js