### PR TITLE
Examples: update build URL

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -236,7 +236,7 @@ function closeCart() {
 <!-- .cart end -->
 
 
-<script src="http://sdks.shopifycdn.com/js-buy-sdk/latest/shopify-buy.polyfilled.globals.min.js"></script>
+<script src="http://sdks.shopifycdn.com/js-buy-sdk/v0/latest/shopify-buy.umd.polyfilled.min.js"></script>
 <script src="../assets/scripts/addToCart.js"></script>
 
 


### PR DESCRIPTION
The previously URL was outdated and no longer exists for new builds.

https://github.com/Shopify/js-buy-sdk/pull/361 broke the docs when it was merged because it was using a new config key that didn't exist in the old version.