### PR TITLE
Remove director

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,4 +1,3 @@
 # https://services.shopify.io/services/js-buy-sdk/production
-director: stergios14
 owners: [minasmart]
 classification: library


### PR DESCRIPTION
**Owners**: @minasmart
**Service**: [js-buy-sdk/production](https://services.shopify.io/services/js-buy-sdk/production)

Director ownership has been deprecated in favour of Product/Service Line ownership.

For more information on service ownership, you can read the docs in [Services DB](https://services.shopify.io/doc/ownership).
