### PR TITLE
Take methods off the top level and move into resources

### DIFF
--- a/src/checkout-resource.js
+++ b/src/checkout-resource.js
@@ -1,0 +1,139 @@
+import Resource from './resource';
+import defaultResolver from './default-resolver';
+import handleCheckoutMutation from './handle-checkout-mutation';
+
+// GraphQL
+import checkoutNodeQuery from './graphql/checkoutNodeQuery.graphql';
+import checkoutCreateMutation from './graphql/checkoutCreateMutation.graphql';
+import checkoutLineItemsAddMutation from './graphql/checkoutLineItemsAddMutation.graphql';
+import checkoutLineItemsRemoveMutation from './graphql/checkoutLineItemsRemoveMutation.graphql';
+import checkoutLineItemsUpdateMutation from './graphql/checkoutLineItemsUpdateMutation.graphql';
+
+export default class CheckoutResource extends Resource {
+
+  /**
+   * Fetches a checkout by ID.
+   *
+   * @example
+   * client.fetchCheckout('FlZj9rZXlN5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=').then((checkout) => {
+   *   // Do something with the checkout
+   * });
+   *
+   * @param {String} id The id of the checkout to fetch.
+   * @param {Client.Queries.checkoutNodeQuery} [query] Callback function to specify fields to query on the checkout.
+   * @return {Promise|GraphModel} A promise resolving with a `GraphModel` of the checkout.
+   */
+  fetch(id) {
+    return this.graphQLClient
+      .send(checkoutNodeQuery, {id})
+      .then(defaultResolver('node'))
+      .then((checkout) => {
+        return this.graphQLClient.fetchAllPages(checkout.lineItems, {pageSize: 250}).then((lineItems) => {
+          checkout.attrs.lineItems = lineItems;
+
+          return checkout;
+        });
+      });
+  }
+
+  /**
+   * Creates a checkout.
+   *
+   * @example
+   * const input = {
+   *   lineItems: [
+   *     {variantId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjAyMjc5Mg==', quantity: 5}
+   *   ]
+   * };
+   *
+   * client.createCheckout(input).then((checkout) => {
+   *   // Do something with the newly created checkout
+   * });
+   *
+   * @param {Object} [input] An input object containing zero or more of:
+   *   @param {String} [input.email] An email connected to the checkout.
+   *   @param {Object[]} [input.lineItems] A list of line items in the checkout. See the {@link https://help.shopify.com/api/storefront-api/reference/input_object/checkoutlineiteminput|Storefront API reference} for valid input fields for each line item.
+   *   @param {Object} [input.shippingAddress] A shipping address. See the {@link https://help.shopify.com/api/storefront-api/reference/input_object/mailingaddressinput|Storefront API reference} for valid input fields.
+   *   @param {String} [input.note] A note for the checkout.
+   *   @param {Object[]} [input.customAttributes] A list of custom attributes for the checkout. See the {@link https://help.shopify.com/api/storefront-api/reference/input_object/attributeinput|Storefront API reference} for valid input fields.
+   * @param {Client.Queries.checkoutQuery} [query] Callback function to specify fields to query on the checkout returned.
+   * @return {Promise|GraphModel} A promise resolving with the created checkout.
+   */
+  create(input = {}) {
+    return this.graphQLClient
+      .send(checkoutCreateMutation, {input})
+      .then(handleCheckoutMutation('checkoutCreate', this.graphQLClient));
+  }
+
+  /**
+   * Adds line items to an existing checkout.
+   *
+   * @example
+   * const checkoutId = 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9kMTZmM2EzMDM4Yjc4N=';
+   * const lineItems = [{variantId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjAyMjc5Mg==', quantity: 5}];
+   *
+   * client.addLineItems(checkoutId, lineItems).then((checkout) => {
+   *   // Do something with the updated checkout
+   * });
+   *
+   * @param {String} checkoutId The ID of the checkout to add line items to.
+   * @param {Object[]} lineItems A list of line items to add to the checkout. See the {@link https://help.shopify.com/api/storefront-api/reference/input_object/checkoutlineiteminput|Storefront API reference} for valid input fields for each line item.
+   * @param {Client.Queries.checkoutQuery} [query] Callback function to specify fields to query on the checkout returned.
+   * @return {Promise|GraphModel} A promise resolving with the updated checkout.
+   */
+  addLineItems(checkoutId, lineItems) {
+    return this.graphQLClient
+      .send(checkoutLineItemsAddMutation, {checkoutId, lineItems})
+      .then(handleCheckoutMutation('checkoutLineItemsAdd', this.graphQLClient));
+  }
+
+  /**
+   * Removes line items from an existing checkout.
+   *
+   * @example
+   * const checkoutId = 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9kMTZmM2EzMDM4Yjc4N=';
+   * const lineItemIds = ['TViZGE5Y2U1ZDFhY2FiMmM2YT9rZXk9NTc2YjBhODcwNWIxYzg0YjE5ZjRmZGQ5NjczNGVkZGU='];
+   *
+   * client.removeLineItems(checkoutId, lineItemIds).then((checkout) => {
+   *   // Do something with the updated checkout
+   * });
+   *
+   * @param {String} checkoutId The ID of the checkout to remove line items from.
+   * @param {String[]} lineItemIds A list of the ids of line items to remove from the checkout.
+   * @param {Client.Queries.checkoutQuery} [query] Callback function to specify fields to query on the checkout returned.
+   * @return {Promise|GraphModel} A promise resolving with the updated checkout.
+   */
+  removeLineItems(checkoutId, lineItemIds) {
+    return this.graphQLClient
+      .send(checkoutLineItemsRemoveMutation, {checkoutId, lineItemIds})
+      .then(handleCheckoutMutation('checkoutLineItemsRemove', this.graphQLClient));
+  }
+
+  /**
+   * Updates line items on an existing checkout.
+   *
+   * @example
+   * const checkoutId = 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9kMTZmM2EzMDM4Yjc4N=';
+   * const lineItems = [
+   *   {
+   *     id: 'TViZGE5Y2U1ZDFhY2FiMmM2YT9rZXk9NTc2YjBhODcwNWIxYzg0YjE5ZjRmZGQ5NjczNGVkZGU=',
+   *     quantity: 5,
+   *     variantId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjAyMjc5Mg=='
+   *   }
+   * ];
+   *
+   * client.updateLineItems(checkoutId, lineItems).then(checkout => {
+   *   // Do something with the updated checkout
+   * });
+   *
+   * @param {String} checkoutId The ID of the checkout to update a line item on.
+   * @param {Object[]} lineItems A list of line item information to update. See the {@link https://help.shopify.com/api/storefront-api/reference/input_object/checkoutlineitemupdateinput|Storefront API reference} for valid input fields for each line item.
+   * @param {Client.Queries.checkoutQuery} [query] Callback function to specify fields to query on the checkout returned.
+   * @return {Promise|GraphModel} A promise resolving with the updated checkout.
+   */
+  updateLineItems(checkoutId, lineItems) {
+    return this.graphQLClient
+      .send(checkoutLineItemsUpdateMutation, {checkoutId, lineItems})
+      .then(handleCheckoutMutation('checkoutLineItemsUpdate', this.graphQLClient));
+  }
+}

--- a/src/client.js
+++ b/src/client.js
@@ -1,11 +1,10 @@
 import GraphQLJSClient from './graphql-client';
 import Config from './config';
-import productHelpers from './product-helpers';
-import imageHelpers from './image-helpers';
 import ProductResource from './product-resource';
 import CollectionResource from './collection-resource';
 import ShopResource from './shop-resource';
 import CheckoutResource from './checkout-resource';
+import ImageResource from './image-resource';
 import {version} from '../package.json';
 
 // GraphQL
@@ -16,26 +15,6 @@ import types from '../schema.json';
  * @class
  */
 class Client {
-
-  /**
-   * A namespace providing utilities for product resources.
-   * @namespace
-   */
-  static get Product() {
-    return {
-      Helpers: productHelpers
-    };
-  }
-
-  /**
-   * A namespace providing utilities for image resources.
-   * @namespace
-   */
-  static get Image() {
-    return {
-      Helpers: imageHelpers
-    };
-  }
 
   /**
    * Primary entry point for building a new Client.
@@ -64,10 +43,11 @@ class Client {
       }
     });
 
-    this.product = new ProductResource(this.graphQLClient, productHelpers);
+    this.product = new ProductResource(this.graphQLClient);
     this.collection = new CollectionResource(this.graphQLClient);
     this.shop = new ShopResource(this.graphQLClient);
     this.checkout = new CheckoutResource(this.graphQLClient);
+    this.image = new ImageResource(this.graphQLClient);
   }
 }
 

--- a/src/client.js
+++ b/src/client.js
@@ -6,13 +6,12 @@ import imageHelpers from './image-helpers';
 import defaultResolver from './default-resolver';
 import ProductResource from './product-resource';
 import CollectionResource from './collection-resource';
+import ShopResource from './shop-resource';
 import {version} from '../package.json';
 
 // GraphQL
 import types from '../schema.json';
 import checkoutNodeQuery from './graphql/checkoutNodeQuery.graphql';
-import shopQuery from './graphql/shopQuery.graphql';
-import shopPolicyQuery from './graphql/shopPolicyQuery.graphql';
 import checkoutCreateMutation from './graphql/checkoutCreateMutation.graphql';
 import checkoutLineItemsAddMutation from './graphql/checkoutLineItemsAddMutation.graphql';
 import checkoutLineItemsRemoveMutation from './graphql/checkoutLineItemsRemoveMutation.graphql';
@@ -73,40 +72,7 @@ class Client {
 
     this.product = new ProductResource(this.graphQLClient, productHelpers);
     this.collection = new CollectionResource(this.graphQLClient);
-    console.log(this.collection);
-  }
-
-  /**
-   * Fetches shop information (`currencyCode`, `description`, `moneyFormat`, `name`, and `primaryDomain`).
-   * See the {@link https://help.shopify.com/api/storefront-api/reference/object/shop|Storefront API reference} for more information.
-   *
-   * @example
-   * client.fetchShopInfo().then((shop) => {
-   *   // Do something with the shop
-   * });
-   *
-   * @return {Promise|GraphModel} A promise resolving with a `GraphModel` of the shop.
-   */
-  fetchShopInfo() {
-    return this.graphQLClient
-      .send(shopQuery)
-      .then(defaultResolver('shop'));
-  }
-
-  /**
-   * Fetches shop policies (privacy policy, terms of service and refund policy).
-   *
-   * @example
-   * client.fetchShopPolicies().then((shop) => {
-   *   // Do something with the shop
-   * });
-   *
-   * @return {Promise|GraphModel} A promise resolving with a `GraphModel` of the shop.
-   */
-  fetchShopPolicies() {
-    return this.graphQLClient
-      .send(shopPolicyQuery)
-      .then(defaultResolver('shop'));
+    this.shop = new ShopResource(this.graphQLClient);
   }
 
   /**

--- a/src/client.js
+++ b/src/client.js
@@ -4,18 +4,13 @@ import handleCheckoutMutation from './handle-checkout-mutation';
 import productHelpers from './product-helpers';
 import imageHelpers from './image-helpers';
 import defaultResolver from './default-resolver';
-import {paginateCollectionsProductConnectionsAndResolve} from './paginators';
 import ProductResource from './product-resource';
+import CollectionResource from './collection-resource';
 import {version} from '../package.json';
 
 // GraphQL
 import types from '../schema.json';
 import checkoutNodeQuery from './graphql/checkoutNodeQuery.graphql';
-import collectionNodeQuery from './graphql/collectionNodeQuery.graphql';
-import collectionNodeWithProductsQuery from './graphql/collectionNodeWithProductsQuery.graphql';
-import collectionConnectionQuery from './graphql/collectionConnectionQuery.graphql';
-import collectionConnectionWithProductsQuery from './graphql/collectionConnectionWithProductsQuery.graphql';
-import collectionByHandleQuery from './graphql/collectionByHandleQuery.graphql';
 import shopQuery from './graphql/shopQuery.graphql';
 import shopPolicyQuery from './graphql/shopPolicyQuery.graphql';
 import checkoutCreateMutation from './graphql/checkoutCreateMutation.graphql';
@@ -77,6 +72,8 @@ class Client {
     });
 
     this.product = new ProductResource(this.graphQLClient, productHelpers);
+    this.collection = new CollectionResource(this.graphQLClient);
+    console.log(this.collection);
   }
 
   /**
@@ -113,95 +110,6 @@ class Client {
   }
 
   /**
-   * Fetches a collection by handle on the shop.
-   *
-   * @example
-   * client.fetchCollectionByHandle('my-collection').then((collection) => {
-   *   // Do something with the collection
-   * });
-   *
-   * @param {String} handle The handle of the collection to fetch.
-   * @return {Promise|GraphModel} A promise resolving with a `GraphModel` of the collection.
-   */
-  fetchCollectionByHandle(handle) {
-    return this.graphQLClient
-      .send(collectionByHandleQuery, {handle})
-      .then(defaultResolver('shop.collectionByHandle'));
-  }
-
-  /**
-   * Fetches all collections on the shop, not including products.
-   * To fetch collections with products use [fetchAllCollectionsWithProducts]{@link Client#fetchAllCollectionsWithProducts}.
-   *
-   * @example
-   * client.fetchAllCollections().then((collections) => {
-   *   // Do something with the collections
-   * });
-   *
-   * @param {Client.Queries.collectionConnectionQuery} [query] Callback function to specify fields to query on the collections.
-   * @return {Promise|GraphModel[]} A promise resolving with an array of `GraphModel`s of the collections.
-   */
-  fetchAllCollections() {
-    return this.graphQLClient
-      .send(collectionConnectionQuery)
-      .then(defaultResolver('shop.collections'));
-  }
-
-  /**
-   * Fetches all collections on the shop, including products.
-   *
-   * @example
-   * client.fetchAllCollectionsWithProducts().then((collections) => {
-   *   // Do something with the collections
-   * });
-   *
-   * @return {Promise|GraphModel[]} A promise resolving with an array of `GraphModel`s of the collections.
-   */
-  fetchAllCollectionsWithProducts({first = 20, productsFirst = 20} = {}) {
-    return this.graphQLClient
-      .send(collectionConnectionWithProductsQuery, {first, productsFirst})
-      .then(defaultResolver('shop.collections'))
-      .then(paginateCollectionsProductConnectionsAndResolve(this.graphQLClient));
-  }
-
-  /**
-   * Fetches a single collection by ID on the shop, not including products.
-   * To fetch the collection with products use [fetchCollectionWithProducts]{@link Client#fetchCollectionWithProducts}.
-   *
-   * @example
-   * client.fetchCollection('Xk9lM2JkNzFmNzIQ4NTIY4ZDFiZTUyZTUwNTE2MDNhZjg==').then((collection) => {
-   *   // Do something with the collection
-   * });
-   *
-   * @param {String} id The id of the collection to fetch.
-   * @param {Client.Queries.collectionNodeQuery} [query] Callback function to specify fields to query on the collection.
-   * @return {Promise|GraphModel} A promise resolving with a `GraphModel` of the collection.
-   */
-  fetchCollection(id) {
-    return this.graphQLClient
-      .send(collectionNodeQuery, {id})
-      .then(defaultResolver('node'));
-  }
-
-  /**
-   * Fetches a single collection by ID on the shop, including products.
-   *
-   * @example
-   * client.fetchCollectionWithProducts('Xk9lM2JkNzFmNzIQ4NTIY4ZDFiZTUyZTUwNTE2MDNhZjg==').then((collection) => {
-   *   // Do something with the collection
-   * });
-   *
-   * @param {String} id The id of the collection to fetch.
-   * @return {Promise|GraphModel} A promise resolving with a `GraphModel` of the collection.
-   */
-  fetchCollectionWithProducts(id, productsFirst = 20) {
-    return this.graphQLClient
-      .send(collectionNodeWithProductsQuery, {id, productsFirst})
-      .then(defaultResolver('node'))
-      .then(paginateCollectionsProductConnectionsAndResolve(this.graphQLClient));
-  }
-
-  /**
    * Fetches a checkout by ID.
    *
    * @example
@@ -224,33 +132,6 @@ class Client {
           return checkout;
         });
       });
-  }
-
-  /**
-   * Fetches all collections on the shop that match the query.
-   *
-   * @example
-   * client.fetchQueryCollections({sortBy: 'title', limit: 10}).then((collections) => {
-   *   // Do something with the first 10 collections sorted by title in ascending order
-   * });
-   *
-   * @param {Object} [queryObject] An object specifying the query data containing zero or more of:
-   *   @param {String} [queryObject.title] The title of the collection to fetch.
-   *   @param {String} [queryObject.updatedAtMin] Collections updated since the supplied timestamp (format: `2016-09-25T21:31:33`).
-   *   @param {Number} [queryObject.limit=20] The number of collections to fetch.
-   *   @param {String} [queryObject.sortBy] The field to use to sort collections. Possible values are `title` and `updatedAt`.
-   *   @param {String} [queryObject.sortDirection] The sort direction of the collections.
-   *     Will sort collections by ascending order unless `'desc'` is specified.
-   * @param {Client.Queries.collectionConnectionQuery} [query] Callback function to specify fields to query on the collections.
-   * @return {Promise|GraphModel[]} A promise resolving with an array of `GraphModel`s of the collections.
-   */
-  fetchQueryCollections({first = 20, sortKey = 'ID', query, reverse}) {
-    return this.graphQLClient.send(collectionConnectionQuery, {
-      first,
-      sortKey: this.graphQLClient.enum(sortKey),
-      query,
-      reverse
-    }).then(defaultResolver('shop.collections'));
   }
 
   /**

--- a/src/client.js
+++ b/src/client.js
@@ -1,21 +1,15 @@
 import GraphQLJSClient from './graphql-client';
 import Config from './config';
-import handleCheckoutMutation from './handle-checkout-mutation';
 import productHelpers from './product-helpers';
 import imageHelpers from './image-helpers';
-import defaultResolver from './default-resolver';
 import ProductResource from './product-resource';
 import CollectionResource from './collection-resource';
 import ShopResource from './shop-resource';
+import CheckoutResource from './checkout-resource';
 import {version} from '../package.json';
 
 // GraphQL
 import types from '../schema.json';
-import checkoutNodeQuery from './graphql/checkoutNodeQuery.graphql';
-import checkoutCreateMutation from './graphql/checkoutCreateMutation.graphql';
-import checkoutLineItemsAddMutation from './graphql/checkoutLineItemsAddMutation.graphql';
-import checkoutLineItemsRemoveMutation from './graphql/checkoutLineItemsRemoveMutation.graphql';
-import checkoutLineItemsUpdateMutation from './graphql/checkoutLineItemsUpdateMutation.graphql';
 
 /**
  * The JS Buy SDK Client.
@@ -73,132 +67,7 @@ class Client {
     this.product = new ProductResource(this.graphQLClient, productHelpers);
     this.collection = new CollectionResource(this.graphQLClient);
     this.shop = new ShopResource(this.graphQLClient);
-  }
-
-  /**
-   * Fetches a checkout by ID.
-   *
-   * @example
-   * client.fetchCheckout('FlZj9rZXlN5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=').then((checkout) => {
-   *   // Do something with the checkout
-   * });
-   *
-   * @param {String} id The id of the checkout to fetch.
-   * @param {Client.Queries.checkoutNodeQuery} [query] Callback function to specify fields to query on the checkout.
-   * @return {Promise|GraphModel} A promise resolving with a `GraphModel` of the checkout.
-   */
-  fetchCheckout(id) {
-    return this.graphQLClient
-      .send(checkoutNodeQuery, {id})
-      .then(defaultResolver('node'))
-      .then((checkout) => {
-        return this.graphQLClient.fetchAllPages(checkout.lineItems, {pageSize: 250}).then((lineItems) => {
-          checkout.attrs.lineItems = lineItems;
-
-          return checkout;
-        });
-      });
-  }
-
-  /**
-   * Creates a checkout.
-   *
-   * @example
-   * const input = {
-   *   lineItems: [
-   *     {variantId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjAyMjc5Mg==', quantity: 5}
-   *   ]
-   * };
-   *
-   * client.createCheckout(input).then((checkout) => {
-   *   // Do something with the newly created checkout
-   * });
-   *
-   * @param {Object} [input] An input object containing zero or more of:
-   *   @param {String} [input.email] An email connected to the checkout.
-   *   @param {Object[]} [input.lineItems] A list of line items in the checkout. See the {@link https://help.shopify.com/api/storefront-api/reference/input_object/checkoutlineiteminput|Storefront API reference} for valid input fields for each line item.
-   *   @param {Object} [input.shippingAddress] A shipping address. See the {@link https://help.shopify.com/api/storefront-api/reference/input_object/mailingaddressinput|Storefront API reference} for valid input fields.
-   *   @param {String} [input.note] A note for the checkout.
-   *   @param {Object[]} [input.customAttributes] A list of custom attributes for the checkout. See the {@link https://help.shopify.com/api/storefront-api/reference/input_object/attributeinput|Storefront API reference} for valid input fields.
-   * @param {Client.Queries.checkoutQuery} [query] Callback function to specify fields to query on the checkout returned.
-   * @return {Promise|GraphModel} A promise resolving with the created checkout.
-   */
-  createCheckout(input = {}) {
-    return this.graphQLClient
-      .send(checkoutCreateMutation, {input})
-      .then(handleCheckoutMutation('checkoutCreate', this.graphQLClient));
-  }
-
-  /**
-   * Adds line items to an existing checkout.
-   *
-   * @example
-   * const checkoutId = 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9kMTZmM2EzMDM4Yjc4N=';
-   * const lineItems = [{variantId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjAyMjc5Mg==', quantity: 5}];
-   *
-   * client.addLineItems(checkoutId, lineItems).then((checkout) => {
-   *   // Do something with the updated checkout
-   * });
-   *
-   * @param {String} checkoutId The ID of the checkout to add line items to.
-   * @param {Object[]} lineItems A list of line items to add to the checkout. See the {@link https://help.shopify.com/api/storefront-api/reference/input_object/checkoutlineiteminput|Storefront API reference} for valid input fields for each line item.
-   * @param {Client.Queries.checkoutQuery} [query] Callback function to specify fields to query on the checkout returned.
-   * @return {Promise|GraphModel} A promise resolving with the updated checkout.
-   */
-  addLineItems(checkoutId, lineItems) {
-    return this.graphQLClient
-      .send(checkoutLineItemsAddMutation, {checkoutId, lineItems})
-      .then(handleCheckoutMutation('checkoutLineItemsAdd', this.graphQLClient));
-  }
-
-  /**
-   * Removes line items from an existing checkout.
-   *
-   * @example
-   * const checkoutId = 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9kMTZmM2EzMDM4Yjc4N=';
-   * const lineItemIds = ['TViZGE5Y2U1ZDFhY2FiMmM2YT9rZXk9NTc2YjBhODcwNWIxYzg0YjE5ZjRmZGQ5NjczNGVkZGU='];
-   *
-   * client.removeLineItems(checkoutId, lineItemIds).then((checkout) => {
-   *   // Do something with the updated checkout
-   * });
-   *
-   * @param {String} checkoutId The ID of the checkout to remove line items from.
-   * @param {String[]} lineItemIds A list of the ids of line items to remove from the checkout.
-   * @param {Client.Queries.checkoutQuery} [query] Callback function to specify fields to query on the checkout returned.
-   * @return {Promise|GraphModel} A promise resolving with the updated checkout.
-   */
-  removeLineItems(checkoutId, lineItemIds) {
-    return this.graphQLClient
-      .send(checkoutLineItemsRemoveMutation, {checkoutId, lineItemIds})
-      .then(handleCheckoutMutation('checkoutLineItemsRemove', this.graphQLClient));
-  }
-
-  /**
-   * Updates line items on an existing checkout.
-   *
-   * @example
-   * const checkoutId = 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9kMTZmM2EzMDM4Yjc4N=';
-   * const lineItems = [
-   *   {
-   *     id: 'TViZGE5Y2U1ZDFhY2FiMmM2YT9rZXk9NTc2YjBhODcwNWIxYzg0YjE5ZjRmZGQ5NjczNGVkZGU=',
-   *     quantity: 5,
-   *     variantId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjAyMjc5Mg=='
-   *   }
-   * ];
-   *
-   * client.updateLineItems(checkoutId, lineItems).then(checkout => {
-   *   // Do something with the updated checkout
-   * });
-   *
-   * @param {String} checkoutId The ID of the checkout to update a line item on.
-   * @param {Object[]} lineItems A list of line item information to update. See the {@link https://help.shopify.com/api/storefront-api/reference/input_object/checkoutlineitemupdateinput|Storefront API reference} for valid input fields for each line item.
-   * @param {Client.Queries.checkoutQuery} [query] Callback function to specify fields to query on the checkout returned.
-   * @return {Promise|GraphModel} A promise resolving with the updated checkout.
-   */
-  updateLineItems(checkoutId, lineItems) {
-    return this.graphQLClient
-      .send(checkoutLineItemsUpdateMutation, {checkoutId, lineItems})
-      .then(handleCheckoutMutation('checkoutLineItemsUpdate', this.graphQLClient));
+    this.checkout = new CheckoutResource(this.graphQLClient);
   }
 }
 

--- a/src/collection-resource.js
+++ b/src/collection-resource.js
@@ -1,0 +1,129 @@
+import Resource from './resource';
+import defaultResolver from './default-resolver';
+import {paginateCollectionsProductConnectionsAndResolve} from './paginators';
+
+// GraphQL
+import collectionNodeQuery from './graphql/collectionNodeQuery.graphql';
+import collectionNodeWithProductsQuery from './graphql/collectionNodeWithProductsQuery.graphql';
+import collectionConnectionQuery from './graphql/collectionConnectionQuery.graphql';
+import collectionConnectionWithProductsQuery from './graphql/collectionConnectionWithProductsQuery.graphql';
+import collectionByHandleQuery from './graphql/collectionByHandleQuery.graphql';
+
+export default class CollectionResource extends Resource {
+
+  /**
+   * Fetches all collections on the shop, not including products.
+   * To fetch collections with products use [fetchAllCollectionsWithProducts]{@link Client#fetchAllCollectionsWithProducts}.
+   *
+   * @example
+   * client.fetchAllCollections().then((collections) => {
+   *   // Do something with the collections
+   * });
+   *
+   * @param {Client.Queries.collectionConnectionQuery} [query] Callback function to specify fields to query on the collections.
+   * @return {Promise|GraphModel[]} A promise resolving with an array of `GraphModel`s of the collections.
+   */
+  fetchAll() {
+    return this.graphQLClient
+      .send(collectionConnectionQuery)
+      .then(defaultResolver('shop.collections'));
+  }
+
+  /**
+   * Fetches all collections on the shop, including products.
+   *
+   * @example
+   * client.fetchAllCollectionsWithProducts().then((collections) => {
+   *   // Do something with the collections
+   * });
+   *
+   * @return {Promise|GraphModel[]} A promise resolving with an array of `GraphModel`s of the collections.
+   */
+  fetchAllWithProducts({first = 20, productsFirst = 20} = {}) {
+    return this.graphQLClient
+      .send(collectionConnectionWithProductsQuery, {first, productsFirst})
+      .then(defaultResolver('shop.collections'))
+      .then(paginateCollectionsProductConnectionsAndResolve(this.graphQLClient));
+  }
+
+  /**
+   * Fetches a single collection by ID on the shop, not including products.
+   * To fetch the collection with products use [fetchCollectionWithProducts]{@link Client#fetchCollectionWithProducts}.
+   *
+   * @example
+   * client.fetchCollection('Xk9lM2JkNzFmNzIQ4NTIY4ZDFiZTUyZTUwNTE2MDNhZjg==').then((collection) => {
+   *   // Do something with the collection
+   * });
+   *
+   * @param {String} id The id of the collection to fetch.
+   * @param {Client.Queries.collectionNodeQuery} [query] Callback function to specify fields to query on the collection.
+   * @return {Promise|GraphModel} A promise resolving with a `GraphModel` of the collection.
+   */
+  fetch(id) {
+    return this.graphQLClient
+      .send(collectionNodeQuery, {id})
+      .then(defaultResolver('node'));
+  }
+
+  /**
+   * Fetches a single collection by ID on the shop, including products.
+   *
+   * @example
+   * client.fetchCollectionWithProducts('Xk9lM2JkNzFmNzIQ4NTIY4ZDFiZTUyZTUwNTE2MDNhZjg==').then((collection) => {
+   *   // Do something with the collection
+   * });
+   *
+   * @param {String} id The id of the collection to fetch.
+   * @return {Promise|GraphModel} A promise resolving with a `GraphModel` of the collection.
+   */
+  fetchWithProducts(id, productsFirst = 20) {
+    return this.graphQLClient
+      .send(collectionNodeWithProductsQuery, {id, productsFirst})
+      .then(defaultResolver('node'))
+      .then(paginateCollectionsProductConnectionsAndResolve(this.graphQLClient));
+  }
+
+  /**
+   * Fetches a collection by handle on the shop.
+   *
+   * @example
+   * client.fetchCollectionByHandle('my-collection').then((collection) => {
+   *   // Do something with the collection
+   * });
+   *
+   * @param {String} handle The handle of the collection to fetch.
+   * @return {Promise|GraphModel} A promise resolving with a `GraphModel` of the collection.
+   */
+  fetchByHandle(handle) {
+    return this.graphQLClient
+      .send(collectionByHandleQuery, {handle})
+      .then(defaultResolver('shop.collectionByHandle'));
+  }
+
+  /**
+   * Fetches all collections on the shop that match the query.
+   *
+   * @example
+   * client.fetchQueryCollections({sortBy: 'title', limit: 10}).then((collections) => {
+   *   // Do something with the first 10 collections sorted by title in ascending order
+   * });
+   *
+   * @param {Object} [queryObject] An object specifying the query data containing zero or more of:
+   *   @param {String} [queryObject.title] The title of the collection to fetch.
+   *   @param {String} [queryObject.updatedAtMin] Collections updated since the supplied timestamp (format: `2016-09-25T21:31:33`).
+   *   @param {Number} [queryObject.limit=20] The number of collections to fetch.
+   *   @param {String} [queryObject.sortBy] The field to use to sort collections. Possible values are `title` and `updatedAt`.
+   *   @param {String} [queryObject.sortDirection] The sort direction of the collections.
+   *     Will sort collections by ascending order unless `'desc'` is specified.
+   * @param {Client.Queries.collectionConnectionQuery} [query] Callback function to specify fields to query on the collections.
+   * @return {Promise|GraphModel[]} A promise resolving with an array of `GraphModel`s of the collections.
+   */
+  fetchQuery({first = 20, sortKey = 'ID', query, reverse}) {
+    return this.graphQLClient.send(collectionConnectionQuery, {
+      first,
+      sortKey: this.graphQLClient.enum(sortKey),
+      query,
+      reverse
+    }).then(defaultResolver('shop.collections'));
+  }
+}

--- a/src/image-resource.js
+++ b/src/image-resource.js
@@ -1,0 +1,8 @@
+import Resource from './resource';
+import imageHelpers from './image-helpers';
+
+export default class ImageResource extends Resource {
+  get helpers() {
+    return imageHelpers;
+  }
+}

--- a/src/paginators.js
+++ b/src/paginators.js
@@ -1,0 +1,21 @@
+import fetchResourcesForProducts from './fetch-resources-for-products';
+
+export function paginateProductConnectionsAndResolve(client) {
+  return function(products) {
+    return fetchResourcesForProducts(products, client).then(() => {
+      return products;
+    });
+  };
+}
+
+export function paginateCollectionsProductConnectionsAndResolve(client) {
+  return function(collectionOrCollections) {
+    const collections = [].concat(collectionOrCollections);
+
+    return Promise.all(collections.reduce((promiseAcc, collection) => {
+      return promiseAcc.concat(fetchResourcesForProducts(collection.products, client));
+    }, [])).then(() => {
+      return collectionOrCollections;
+    });
+  };
+}

--- a/src/product-helpers.js
+++ b/src/product-helpers.js
@@ -6,7 +6,7 @@ export default {
   /**
    * Returns the variant of a product corresponding to the options given.
    *
-   * @memberof Client.Product.Helpers
+   * @memberof Client.product.Helpers
    * @method variantForOptions
    * @param {GraphModel} product The product to find the variant on. Must include `variants`.
    * @param {Object} options An object containing the options for the variant.

--- a/src/product-resource.js
+++ b/src/product-resource.js
@@ -1,6 +1,7 @@
 import Resource from './resource';
 import defaultResolver from './default-resolver';
 import {paginateProductConnectionsAndResolve} from './paginators';
+import productHelpers from './product-helpers';
 
 // GraphQL
 import productNodeQuery from './graphql/productNodeQuery.graphql';
@@ -8,6 +9,9 @@ import productConnectionQuery from './graphql/productConnectionQuery.graphql';
 import productByHandleQuery from './graphql/productByHandleQuery.graphql';
 
 export default class ProductResource extends Resource {
+  get helpers() {
+    return productHelpers;
+  }
 
   /**
    * Fetches all products on the shop.

--- a/src/product-resource.js
+++ b/src/product-resource.js
@@ -1,0 +1,99 @@
+import Resource from './resource';
+import defaultResolver from './default-resolver';
+import {paginateProductConnectionsAndResolve} from './paginators';
+
+// GraphQL
+import productNodeQuery from './graphql/productNodeQuery.graphql';
+import productConnectionQuery from './graphql/productConnectionQuery.graphql';
+import productByHandleQuery from './graphql/productByHandleQuery.graphql';
+
+export default class ProductResource extends Resource {
+
+  /**
+   * Fetches all products on the shop.
+   *
+   * @example
+   * client.fetchAllProducts().then((products) => {
+   *   // Do something with the products
+   * });
+   *
+   * @param {Client.Queries.productConnectionQuery} [query] Callback function to specify fields to query on the products.
+   * @return {Promise|GraphModel[]} A promise resolving with an array of `GraphModel`s of the products.
+   */
+  fetchAll(pageSize = 20) {
+    return this.graphQLClient
+      .send(productConnectionQuery, {pageSize})
+      .then(defaultResolver('shop.products'))
+      .then(paginateProductConnectionsAndResolve(this.graphQLClient));
+  }
+
+  /**
+   * Fetches a single product by ID on the shop.
+   *
+   * @example
+   * client.fetchProduct('Xk9lM2JkNzFmNzIQ4NTIY4ZDFi9DaGVja291dC9lM2JkN==').then((product) => {
+   *   // Do something with the product
+   * });
+   *
+   * @param {String} id The id of the product to fetch.
+   * @param {Client.Queries.productNodeQuery} [query] Callback function to specify fields to query on the product.
+   * @return {Promise|GraphModel} A promise resolving with a `GraphModel` of the product.
+   */
+  fetch(id) {
+    return this.graphQLClient
+      .send(productNodeQuery, {id})
+      .then(defaultResolver('node'))
+      .then(paginateProductConnectionsAndResolve(this.graphQLClient));
+  }
+
+  /**
+   * Fetches a single product by handle on the shop.
+   *
+   * @example
+   * client.fetchProductByHandle('my-product').then((product) => {
+   *   // Do something with the product
+   * });
+   *
+   * @param {String} handle The handle of the product to fetch.
+   * @return {Promise|GraphModel} A promise resolving with a `GraphModel` of the product.
+   */
+  fetchByHandle(handle) {
+    return this.graphQLClient
+      .send(productByHandleQuery, {handle})
+      .then(defaultResolver('shop.productByHandle'))
+      .then(paginateProductConnectionsAndResolve(this.graphQLClient));
+  }
+
+  /**
+   * Fetches all products on the shop that match the query.
+   *
+   * @example
+   * client.fetchQueryProducts({sortBy: 'title', limit: 10}).then((products) => {
+   *   // Do something with the first 10 products sorted by title in ascending order
+   * });
+   *
+   * @param {Object} [queryObject] An object specifying the query data containing zero or more of:
+   *   @param {String} [queryObject.title] The title of the product to fetch.
+   *   @param {String} [queryObject.updatedAtMin] Products updated since the supplied timestamp (format: `2016-09-25T21:31:33`).
+   *   @param {String} [queryObject.createdAtMin] Products created since the supplied timestamp (format: `2016-09-25T21:31:33`).
+   *   @param {String} [queryObject.productType] The type of products to fetch.
+   *   @param {Number} [queryObject.limit=20] The number of products to fetch.
+   *   @param {String} [queryObject.sortBy] The field to use to sort products. Possible values are `title`, `updatedAt`, and `createdAt`.
+   *   @param {String} [queryObject.sortDirection] The sort direction of the products.
+   *     Will sort products by ascending order unless `'desc'` is specified.
+   * @param {Client.Queries.productConnectionQuery} [query] Callback function to specify fields to query on the products.
+   * @return {Promise|GraphModel[]} A promise resolving with an array of `GraphModel`s of the products.
+   */
+  fetchQuery({first = 20, sortKey = 'ID', query, reverse}) {
+    return this.graphQLClient
+      .send(productConnectionQuery, {
+        first,
+        sortKey: this.graphQLClient.enum(sortKey),
+        query,
+        reverse
+      })
+      .then(defaultResolver('shop.products'))
+      .then(paginateProductConnectionsAndResolve(this.graphQLClient));
+  }
+
+}

--- a/src/resource.js
+++ b/src/resource.js
@@ -1,0 +1,6 @@
+export default class Resource {
+  constructor(client, helpers) {
+    this.graphQLClient = client;
+    this.helpers = helpers;
+  }
+}

--- a/src/resource.js
+++ b/src/resource.js
@@ -1,6 +1,5 @@
 export default class Resource {
-  constructor(client, helpers) {
+  constructor(client) {
     this.graphQLClient = client;
-    this.helpers = helpers;
   }
 }

--- a/src/shop-resource.js
+++ b/src/shop-resource.js
@@ -1,0 +1,42 @@
+import Resource from './resource';
+import defaultResolver from './default-resolver';
+
+// GraphQL
+import shopQuery from './graphql/shopQuery.graphql';
+import shopPolicyQuery from './graphql/shopPolicyQuery.graphql';
+
+export default class ShopResource extends Resource {
+
+  /**
+   * Fetches shop information (`currencyCode`, `description`, `moneyFormat`, `name`, and `primaryDomain`).
+   * See the {@link https://help.shopify.com/api/storefront-api/reference/object/shop|Storefront API reference} for more information.
+   *
+   * @example
+   * client.fetchShopInfo().then((shop) => {
+   *   // Do something with the shop
+   * });
+   *
+   * @return {Promise|GraphModel} A promise resolving with a `GraphModel` of the shop.
+   */
+  fetchInfo() {
+    return this.graphQLClient
+      .send(shopQuery)
+      .then(defaultResolver('shop'));
+  }
+
+  /**
+   * Fetches shop policies (privacy policy, terms of service and refund policy).
+   *
+   * @example
+   * client.fetchShopPolicies().then((shop) => {
+   *   // Do something with the shop
+   * });
+   *
+   * @return {Promise|GraphModel} A promise resolving with a `GraphModel` of the shop.
+   */
+  fetchPolicies() {
+    return this.graphQLClient
+      .send(shopPolicyQuery)
+      .then(defaultResolver('shop'));
+  }
+}

--- a/test/client-checkout-integration-test.js
+++ b/test/client-checkout-integration-test.js
@@ -30,18 +30,18 @@ suite('client-checkout-integration-test', () => {
     fetchMock.restore();
   });
 
-  test('it resolves with a checkout on Client#fetchCheckout', () => {
+  test('it resolves with a checkout on Client.checkout#fetch', () => {
     fetchMock.postOnce(apiUrl, checkoutFixture);
 
     const checkoutId = checkoutFixture.data.node.id;
 
-    return client.fetchCheckout(checkoutId).then((checkout) => {
+    return client.checkout.fetch(checkoutId).then((checkout) => {
       assert.equal(checkout.id, checkoutId);
       assert.ok(fetchMock.done());
     });
   });
 
-  test('it resolves with a checkout on Client#createCheckout', () => {
+  test('it resolves with a checkout on Client.checkout#create', () => {
     const input = {
       lineItems: [
         {
@@ -54,13 +54,13 @@ suite('client-checkout-integration-test', () => {
 
     fetchMock.postOnce(apiUrl, checkoutCreateFixture);
 
-    return client.createCheckout(input).then((checkout) => {
+    return client.checkout.create(input).then((checkout) => {
       assert.equal(checkout.id, checkoutCreateFixture.data.checkoutCreate.checkout.id);
       assert.ok(fetchMock.done());
     });
   });
 
-  test('it resolves with a checkout on Client#addLineItems', () => {
+  test('it resolves with a checkout on Client.checkout#addLineItems', () => {
     const checkoutId = checkoutLineItemsAddFixture.data.checkoutLineItemsAdd.checkout.id;
     const lineItems = [
       {variantId: 'id1', quantity: 5},
@@ -69,13 +69,13 @@ suite('client-checkout-integration-test', () => {
 
     fetchMock.postOnce(apiUrl, checkoutLineItemsAddFixture);
 
-    return client.addLineItems(checkoutId, lineItems).then((checkout) => {
+    return client.checkout.addLineItems(checkoutId, lineItems).then((checkout) => {
       assert.equal(checkout.id, checkoutId);
       assert.ok(fetchMock.done());
     });
   });
 
-  test('it resolves with a checkout on Client#updateLineItems', () => {
+  test('it resolves with a checkout on Client.checkout#updateLineItems', () => {
     fetchMock.postOnce(apiUrl, checkoutLineItemsUpdateFixture);
 
     const checkoutId = checkoutLineItemsUpdateFixture.data.checkoutLineItemsUpdate.checkout.id;
@@ -87,18 +87,18 @@ suite('client-checkout-integration-test', () => {
       }
     ];
 
-    return client.updateLineItems(checkoutId, lineItems).then((checkout) => {
+    return client.checkout.updateLineItems(checkoutId, lineItems).then((checkout) => {
       assert.equal(checkout.id, checkoutId);
       assert.ok(fetchMock.done());
     });
   });
 
-  test('it resolves with a checkout on Client#removeLineItems', () => {
+  test('it resolves with a checkout on Client.checkout#removeLineItems', () => {
     fetchMock.postOnce(apiUrl, checkoutLineItemsRemoveFixture);
 
     const checkoutId = checkoutLineItemsRemoveFixture.data.checkoutLineItemsRemove.checkout.id;
 
-    return client.removeLineItems(checkoutId, ['line-item-id']).then((checkout) => {
+    return client.checkout.removeLineItems(checkoutId, ['line-item-id']).then((checkout) => {
       assert.equal(checkout.id, checkoutId);
       assert.ok(fetchMock.done());
     });
@@ -117,7 +117,7 @@ suite('client-checkout-integration-test', () => {
       .postOnce(apiUrl, secondPageLineItemsFixture)
       .postOnce(apiUrl, thirdPageLineItemsFixture);
 
-    return client.createCheckout(input).then(() => {
+    return client.checkout.create(input).then(() => {
       assert.ok(fetchMock.done());
     });
   });
@@ -149,7 +149,7 @@ suite('client-checkout-integration-test', () => {
 
     fetchMock.postOnce(apiUrl, checkoutCreateWithUserErrorsFixture);
 
-    return client.createCheckout(input).then(() => {
+    return client.checkout.create(input).then(() => {
       assert.ok(false, 'Promise should not resolve');
     }).catch((error) => {
       assert.equal(error.message, '[{"message":"Variant is invalid","field":["lineItems","0","variantId"]}]');

--- a/test/client-integration-test.js
+++ b/test/client-integration-test.js
@@ -232,20 +232,20 @@ suite('client-integration-test', () => {
     });
   });
 
-  test('it resolves with `shop` on Client#fetchShopInfo', () => {
+  test('it resolves with `shop` on Client.shop#fetchInfo', () => {
     fetchMock.postOnce(apiUrl, shopInfoFixture);
 
-    return client.fetchShopInfo().then((shop) => {
+    return client.shop.fetchInfo().then((shop) => {
       assert.equal(shop.name, shopInfoFixture.data.shop.name);
       assert.equal(shop.description, shopInfoFixture.data.shop.description);
       assert.ok(fetchMock.done());
     });
   });
 
-  test('it resolves with `shop` on Client#fetchShopPolicies', () => {
+  test('it resolves with `shop` on Client.shop#fetchPolicies', () => {
     fetchMock.postOnce(apiUrl, shopPoliciesFixture);
 
-    return client.fetchShopPolicies().then((shop) => {
+    return client.shop.fetchPolicies().then((shop) => {
       assert.equal(shop.privacyPolicy.id, shopPoliciesFixture.data.shop.privacyPolicy.id);
       assert.equal(shop.termsOfService.id, shopPoliciesFixture.data.shop.termsOfService.id);
       assert.equal(shop.refundPolicy.id, shopPoliciesFixture.data.shop.refundPolicy.id);

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -3,13 +3,13 @@ import GraphQLJSClient from '../src/graphql-client';
 import Config from '../src/config';
 import Client from '../src/client';
 import types from '../schema.json';
-import fetchMock from './isomorphic-fetch-mock'; // eslint-disable-line import/no-unresolved
 import {version} from '../package.json';
 
 suite('client-test', () => {
-  teardown(() => {
-    fetchMock.restore();
-  });
+  const config = {
+    domain: 'sendmecats.myshopify.com',
+    storefrontAccessToken: 'abc123'
+  };
 
   test('it instantiates a GraphQL client with the given config', () => {
     let passedTypeBundle;
@@ -24,12 +24,7 @@ suite('client-test', () => {
       }
     }
 
-    const config = new Config({
-      domain: 'sendmecats.myshopify.com',
-      storefrontAccessToken: 'abc123'
-    });
-
-    new Client(config, FakeGraphQLJSClient); // eslint-disable-line no-new
+    new Client(new Config(config), FakeGraphQLJSClient); // eslint-disable-line no-new
 
     assert.deepEqual(passedTypeBundle, types);
     assert.equal(passedUrl, 'https://sendmecats.myshopify.com/api/graphql');
@@ -43,18 +38,15 @@ suite('client-test', () => {
   });
 
   test('it creates an instance of the GraphQLJSClient by default', () => {
-    const config = new Config({
-      domain: 'sendmecats.myshopify.com',
-      storefrontAccessToken: 'abc123'
-    });
-
-    const client = new Client(config);
+    const client = Client.buildClient(config);
 
     assert.ok(GraphQLJSClient.prototype.isPrototypeOf(client.graphQLClient));
   });
 
   test('it has static helpers', () => {
-    assert.ok(Client.Product.Helpers);
-    assert.ok(Client.Image.Helpers);
+    const client = Client.buildClient(config);
+
+    assert.ok(client.product.helpers);
+    assert.ok(client.image.helpers);
   });
 });


### PR DESCRIPTION
This cleans up our top level namespace, and makes it clear what resource a query or mutation is operating on.