### PR TITLE
bump graphql js client version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "fb-watchman": "1.9.0",
     "fetch-mock": "5.8.1",
     "fs-extra": "1.0.0",
-    "graphql-js-client": "0.4.2",
+    "graphql-js-client": "0.6.2",
     "graphql-js-schema": "0.6.0",
     "graphql-js-schema-fetch": "1.1.2",
     "http-server": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "fb-watchman": "1.9.0",
     "fetch-mock": "5.8.1",
     "fs-extra": "1.0.0",
-    "graphql-js-client": "0.6.2",
+    "graphql-js-client": "0.6.3",
     "graphql-js-schema": "0.6.0",
     "graphql-js-schema-fetch": "1.1.2",
     "http-server": "0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2646,9 +2646,9 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, 
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-graphql-js-client@0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/graphql-js-client/-/graphql-js-client-0.4.2.tgz#a5854df801a3447f7035bb0108b81322e324107f"
+graphql-js-client@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/graphql-js-client/-/graphql-js-client-0.6.3.tgz#0fa8a286db91c8dd7812a66230467470d5f19e1a"
 
 graphql-js-schema-fetch@1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Need support from the latest version of `graphql-js-client` to continue work on `buy-button-js`