### PR TITLE
expose config as a key on client

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -27,8 +27,11 @@ class Client {
    */
   static buildClient(config, fetchFunction) {
     const newConfig = new Config(config);
+    const client = new Client(newConfig, GraphQLJSClient, fetchFunction);
 
-    return new Client(newConfig, GraphQLJSClient, fetchFunction);
+    client.config = newConfig;
+
+    return client;
   }
 
   /**


### PR DESCRIPTION
This is necessary so that buy button has access to the config and can prefix the cart key with data from the config