### PR TITLE
backwards compatibility support for old client configuration

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -61,6 +61,7 @@ The JS Buy SDK Client.
             * [.shopPolicyQuery([fields])](#Client.Queries.shopPolicyQuery)
             * [.variantConnectionQuery([fields])](#Client.Queries.variantConnectionQuery)
             * [.variantQuery([fields])](#Client.Queries.variantQuery)
+        * [.buildClient()](#Client.buildClient)
 
 <a name="new_Client_new"></a>
 
@@ -761,6 +762,12 @@ Use this when fetching a single variant.
 ```js
 const query = variantQuery(['id', 'src']);
 ```
+<a name="Client.buildClient"></a>
+
+### Client.buildClient()
+Primary entry point for building a new Client.
+
+**Kind**: static method of [<code>Client</code>](#Client)  
 <a name="Config"></a>
 
 ## Config

--- a/src/client.js
+++ b/src/client.js
@@ -65,6 +65,14 @@ function fetchResourcesForProducts(products, client) {
   }, []);
 }
 
+function adaptConfig(config) {
+  const accessToken = config.storefrontAccessToken || config.apiKey;
+  return new Config({
+    domain: config.domain,
+    storefrontAccessToken: accessToken,
+  });
+}
+
 /**
  * The JS Buy SDK Client.
  * @class
@@ -115,6 +123,14 @@ class Client {
       variantQuery,
       checkoutNodeQuery
     };
+  }
+
+  /**
+   * A wrapper around the constructor, for backwards compatability.
+   */
+  static buildClient(config) {
+    const newConfig = adaptConfig(config);
+    return new Client(newConfig);
   }
 
   /**

--- a/src/client.js
+++ b/src/client.js
@@ -66,8 +66,11 @@ function fetchResourcesForProducts(products, client) {
   }, []);
 }
 
-function adaptConfig(config) {
-  const accessToken = config.accessToken || config.apiKey;
+function normalizeAccessToken(config) {
+  if (config.accessToken) {
+    console.warn("[ShopifyBuy] accessToken is deprecated as of v1.0, please use storefrontAccessToken instead.")
+  }
+  const accessToken = config.storefrontAccessToken || config.accessToken;
 
   return new Config({
     domain: config.domain,
@@ -131,7 +134,7 @@ class Client {
    * A wrapper around the constructor, for backwards compatability.
    */
   static buildClient(config) {
-    const newConfig = adaptConfig(config);
+    const newConfig = normalizeAccessToken(config);
 
     return new Client(newConfig);
   }

--- a/src/client.js
+++ b/src/client.js
@@ -119,7 +119,8 @@ class Client {
   }
 
   /**
-   * A wrapper around the constructor, for backwards compatability.
+   * Primary entry point for building a new Client.
+   * @namespace
    */
   static buildClient(config) {
     const newConfig = new Config(config);

--- a/src/client.js
+++ b/src/client.js
@@ -1,4 +1,5 @@
 import GraphQLJSClient from './graphql-client';
+import Config from './config';
 import types from '../types';
 import productNodeQuery from './product-node-query';
 import productConnectionQuery from './product-connection-query';
@@ -66,10 +67,11 @@ function fetchResourcesForProducts(products, client) {
 }
 
 function adaptConfig(config) {
-  const accessToken = config.storefrontAccessToken || config.apiKey;
+  const accessToken = config.accessToken || config.apiKey;
+
   return new Config({
     domain: config.domain,
-    storefrontAccessToken: accessToken,
+    storefrontAccessToken: accessToken
   });
 }
 
@@ -130,6 +132,7 @@ class Client {
    */
   static buildClient(config) {
     const newConfig = adaptConfig(config);
+
     return new Client(newConfig);
   }
 

--- a/src/client.js
+++ b/src/client.js
@@ -66,18 +66,6 @@ function fetchResourcesForProducts(products, client) {
   }, []);
 }
 
-function normalizeAccessToken(config) {
-  if (config.accessToken) {
-    console.warn("[ShopifyBuy] accessToken is deprecated as of v1.0, please use storefrontAccessToken instead.")
-  }
-  const accessToken = config.storefrontAccessToken || config.accessToken;
-
-  return new Config({
-    domain: config.domain,
-    storefrontAccessToken: accessToken
-  });
-}
-
 /**
  * The JS Buy SDK Client.
  * @class
@@ -134,7 +122,7 @@ class Client {
    * A wrapper around the constructor, for backwards compatability.
    */
   static buildClient(config) {
-    const newConfig = normalizeAccessToken(config);
+    const newConfig = new Config(config);
 
     return new Client(newConfig);
   }

--- a/src/client.js
+++ b/src/client.js
@@ -120,7 +120,6 @@ class Client {
 
   /**
    * Primary entry point for building a new Client.
-   * @namespace
    */
   static buildClient(config) {
     const newConfig = new Config(config);

--- a/src/config.js
+++ b/src/config.js
@@ -29,7 +29,7 @@ class Config {
       if (attrs.hasOwnProperty(key)) {
         this[key] = attrs[key];
       } else if (key === 'accessToken') {
-        // eslint-disable-next-line
+        // eslint-disable-next-line no-console
         console.warn('[ShopifyBuy] accessToken is deprecated as of v1.0, please use storefrontAccessToken instead.');
         this.storefrontAccessToken = attrs.accessToken;
       } else {

--- a/src/config.js
+++ b/src/config.js
@@ -1,12 +1,3 @@
-
-function normalizeAccessToken(config) {
-  // eslint-disable-next-line
-  console.warn('[ShopifyBuy] accessToken is deprecated as of v1.0, please use storefrontAccessToken instead.');
-  const accessToken = config.storefrontAccessToken || config.accessToken;
-
-  return accessToken;
-}
-
 /**
  * The class used to configure the JS Buy SDK Client.
  * @class
@@ -38,7 +29,9 @@ class Config {
       if (attrs.hasOwnProperty(key)) {
         this[key] = attrs[key];
       } else if (key === 'accessToken') {
-        this.storefrontAccessToken = normalizeAccessToken(attrs);
+        // eslint-disable-next-line
+        console.warn('[ShopifyBuy] accessToken is deprecated as of v1.0, please use storefrontAccessToken instead.');
+        this.storefrontAccessToken = attrs.accessToken;
       } else {
         throw new Error(`new Config() requires the option '${key}'`);
       }

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,12 @@
+
+function normalizeAccessToken(config) {
+  // eslint-disable-next-line
+  console.warn('[ShopifyBuy] accessToken is deprecated as of v1.0, please use storefrontAccessToken instead.');
+  const accessToken = config.storefrontAccessToken || config.accessToken;
+
+  return accessToken;
+}
+
 /**
  * The class used to configure the JS Buy SDK Client.
  * @class
@@ -28,6 +37,8 @@ class Config {
     this.requiredProperties.forEach((key) => {
       if (attrs.hasOwnProperty(key)) {
         this[key] = attrs[key];
+      } else if (key === 'accessToken') {
+        this.storefrontAccessToken = normalizeAccessToken(attrs);
       } else {
         throw new Error(`new Config() requires the option '${key}'`);
       }


### PR DESCRIPTION
in the context of buy-button-js: the previous config process was to call `ShopifyBuy.buildClient(config)`. the current 1.0 version no longer has that method, and asks you to create an instance of ShopifyBuy with the config passed to the constructor instead. 

I've created a `.buildClient` wrapper method which adapts the old configuration object {apiKey, domain, appId}, to the new `Config` object {domain, storefrontAccessToken}. Further changes need to be made in buy-button-js in order to keep existing buy button embeds alive as well, which are linked in the buy-button-js PR below.