### PR TITLE
Fix formats of data sent to queries

### DIFF
--- a/src/collection-resource.js
+++ b/src/collection-resource.js
@@ -26,9 +26,9 @@ class CollectionResource extends Resource {
    *
    * @return {Promise|GraphModel[]} A promise resolving with an array of `GraphModel`s of the collections.
    */
-  fetchAll() {
+  fetchAll(first = 20) {
     return this.graphQLClient
-      .send(collectionConnectionQuery)
+      .send(collectionConnectionQuery, {first})
       .then(defaultResolver('shop.collections'));
   }
 
@@ -118,10 +118,10 @@ class CollectionResource extends Resource {
    *   @param {Boolean} [args.reverse] Whether or not to reverse the sort order of the results
    * @return {Promise|GraphModel[]} A promise resolving with an array of `GraphModel`s of the collections.
    */
-  fetchQuery({first = 20, sortKey = 'ID', query, reverse}) {
+  fetchQuery({first = 20, sortKey = 'ID', query, reverse} = {}) {
     return this.graphQLClient.send(collectionConnectionQuery, {
       first,
-      sortKey: this.graphQLClient.enum(sortKey),
+      sortKey,
       query,
       reverse
     }).then(defaultResolver('shop.collections'));

--- a/src/product-resource.js
+++ b/src/product-resource.js
@@ -29,9 +29,9 @@ class ProductResource extends Resource {
    * @param {Int} [pageSize] The number of products to fetch per page
    * @return {Promise|GraphModel[]} A promise resolving with an array of `GraphModel`s of the products.
    */
-  fetchAll(pageSize = 20) {
+  fetchAll(first = 20) {
     return this.graphQLClient
-      .send(productConnectionQuery, {pageSize})
+      .send(productConnectionQuery, {first})
       .then(defaultResolver('shop.products'))
       .then(paginateProductConnectionsAndResolve(this.graphQLClient));
   }
@@ -107,11 +107,11 @@ class ProductResource extends Resource {
    *   @param {Boolean} [args.reverse] Whether or not to reverse the sort order of the results
    * @return {Promise|GraphModel[]} A promise resolving with an array of `GraphModel`s of the products.
    */
-  fetchQuery({first = 20, sortKey = 'ID', query, reverse}) {
+  fetchQuery({first = 20, sortKey = 'ID', query, reverse} = {}) {
     return this.graphQLClient
       .send(productConnectionQuery, {
         first,
-        sortKey: this.graphQLClient.enum(sortKey),
+        sortKey,
         query,
         reverse
       })


### PR DESCRIPTION
Also a tiny fix around using `pageSize` and `first` interchangeably. Be consistent with relay and use `first` always.