### PR TITLE
Switch default resolver to return promise and reject undefined keys with proper error messages

### DIFF
--- a/src/default-resolver.js
+++ b/src/default-resolver.js
@@ -1,9 +1,23 @@
+export const defaultErrors = [{message: 'an unknown error has occured'}];
+
 export default function defaultResolver(path) {
   const keys = path.split('.');
 
-  return function({model}) {
-    return keys.reduce((ref, key) => {
-      return ref[key];
-    }, model);
+  return function({model, errors}) {
+    return new Promise((resolve, reject) => {
+      try {
+        const result = keys.reduce((ref, key) => {
+          return ref[key];
+        }, model);
+
+        resolve(result);
+      } catch (_) {
+        if (errors) {
+          reject(errors);
+        } else {
+          reject(defaultErrors);
+        }
+      }
+    });
   };
 }

--- a/src/default-resolver.js
+++ b/src/default-resolver.js
@@ -1,4 +1,4 @@
-export const defaultErrors = [{message: 'an unknown error has occured'}];
+export const defaultErrors = [{message: 'an unknown error has occured.'}];
 
 export default function defaultResolver(path) {
   const keys = path.split('.');

--- a/test/default-resolver-test.js
+++ b/test/default-resolver-test.js
@@ -47,7 +47,7 @@ suite('default-resolver-test', () => {
     });
   });
 
-  test('it rejects with synthetic errors hash if no top level key available', () => {
+  test('it rejects with a synthetic errors hash if no top level key available', () => {
     const resolve = defaultResolver('node');
 
     return resolve({}).then(() => {

--- a/test/default-resolver-test.js
+++ b/test/default-resolver-test.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import defaultResolver from '../src/default-resolver';
+import defaultResolver, {defaultErrors} from '../src/default-resolver';
 
 suite('default-resolver-test', () => {
   test('it resolves a given key', () => {
@@ -7,7 +7,9 @@ suite('default-resolver-test', () => {
     const object = {aKey: value};
     const resolve = defaultResolver('aKey');
 
-    assert.equal(resolve({model: object}), value);
+    return resolve({model: object}).then((resolvedValue) => {
+      assert.equal(resolvedValue, value);
+    });
   });
 
   test('it resolves a given path', () => {
@@ -23,6 +25,37 @@ suite('default-resolver-test', () => {
     };
     const resolve = defaultResolver('refOne.refTwo.refThree.refFour');
 
-    assert.equal(resolve({model: object}), value);
+    return resolve({model: object}).then((resolvedValue) => {
+      assert.equal(resolvedValue, value);
+    });
+  });
+
+  test('it rejects with top level errors hash if available', () => {
+    const errors = [
+      {
+        message: 'an error message'
+      }
+    ];
+    const resolve = defaultResolver('node');
+
+    return resolve({errors}).then(() => {
+      assert.ok(false, 'should not resolve');
+    }).catch((resolvedErrors) => {
+      assert.equal(resolvedErrors, errors);
+
+      return true;
+    });
+  });
+
+  test('it rejects with synthetic errors hash if no top level key available', () => {
+    const resolve = defaultResolver('node');
+
+    return resolve({}).then(() => {
+      assert.ok(false, 'should not resolve');
+    }).catch((resolvedErrors) => {
+      assert.equal(resolvedErrors, defaultErrors);
+
+      return true;
+    });
   });
 });

--- a/test/default-resolver.js
+++ b/test/default-resolver.js
@@ -1,3 +1,0 @@
-export default function defaultResolver(path) {
-  return function() { return path; };
-}


### PR DESCRIPTION
There were issues where the resolver was failing when trying to fetch products with invalid `ids` . This PR fixes it and rejects with proper error messages