### PR TITLE
Fetch only product ID

### DIFF
--- a/src/graphql/VariantWithProductFragment.graphql
+++ b/src/graphql/VariantWithProductFragment.graphql
@@ -1,19 +1,6 @@
 fragment VariantWithProductFragment on ProductVariant {
   ...VariantFragment
   product {
-    images(first: 1) {
-      pageInfo {
-        hasNextPage
-        hasPreviousPage
-      }
-      edges {
-        cursor
-        node {
-          id
-          src
-          altText
-        }
-      }
-    }
+    id
   }
 }


### PR DESCRIPTION
We made a recent change that makes the variant fall back to the first product image if it has no images associated with it. This removes the need to fetch the images with the product for the cart