### PR TITLE
Replace addVariants with createLineItemsFromVariants because its deprecated

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -100,11 +100,11 @@ shopClient.createCart().then(function (newCart) {
 ### Adding items to a cart
 
 Cart items can be retrieved as an array with the `cart.lineItems` getter. To add items to a cart,
-you can call the cart’s `addVariants` method and pass in the product(s) to be added.
+you can call the cart’s `createLineItemsFromVariants` method and pass in the product(s) to be added.
 The `update` call will return a promise which returns the updated model.
 
 ```js
-cart.addVariants({variant: product.selectedVariant, quantity: 1}).then(function (cart) {
+cart.createLineItemsFromVariants({variant: product.selectedVariant, quantity: 1}).then(function (cart) {
   // do something with updated cart
 });
 ```


### PR DESCRIPTION
I just followed the Getting started and the following error message comes up:
`[JS-BUY-SDK]:  CartModel -  addVariants is deprecated, please use createLineItemsFromVariants instead`

So the Getting started includes an deprecated version. I replaced it by `addVariants`.