### PR TITLE
reverse order of maxHeight and maxWidth in generated url

### DIFF
--- a/src/image-helpers.js
+++ b/src/image-helpers.js
@@ -11,11 +11,11 @@ export default {
    * @method imageForSize
    * @param {Object} image The original image model to generate the image src for.
    * @param {Object} options An options object containing:
-   *  @param {Integer} options.maxHeight The maximum height for the image.
    *  @param {Integer} options.maxWidth The maximum width for the image.
+   *  @param {Integer} options.maxHeight The maximum height for the image.
    * @return {String} The image src for the resized image.
    */
-  imageForSize(image, {maxHeight, maxWidth}) {
+  imageForSize(image, {maxWidth, maxHeight}) {
     const splitUrl = image.src.split('?');
     const notQuery = splitUrl[0];
     const query = splitUrl[1] ? `?${splitUrl[1]}` : '';
@@ -26,7 +26,7 @@ export default {
     // Take the token before the file extension and append the dimensions
     const imagePathIndex = imageTokens.length - 2;
 
-    imageTokens[imagePathIndex] = `${imageTokens[imagePathIndex]}_${maxHeight}x${maxWidth}`;
+    imageTokens[imagePathIndex] = `${imageTokens[imagePathIndex]}_${maxWidth}x${maxHeight}`;
 
     return `${imageTokens.join('.')}${query}`;
   }

--- a/test/image-helpers-test.js
+++ b/test/image-helpers-test.js
@@ -3,26 +3,26 @@ import imageHelpers from '../src/image-helpers';
 
 suite('image-helpers-test', () => {
   test('it returns the image src with the specified width and height', () => {
-    const resizedImageSrc = imageHelpers.imageForSize({src: 'https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038'}, {maxWidth: 30, maxHeight: 30});
+    const resizedImageSrc = imageHelpers.imageForSize({src: 'https://cdn.shopify.com/s/files/1/1019/0495/products/babyandco5.jpg?v=1487171332'}, {maxWidth: 280, maxHeight: 560});
 
-    assert.equal(resizedImageSrc, 'https://cdn.shopify.com/s/files/1/1510/7238/products/cat_30x30.jpg?v=1489515038');
+    assert.equal(resizedImageSrc, 'https://cdn.shopify.com/s/files/1/1019/0495/products/babyandco5_280x560.jpg?v=1487171332');
   });
 
   test('it returns the correct url for an image without any url params', () => {
-    const resizedImageSrc = imageHelpers.imageForSize({src: 'https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg'}, {maxWidth: 30, maxHeight: 30});
+    const resizedImageSrc = imageHelpers.imageForSize({src: 'https://cdn.shopify.com/s/files/1/1019/0495/products/babyandco5.jpg'}, {maxWidth: 280, maxHeight: 560});
 
-    assert.equal(resizedImageSrc, 'https://cdn.shopify.com/s/files/1/1510/7238/products/cat_30x30.jpg');
+    assert.equal(resizedImageSrc, 'https://cdn.shopify.com/s/files/1/1019/0495/products/babyandco5_280x560.jpg');
   });
 
   test('it returns the correct url for filenames with .', () => {
-    const resizedImageSrc = imageHelpers.imageForSize({src: 'https://cdn.shopify.com/s/files/1/1510/7238/products/cat.really.big.jpg?v=1489515038'}, {maxWidth: 30, maxHeight: 30});
+    const resizedImageSrc = imageHelpers.imageForSize({src: 'https://cdn.shopify.com/s/files/1/1019/0495/products/Ashley.34.51031.test.jpg?v=1505141764'}, {maxWidth: 280, maxHeight: 560});
 
-    assert.equal(resizedImageSrc, 'https://cdn.shopify.com/s/files/1/1510/7238/products/cat.really.big_30x30.jpg?v=1489515038');
+    assert.equal(resizedImageSrc, 'https://cdn.shopify.com/s/files/1/1019/0495/products/Ashley.34.51031.test_280x560.jpg?v=1505141764');
   });
 
   test('it returns the correct url for an image src with . in the query param', () => {
-    const resizedImageSrc = imageHelpers.imageForSize({src: 'https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1.489.51.5038'}, {maxWidth: 30, maxHeight: 30});
+    const resizedImageSrc = imageHelpers.imageForSize({src: 'https://cdn.shopify.com/s/files/1/1019/0495/products/babyandco5.jpg?v=148.71713.32'}, {maxWidth: 280, maxHeight: 560});
 
-    assert.equal(resizedImageSrc, 'https://cdn.shopify.com/s/files/1/1510/7238/products/cat_30x30.jpg?v=1.489.51.5038');
+    assert.equal(resizedImageSrc, 'https://cdn.shopify.com/s/files/1/1019/0495/products/babyandco5_280x560.jpg?v=148.71713.32');
   });
 });


### PR DESCRIPTION
`maxHeight` and `maxWidth` order was incorrect in the generated URL. This PR fixes the ordering, and associated ordering details for consistency. 

Updated the tests to use a non-square image to better ensure order of height+width values in generated URL. Also switched to use the `embeds` shop for consistency.