### PR TITLE
Handle a null response when fetching a checkout

### DIFF
--- a/fixtures/node-null-fixture.js
+++ b/fixtures/node-null-fixture.js
@@ -1,0 +1,5 @@
+export default {
+  "data": {
+    "node": null
+  }
+};

--- a/src/checkout-resource.js
+++ b/src/checkout-resource.js
@@ -34,6 +34,8 @@ class CheckoutResource extends Resource {
       .send(checkoutNodeQuery, {id})
       .then(defaultResolver('node'))
       .then((checkout) => {
+        if (!checkout) { return null; }
+
         return this.graphQLClient.fetchAllPages(checkout.lineItems, {pageSize: 250}).then((lineItems) => {
           checkout.attrs.lineItems = lineItems;
 

--- a/test/client-checkout-integration-test.js
+++ b/test/client-checkout-integration-test.js
@@ -4,6 +4,7 @@ import fetchMock from './isomorphic-fetch-mock'; // eslint-disable-line import/n
 
 // fixtures
 import checkoutFixture from '../fixtures/checkout-fixture';
+import checkoutNullFixture from '../fixtures/node-null-fixture';
 import checkoutCreateFixture from '../fixtures/checkout-create-fixture';
 import checkoutCreateWithPaginatedLineItemsFixture from '../fixtures/checkout-create-with-paginated-line-items-fixture';
 import {secondPageLineItemsFixture, thirdPageLineItemsFixture} from '../fixtures/paginated-line-items-fixture';
@@ -39,6 +40,17 @@ suite('client-checkout-integration-test', () => {
 
     return client.checkout.fetch(checkoutId).then((checkout) => {
       assert.equal(checkout.id, checkoutId);
+      assert.ok(fetchMock.done());
+    });
+  });
+
+  test('it resolves with null on Client.checkout#fetch for a bad checkoutId', () => {
+    fetchMock.postOnce(apiUrl, checkoutNullFixture);
+
+    const checkoutId = checkoutFixture.data.node.id;
+
+    return client.checkout.fetch(checkoutId).then((checkout) => {
+      assert.equal(checkout, null);
       assert.ok(fetchMock.done());
     });
   });


### PR DESCRIPTION
If you try to fetch a checkout which doesn't exist, the `CheckoutResource.fetch` code throws an error. Since this is a valid case, we should handle it by returning the null checkout.

Fixes #563 