### PR TITLE
checkoutEmailIUpdate mutation

### DIFF
--- a/fixtures/checkout-update-email-fixture.js
+++ b/fixtures/checkout-update-email-fixture.js
@@ -1,0 +1,81 @@
+export default {
+  "data": {
+    "checkoutEmailUpdate": {
+      "userErrors": [],
+      "checkout": {
+        "id": "Z2lkOi8vU2hvcGlmeS9FeGFtcGxlLzE=",
+        "ready": true,
+        "lineItems": {
+          "pageInfo": {
+            "hasNextPage": false,
+            "hasPreviousPage": false
+          },
+          "edges": [
+            {
+              "cursor": "eyJsYXN0X2lkIjoiZDUyZWU5ZTEwYmQxMWE0NDlkNmQzMWNkMzBhMGFjNzMifQ==",
+              "node": {
+                "title": "Intelligent Granite Table",
+                "variant": {
+                  "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
+                  "title": "Awesome Copper Bench",
+                  "price": "64.99",
+                  "weight": 4.5,
+                  "image": null,
+                  "selectedOptions": [
+                    {
+                      "name": "Color or something",
+                      "value": "Awesome Copper Bench"
+                    }
+                  ]
+                },
+                "quantity": 5,
+                "customAttributes": []
+              }
+            }
+          ]
+        },
+        "shippingAddress": {
+          "address1": "123 Cat Road",
+          "address2": null,
+          "city": "Cat Land",
+          "company": "Catmart",
+          "country": "Canada",
+          "firstName": "Meow",
+          "formatted": [
+            "Catmart",
+            "123 Cat Road",
+            "Cat Land ON M3O 0W1",
+            "Canada"
+          ],
+          "lastName": "Meowington",
+          "latitude": null,
+          "longitude": null,
+          "phone": "4161234566",
+          "province": "Ontario",
+          "zip": "M3O 0W1",
+          "name": "Meow Meowington",
+          "countryCode": "CA",
+          "provinceCode": "ON",
+          "id": "Z2lkOi8vc2hvcGlmeS9QcmdfnAU8nakdWMnAbh890hyOTEwNjA2NDU4NA=="
+        },
+        "shippingLine": null,
+        "requiresShipping": true,
+        "email": "user@example.com",
+        "customAttributes": [{key: "MyKey", value: "MyValue"}],
+        "note": null,
+        "paymentDue": "367.19",
+        "webUrl": "https://checkout.myshopify.io/1/checkouts/c4abf4bf036239ab5e3d0bf93c642c96",
+        "orderStatusUrl": null,
+        "taxExempt": false,
+        "taxesIncluded": false,
+        "currencyCode": "CAD",
+        "totalTax": "42.24",
+        "subtotalPrice": "324.95",
+        "totalPrice": "367.19",
+        "completedAt": null,
+        "createdAt": "2017-03-28T16:58:31Z",
+        "updatedAt": "2017-03-28T16:58:31Z"
+      }
+    }
+  }
+};

--- a/src/checkout-resource.js
+++ b/src/checkout-resource.js
@@ -106,7 +106,7 @@ class CheckoutResource extends Resource {
    * });
    *
    * @param {String} checkoutId The ID of the checkout to add discount to.
-   * @param {String} email The discount code to apply to the checkout.
+   * @param {String} email The email address to apply to the checkout.
    * @return {Promise|GraphModel} A promise resolving with the updated checkout.
    */
   updateEmail(checkoutId, email) {

--- a/src/checkout-resource.js
+++ b/src/checkout-resource.js
@@ -10,6 +10,7 @@ import checkoutLineItemsRemoveMutation from './graphql/checkoutLineItemsRemoveMu
 import checkoutLineItemsUpdateMutation from './graphql/checkoutLineItemsUpdateMutation.graphql';
 import checkoutAttributesUpdateMutation from './graphql/checkoutAttributesUpdateMutation.graphql';
 import checkoutDiscountCodeApplyMutation from './graphql/checkoutDiscountCodeApplyMutation.graphql';
+import checkoutEmailUpdateMutation from './graphql/checkoutEmailUpdateMutation.graphql';
 
 /**
  * The JS Buy SDK checkout resource
@@ -91,6 +92,27 @@ class CheckoutResource extends Resource {
     return this.graphQLClient
       .send(checkoutAttributesUpdateMutation, {checkoutId, input})
       .then(handleCheckoutMutation('checkoutAttributesUpdate', this.graphQLClient));
+  }
+
+  /**
+   * Replaces the value of checkout's email address
+   *
+   * @example
+   * const checkoutId = 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9kMTZmM2EzMDM4Yjc4N=';
+   * const email = 'user@example.com';
+   *
+   * client.checkout.updateEmail(checkoutId, email).then((checkout) => {
+   *   // Do something with the updated checkout
+   * });
+   *
+   * @param {String} checkoutId The ID of the checkout to add discount to.
+   * @param {String} email The discount code to apply to the checkout.
+   * @return {Promise|GraphModel} A promise resolving with the updated checkout.
+   */
+  updateEmail(checkoutId, email) {
+    return this.graphQLClient
+      .send(checkoutEmailUpdateMutation, {checkoutId, email})
+      .then(handleCheckoutMutation('checkoutEmailUpdate', this.graphQLClient));
   }
 
   /**

--- a/src/graphql/CheckoutFragment.graphql
+++ b/src/graphql/CheckoutFragment.graphql
@@ -35,6 +35,7 @@ fragment CheckoutFragment on Checkout {
   completedAt
   createdAt
   updatedAt
+  email
   shippingAddress {
     ...MailingAddressFragment
   }

--- a/src/graphql/checkoutEmailUpdateMutation.graphql
+++ b/src/graphql/checkoutEmailUpdateMutation.graphql
@@ -1,0 +1,10 @@
+mutation checkoutEmailUpdate($checkoutId: ID!, $email: String!) {
+  checkoutEmailUpdate(checkoutId: $checkoutId, email: $email) {
+    userErrors {
+      ...UserErrorFragment
+    }
+    checkout {
+      ...CheckoutFragment
+    }
+  }
+}

--- a/test/client-checkout-integration-test.js
+++ b/test/client-checkout-integration-test.js
@@ -11,6 +11,7 @@ import checkoutLineItemsAddFixture from '../fixtures/checkout-line-items-add-fix
 import checkoutLineItemsUpdateFixture from '../fixtures/checkout-line-items-update-fixture';
 import checkoutLineItemsRemoveFixture from '../fixtures/checkout-line-items-remove-fixture';
 import checkoutUpdateAttributesFixture from '../fixtures/checkout-update-custom-attrs-fixture';
+import checkoutUpdateEmailFixture from '../fixtures/checkout-update-email-fixture';
 
 suite('client-checkout-integration-test', () => {
   const domain = 'client-integration-tests.myshopify.io';
@@ -78,6 +79,21 @@ suite('client-checkout-integration-test', () => {
       assert.equal(checkout.id, checkoutUpdateAttributesFixture.data.checkoutAttributesUpdate.checkout.id);
       assert.equal(checkout.customAttributes[0].key, checkoutUpdateAttributesFixture.data.checkoutAttributesUpdate.checkout.customAttributes[0].key);
       assert.equal(checkout.customAttributes[0].value, checkoutUpdateAttributesFixture.data.checkoutAttributesUpdate.checkout.customAttributes[0].value);
+      assert.ok(fetchMock.done());
+    });
+  });
+
+  test('it resolves with a checkout on Client.checkout#email_update', () => {
+    const checkoutId = 'Z2lkOi8vU2hvcGlmeS9FeGFtcGxlLzE=';
+    const input = {
+      email: 'user@example.com'
+    };
+
+    fetchMock.postOnce(apiUrl, checkoutUpdateEmailFixture);
+
+    return client.checkout.updateEmail(checkoutId, input).then((checkout) => {
+      assert.equal(checkout.id, checkoutUpdateEmailFixture.data.checkoutEmailUpdate.checkout.id);
+      assert.equal(checkout.email, checkoutUpdateEmailFixture.data.checkoutEmailUpdate.checkout.email);
       assert.ok(fetchMock.done());
     });
   });


### PR DESCRIPTION
This PR adds support to the checkoutEmailUpdate mutation. I have also added email to the checkout object.

https://help.shopify.com/en/api/custom-storefronts/storefront-api/reference/mutation/checkoutemailupdate

I have not updated the documents as I noticed in other PRs you've requested not to update as it causes merge conflicts but can do if you would like.