### PR TITLE
Expose discounts on checkouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,17 @@ client.checkout.addDiscount(checkoutId, discountCode).then(checkout => {
 });
 ```
 
+### Removing a Discount
+```javascript
+const checkoutId = 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI='; // ID of an existing checkout
+
+// Removes the applied discount from an existing checkout.
+client.checkout.removeDiscount(checkoutId).then(checkout => {
+  // Do something with the updated checkout
+  console.log(checkout);
+});
+```
+
 ## Example Apps
 
 For more complete examples of using JS Buy SDK, check out our [storefront-api-examples](https://github.com/Shopify/storefront-api-examples) project.

--- a/fixtures/checkout-discount-code-apply-fixture.js
+++ b/fixtures/checkout-discount-code-apply-fixture.js
@@ -1,0 +1,85 @@
+export default {
+  "data": {
+    "checkoutDiscountCodeApply": {
+      "userErrors": [],
+      "checkout": {
+        "id": "Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",
+        "createdAt": "2017-03-17T16:00:40Z",
+        "updatedAt": "2017-03-17T16:00:40Z",
+        "requiresShipping": true,
+        "shippingLine": null,
+        "order": null,
+        "orderStatusUrl": null,
+        "taxExempt": false,
+        "taxesIncluded": false,
+        "currencyCode": "CAD",
+        "totalPrice": "80.28",
+        "subtotalPrice": "67.50",
+        "totalTax": "8.78",
+        "paymentDue": "80.28",
+        "taxExempt": false,
+        "taxesIncluded": false,
+        "completedAt": null,
+        "shippingAddress": {
+          "address1": "123 Cat Road",
+          "address2": null,
+          "city": "Cat Land",
+          "company": "Catmart",
+          "country": "Canada",
+          "firstName": "Meow",
+          "formatted": [
+            "Catmart",
+            "123 Cat Road",
+            "Cat Land ON M3O 0W1",
+            "Canada"
+          ],
+          "lastName": "Meowington",
+          "latitude": null,
+          "longitude": null,
+          "phone": "4161234566",
+          "province": "Ontario",
+          "zip": "M3O 0W1",
+          "name": "Meow Meowington",
+          "countryCode": "CA",
+          "provinceCode": "ON",
+          "id": "291dC9lM2JkNzHJnnf8a89njNJNKAhu1gn7lMzM5MzFlZj9rZXk9NDcwOTJ=="
+        },
+        "lineItems": {
+          "pageInfo": {
+            "hasNextPage": false,
+            "hasPreviousPage": false
+          },
+          "edges": [
+            {
+              "cursor": "eyJsYXN0X2lkIjoiZDUyZWU5ZTEwYmQxMWE0NDlkNmQzMWNkMzBhMGFjNzMifQ==",
+              "node": {
+                "title": "Intelligent Granite Table",
+                "variant": {
+                  "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
+                  "price": "74.99"
+                },
+                "quantity": 5,
+                "customAttributes": [],
+                "discountAllocations": [
+                  {
+                    "allocatedAmount": {
+                      "amount": "7.49",
+                      "currencyCode": "CAD"
+                    },
+                    "discountApplication": {
+                      "targetSelection": "ALL",
+                      "allocationMethod": "ACROSS",
+                      "targetType": "LINE_ITEM",
+                      "code": "TENPERCENTOFF",
+                      "applicable": true
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+};

--- a/fixtures/checkout-discount-code-remove-fixture.js
+++ b/fixtures/checkout-discount-code-remove-fixture.js
@@ -1,0 +1,71 @@
+export default {
+  "data": {
+    "checkoutDiscountCodeRemove": {
+      "userErrors": [],
+      "checkout": {
+        "id": "Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",
+        "createdAt": "2017-03-17T16:00:40Z",
+        "updatedAt": "2017-03-17T16:00:40Z",
+        "requiresShipping": true,
+        "shippingLine": null,
+        "order": null,
+        "orderStatusUrl": null,
+        "taxExempt": false,
+        "taxesIncluded": false,
+        "currencyCode": "CAD",
+        "totalPrice": "88.74",
+        "subtotalPrice": "74.99",
+        "totalTax": "9.75",
+        "paymentDue": "88.74",
+        "taxExempt": false,
+        "taxesIncluded": false,
+        "completedAt": null,
+        "shippingAddress": {
+          "address1": "123 Cat Road",
+          "address2": null,
+          "city": "Cat Land",
+          "company": "Catmart",
+          "country": "Canada",
+          "firstName": "Meow",
+          "formatted": [
+            "Catmart",
+            "123 Cat Road",
+            "Cat Land ON M3O 0W1",
+            "Canada"
+          ],
+          "lastName": "Meowington",
+          "latitude": null,
+          "longitude": null,
+          "phone": "4161234566",
+          "province": "Ontario",
+          "zip": "M3O 0W1",
+          "name": "Meow Meowington",
+          "countryCode": "CA",
+          "provinceCode": "ON",
+          "id": "291dC9lM2JkNzHJnnf8a89njNJNKAhu1gn7lMzM5MzFlZj9rZXk9NDcwOTJ=="
+        },
+        "lineItems": {
+          "pageInfo": {
+            "hasNextPage": false,
+            "hasPreviousPage": false
+          },
+          "edges": [
+            {
+              "cursor": "eyJsYXN0X2lkIjoiZDUyZWU5ZTEwYmQxMWE0NDlkNmQzMWNkMzBhMGFjNzMifQ==",
+              "node": {
+                "title": "Intelligent Granite Table",
+                "variant": {
+                  "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
+                  "price": "74.99"
+                },
+                "quantity": 5,
+                "customAttributes": [],
+                "discountAllocations": []
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+};

--- a/schema.json
+++ b/schema.json
@@ -10,11 +10,231 @@
       "subscriptionType": null,
       "types": [
         {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": "Represents `true` or `false` values.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": "Represents textual data as UTF-8 character sequences. This type is most often used by GraphQL to represent free-form human-readable text.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "QueryRoot",
-          "description":
-            "The schema’s entry-point for queries. This acts as the public, top-level API from which all queries must start.",
+          "description": "The schema’s entry-point for queries. This acts as the public, top-level API from which all queries must start.",
           "fields": [
+            {
+              "name": "articles",
+              "description": "List of the shop's articles.",
+              "args": [
+                {
+                  "name": "first",
+                  "description": "Returns up to the first `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "after",
+                  "description": "Returns the elements that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "reverse",
+                  "description": "Reverse the order of the underlying list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                },
+                {
+                  "name": "sortKey",
+                  "description": "Sort the underlying list by the given key.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "ArticleSortKeys",
+                    "ofType": null
+                  },
+                  "defaultValue": "ID"
+                },
+                {
+                  "name": "query",
+                  "description": "Supported filter parameters:\n - `author`\n - `updated_at`\n - `created_at`\n - `blog_title`\n - `tag`\n\nSee the detailed [search syntax](https://help.shopify.com/api/getting-started/search-syntax).\n",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ArticleConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "blogByHandle",
+              "description": "Find a blog by its handle.",
+              "args": [
+                {
+                  "name": "handle",
+                  "description": "The handle of the blog.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Blog",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "blogs",
+              "description": "List of the shop's blogs.",
+              "args": [
+                {
+                  "name": "first",
+                  "description": "Returns up to the first `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "after",
+                  "description": "Returns the elements that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "reverse",
+                  "description": "Reverse the order of the underlying list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                },
+                {
+                  "name": "sortKey",
+                  "description": "Sort the underlying list by the given key.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "BlogSortKeys",
+                    "ofType": null
+                  },
+                  "defaultValue": "ID"
+                },
+                {
+                  "name": "query",
+                  "description": "Supported filter parameters:\n - `handle`\n - `title`\n - `updated_at`\n - `created_at`\n\nSee the detailed [search syntax](https://help.shopify.com/api/getting-started/search-syntax).\n",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "BlogConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "customer",
               "description": null,
@@ -48,7 +268,7 @@
               "args": [
                 {
                   "name": "id",
-                  "description": null,
+                  "description": "The ID of the Node to return.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -75,7 +295,7 @@
               "args": [
                 {
                   "name": "ids",
-                  "description": null,
+                  "description": "The IDs of the Nodes to return.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -245,8 +465,7 @@
         {
           "kind": "OBJECT",
           "name": "Customer",
-          "description":
-            "A customer represents a customer account with the shop. Customer accounts store contact information for the customer, saving logged-in customers the trouble of having to provide it at every checkout.",
+          "description": "A customer represents a customer account with the shop. Customer accounts store contact information for the customer, saving logged-in customers the trouble of having to provide it at every checkout.",
           "fields": [
             {
               "name": "acceptsMarketing",
@@ -270,21 +489,37 @@
               "args": [
                 {
                   "name": "first",
-                  "description": null,
+                  "description": "Returns up to the first `n` elements from the list.",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
                   },
                   "defaultValue": null
                 },
                 {
                   "name": "after",
-                  "description": null,
+                  "description": "Returns the elements that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -294,7 +529,7 @@
                 },
                 {
                   "name": "reverse",
-                  "description": null,
+                  "description": "Reverse the order of the underlying list.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Boolean",
@@ -400,6 +635,18 @@
               "deprecationReason": null
             },
             {
+              "name": "lastIncompleteCheckout",
+              "description": "The customer's most recently updated, incomplete checkout.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Checkout",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "lastName",
               "description": "The customer’s last name.",
               "args": [],
@@ -417,21 +664,17 @@
               "args": [
                 {
                   "name": "first",
-                  "description": null,
+                  "description": "Returns up to the first `n` elements from the list.",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
                   },
                   "defaultValue": null
                 },
                 {
                   "name": "after",
-                  "description": null,
+                  "description": "Returns the elements that come after the specified cursor.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -440,18 +683,38 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "query",
-                  "description": "Supported filter parameters:\n - `processed_at`",
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "reverse",
+                  "description": "Reverse the order of the underlying list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
                 },
                 {
                   "name": "sortKey",
-                  "description": null,
+                  "description": "Sort the underlying list by the given key.",
                   "type": {
                     "kind": "ENUM",
                     "name": "OrderSortKeys",
@@ -460,14 +723,14 @@
                   "defaultValue": "ID"
                 },
                 {
-                  "name": "reverse",
-                  "description": null,
+                  "name": "query",
+                  "description": "Supported filter parameters:\n - `processed_at`\n\nSee the detailed [search syntax](https://help.shopify.com/api/getting-started/search-syntax).\n",
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Boolean",
+                    "name": "String",
                     "ofType": null
                   },
-                  "defaultValue": "false"
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -518,29 +781,8 @@
         },
         {
           "kind": "SCALAR",
-          "name": "String",
-          "description":
-            "Represents textual data as UTF-8 character sequences. This type is most often used by GraphQL to represent free-form human-readable text.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Boolean",
-          "description": "Represents `true` or `false` values.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
           "name": "DateTime",
-          "description": "An ISO-8601 encoded UTC date string.",
+          "description": "An ISO-8601 encoded UTC date time string.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -554,7 +796,7 @@
           "fields": [
             {
               "name": "address1",
-              "description": null,
+              "description": "The first line of the address. Typically the street address or PO Box number.\n",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -566,7 +808,7 @@
             },
             {
               "name": "address2",
-              "description": null,
+              "description": "The second line of the address. Typically the number of the apartment, suite, or unit.\n",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -578,7 +820,7 @@
             },
             {
               "name": "city",
-              "description": null,
+              "description": "The name of the city, district, village, or town.\n",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -590,7 +832,7 @@
             },
             {
               "name": "company",
-              "description": null,
+              "description": "The name of the customer's company or organization.\n",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -602,7 +844,7 @@
             },
             {
               "name": "country",
-              "description": null,
+              "description": "The name of the country.\n",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -614,11 +856,23 @@
             },
             {
               "name": "countryCode",
-              "description": null,
+              "description": "The two-letter code for the country of the address.\n\nFor example, US.\n",
               "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `countryCodeV2` instead"
+            },
+            {
+              "name": "countryCodeV2",
+              "description": "The two-letter code for the country of the address.\n\nFor example, US.\n",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "CountryCode",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -626,7 +880,7 @@
             },
             {
               "name": "firstName",
-              "description": null,
+              "description": "The first name of the customer.",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -638,11 +892,11 @@
             },
             {
               "name": "formatted",
-              "description": null,
+              "description": "A formatted version of the address, customized by the provided arguments.",
               "args": [
                 {
                   "name": "withName",
-                  "description": null,
+                  "description": "Whether to include the customer's name in the formatted address.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Boolean",
@@ -652,7 +906,7 @@
                 },
                 {
                   "name": "withCompany",
-                  "description": null,
+                  "description": "Whether to include the customer's company in the formatted address.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Boolean",
@@ -683,7 +937,7 @@
             },
             {
               "name": "formattedArea",
-              "description": null,
+              "description": "A comma-separated list of the values for city, province, and country.",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -711,7 +965,7 @@
             },
             {
               "name": "lastName",
-              "description": null,
+              "description": "The last name of the customer.",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -723,7 +977,7 @@
             },
             {
               "name": "latitude",
-              "description": null,
+              "description": "The latitude coordinate of the customer address.",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -735,7 +989,7 @@
             },
             {
               "name": "longitude",
-              "description": null,
+              "description": "The longitude coordinate of the customer address.",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -747,7 +1001,7 @@
             },
             {
               "name": "name",
-              "description": null,
+              "description": "The full name of the customer, based on firstName and lastName.\n",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -759,7 +1013,7 @@
             },
             {
               "name": "phone",
-              "description": null,
+              "description": "A unique phone number for the customer.\n\nFormatted using E.164 standard. For example, _+16135551111_.\n",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -771,7 +1025,7 @@
             },
             {
               "name": "province",
-              "description": null,
+              "description": "The region of the address, such as the province, state, or district.",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -783,7 +1037,7 @@
             },
             {
               "name": "provinceCode",
-              "description": null,
+              "description": "The two-letter code for the region.\n\nFor example, ON.\n",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -795,7 +1049,7 @@
             },
             {
               "name": "zip",
-              "description": null,
+              "description": "The zip or postal code of the address.",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -820,12 +1074,1474 @@
         {
           "kind": "SCALAR",
           "name": "Float",
-          "description":
-            "Represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).",
+          "description": "Represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "CountryCode",
+          "description": "ISO 3166-1 alpha-2 country codes with some differences.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "AF",
+              "description": "Afghanistan.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "AX",
+              "description": "Aland Islands.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "AL",
+              "description": "Albania.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DZ",
+              "description": "Algeria.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "AD",
+              "description": "Andorra.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "AO",
+              "description": "Angola.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "AI",
+              "description": "Anguilla.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "AG",
+              "description": "Antigua And Barbuda.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "AR",
+              "description": "Argentina.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "AM",
+              "description": "Armenia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "AW",
+              "description": "Aruba.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "AU",
+              "description": "Australia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "AT",
+              "description": "Austria.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "AZ",
+              "description": "Azerbaijan.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BS",
+              "description": "Bahamas.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BH",
+              "description": "Bahrain.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BD",
+              "description": "Bangladesh.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BB",
+              "description": "Barbados.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BY",
+              "description": "Belarus.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BE",
+              "description": "Belgium.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BZ",
+              "description": "Belize.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BJ",
+              "description": "Benin.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BM",
+              "description": "Bermuda.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BT",
+              "description": "Bhutan.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BO",
+              "description": "Bolivia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BQ",
+              "description": "Bonaire, Sint Eustatius and Saba.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BA",
+              "description": "Bosnia And Herzegovina.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BW",
+              "description": "Botswana.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BV",
+              "description": "Bouvet Island.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BR",
+              "description": "Brazil.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "IO",
+              "description": "British Indian Ocean Territory.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BN",
+              "description": "Brunei.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BG",
+              "description": "Bulgaria.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BF",
+              "description": "Burkina Faso.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BI",
+              "description": "Burundi.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "KH",
+              "description": "Cambodia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CA",
+              "description": "Canada.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CV",
+              "description": "Cape Verde.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "KY",
+              "description": "Cayman Islands.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CF",
+              "description": "Central African Republic.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TD",
+              "description": "Chad.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CL",
+              "description": "Chile.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CN",
+              "description": "China.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CX",
+              "description": "Christmas Island.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CC",
+              "description": "Cocos (Keeling) Islands.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CO",
+              "description": "Colombia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "KM",
+              "description": "Comoros.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CG",
+              "description": "Congo.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CD",
+              "description": "Congo, The Democratic Republic Of The.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CK",
+              "description": "Cook Islands.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CR",
+              "description": "Costa Rica.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "HR",
+              "description": "Croatia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CU",
+              "description": "Cuba.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CW",
+              "description": "Curaçao.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CY",
+              "description": "Cyprus.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CZ",
+              "description": "Czech Republic.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CI",
+              "description": "Côte d'Ivoire.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DK",
+              "description": "Denmark.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DJ",
+              "description": "Djibouti.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DM",
+              "description": "Dominica.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DO",
+              "description": "Dominican Republic.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "EC",
+              "description": "Ecuador.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "EG",
+              "description": "Egypt.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SV",
+              "description": "El Salvador.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GQ",
+              "description": "Equatorial Guinea.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ER",
+              "description": "Eritrea.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "EE",
+              "description": "Estonia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ET",
+              "description": "Ethiopia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FK",
+              "description": "Falkland Islands (Malvinas).",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FO",
+              "description": "Faroe Islands.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FJ",
+              "description": "Fiji.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FI",
+              "description": "Finland.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FR",
+              "description": "France.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GF",
+              "description": "French Guiana.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PF",
+              "description": "French Polynesia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TF",
+              "description": "French Southern Territories.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GA",
+              "description": "Gabon.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GM",
+              "description": "Gambia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GE",
+              "description": "Georgia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DE",
+              "description": "Germany.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GH",
+              "description": "Ghana.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GI",
+              "description": "Gibraltar.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GR",
+              "description": "Greece.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GL",
+              "description": "Greenland.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GD",
+              "description": "Grenada.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GP",
+              "description": "Guadeloupe.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GT",
+              "description": "Guatemala.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GG",
+              "description": "Guernsey.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GN",
+              "description": "Guinea.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GW",
+              "description": "Guinea Bissau.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GY",
+              "description": "Guyana.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "HT",
+              "description": "Haiti.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "HM",
+              "description": "Heard Island And Mcdonald Islands.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "VA",
+              "description": "Holy See (Vatican City State).",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "HN",
+              "description": "Honduras.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "HK",
+              "description": "Hong Kong.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "HU",
+              "description": "Hungary.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "IS",
+              "description": "Iceland.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "IN",
+              "description": "India.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ID",
+              "description": "Indonesia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "IR",
+              "description": "Iran, Islamic Republic Of.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "IQ",
+              "description": "Iraq.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "IE",
+              "description": "Ireland.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "IM",
+              "description": "Isle Of Man.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "IL",
+              "description": "Israel.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "IT",
+              "description": "Italy.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "JM",
+              "description": "Jamaica.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "JP",
+              "description": "Japan.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "JE",
+              "description": "Jersey.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "JO",
+              "description": "Jordan.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "KZ",
+              "description": "Kazakhstan.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "KE",
+              "description": "Kenya.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "KI",
+              "description": "Kiribati.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "KP",
+              "description": "Korea, Democratic People's Republic Of.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "XK",
+              "description": "Kosovo.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "KW",
+              "description": "Kuwait.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "KG",
+              "description": "Kyrgyzstan.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LA",
+              "description": "Lao People's Democratic Republic.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LV",
+              "description": "Latvia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LB",
+              "description": "Lebanon.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LS",
+              "description": "Lesotho.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LR",
+              "description": "Liberia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LY",
+              "description": "Libyan Arab Jamahiriya.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LI",
+              "description": "Liechtenstein.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LT",
+              "description": "Lithuania.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LU",
+              "description": "Luxembourg.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MO",
+              "description": "Macao.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MK",
+              "description": "Macedonia, Republic Of.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MG",
+              "description": "Madagascar.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MW",
+              "description": "Malawi.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MY",
+              "description": "Malaysia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MV",
+              "description": "Maldives.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ML",
+              "description": "Mali.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MT",
+              "description": "Malta.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MQ",
+              "description": "Martinique.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MR",
+              "description": "Mauritania.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MU",
+              "description": "Mauritius.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "YT",
+              "description": "Mayotte.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MX",
+              "description": "Mexico.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MD",
+              "description": "Moldova, Republic of.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MC",
+              "description": "Monaco.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MN",
+              "description": "Mongolia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ME",
+              "description": "Montenegro.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MS",
+              "description": "Montserrat.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MA",
+              "description": "Morocco.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MZ",
+              "description": "Mozambique.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MM",
+              "description": "Myanmar.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NA",
+              "description": "Namibia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NR",
+              "description": "Nauru.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NP",
+              "description": "Nepal.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NL",
+              "description": "Netherlands.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "AN",
+              "description": "Netherlands Antilles.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NC",
+              "description": "New Caledonia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NZ",
+              "description": "New Zealand.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NI",
+              "description": "Nicaragua.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NE",
+              "description": "Niger.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NG",
+              "description": "Nigeria.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NU",
+              "description": "Niue.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NF",
+              "description": "Norfolk Island.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NO",
+              "description": "Norway.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OM",
+              "description": "Oman.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PK",
+              "description": "Pakistan.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PS",
+              "description": "Palestinian Territory, Occupied.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PA",
+              "description": "Panama.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PG",
+              "description": "Papua New Guinea.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PY",
+              "description": "Paraguay.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PE",
+              "description": "Peru.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PH",
+              "description": "Philippines.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PN",
+              "description": "Pitcairn.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PL",
+              "description": "Poland.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PT",
+              "description": "Portugal.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "QA",
+              "description": "Qatar.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CM",
+              "description": "Republic of Cameroon.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RE",
+              "description": "Reunion.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RO",
+              "description": "Romania.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RU",
+              "description": "Russia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RW",
+              "description": "Rwanda.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BL",
+              "description": "Saint Barthélemy.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SH",
+              "description": "Saint Helena.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "KN",
+              "description": "Saint Kitts And Nevis.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LC",
+              "description": "Saint Lucia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MF",
+              "description": "Saint Martin.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PM",
+              "description": "Saint Pierre And Miquelon.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "WS",
+              "description": "Samoa.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SM",
+              "description": "San Marino.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ST",
+              "description": "Sao Tome And Principe.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SA",
+              "description": "Saudi Arabia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SN",
+              "description": "Senegal.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RS",
+              "description": "Serbia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SC",
+              "description": "Seychelles.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SL",
+              "description": "Sierra Leone.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SG",
+              "description": "Singapore.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SX",
+              "description": "Sint Maarten.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SK",
+              "description": "Slovakia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SI",
+              "description": "Slovenia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SB",
+              "description": "Solomon Islands.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SO",
+              "description": "Somalia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ZA",
+              "description": "South Africa.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GS",
+              "description": "South Georgia And The South Sandwich Islands.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "KR",
+              "description": "South Korea.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SS",
+              "description": "South Sudan.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ES",
+              "description": "Spain.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LK",
+              "description": "Sri Lanka.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "VC",
+              "description": "St. Vincent.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SD",
+              "description": "Sudan.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SR",
+              "description": "Suriname.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SJ",
+              "description": "Svalbard And Jan Mayen.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SZ",
+              "description": "Swaziland.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SE",
+              "description": "Sweden.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CH",
+              "description": "Switzerland.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SY",
+              "description": "Syria.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TW",
+              "description": "Taiwan.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TJ",
+              "description": "Tajikistan.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ",
+              "description": "Tanzania, United Republic Of.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TH",
+              "description": "Thailand.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TL",
+              "description": "Timor Leste.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TG",
+              "description": "Togo.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TK",
+              "description": "Tokelau.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TO",
+              "description": "Tonga.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TT",
+              "description": "Trinidad and Tobago.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TN",
+              "description": "Tunisia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TR",
+              "description": "Turkey.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TM",
+              "description": "Turkmenistan.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TC",
+              "description": "Turks and Caicos Islands.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TV",
+              "description": "Tuvalu.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UG",
+              "description": "Uganda.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UA",
+              "description": "Ukraine.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "AE",
+              "description": "United Arab Emirates.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GB",
+              "description": "United Kingdom.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "US",
+              "description": "United States.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UM",
+              "description": "United States Minor Outlying Islands.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UY",
+              "description": "Uruguay.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UZ",
+              "description": "Uzbekistan.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "VU",
+              "description": "Vanuatu.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "VE",
+              "description": "Venezuela.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "VN",
+              "description": "Vietnam.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "VG",
+              "description": "Virgin Islands, British.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "WF",
+              "description": "Wallis And Futuna.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "EH",
+              "description": "Western Sahara.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "YE",
+              "description": "Yemen.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ZM",
+              "description": "Zambia.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ZW",
+              "description": "Zimbabwe.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -968,8 +2684,7 @@
         {
           "kind": "SCALAR",
           "name": "Int",
-          "description":
-            "Represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+          "description": "Represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -1073,8 +2788,7 @@
         {
           "kind": "OBJECT",
           "name": "Order",
-          "description":
-            "An order is a customer’s completed request to purchase one or more products from a shop. An order is created when a customer completes the checkout process, during which time they provides an email address, billing address and payment information.",
+          "description": "An order is a customer’s completed request to purchase one or more products from a shop. An order is created when a customer completes the checkout process, during which time they provides an email address, billing address and payment information.",
           "fields": [
             {
               "name": "currencyCode",
@@ -1106,12 +2820,79 @@
             },
             {
               "name": "customerUrl",
-              "description": "The order’s URL for a customer.",
+              "description": "The unique URL that the customer can use to access the order.",
               "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "URL",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "discountApplications",
+              "description": "Discounts that have been applied on the order.",
+              "args": [
+                {
+                  "name": "first",
+                  "description": "Returns up to the first `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "after",
+                  "description": "Returns the elements that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "reverse",
+                  "description": "Reverse the order of the underlying list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "DiscountApplicationConnection",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1150,21 +2931,37 @@
               "args": [
                 {
                   "name": "first",
-                  "description": null,
+                  "description": "Returns up to the first `n` elements from the list.",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
                   },
                   "defaultValue": null
                 },
                 {
                   "name": "after",
-                  "description": null,
+                  "description": "Returns the elements that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -1174,7 +2971,7 @@
                 },
                 {
                   "name": "reverse",
-                  "description": null,
+                  "description": "Reverse the order of the underlying list.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Boolean",
@@ -1189,6 +2986,22 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "OrderLineItemConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "Unique identifier for the order that appears on the order.\nFor example, _#1000_ or _Store1001.\n",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },
@@ -1225,8 +3038,7 @@
             },
             {
               "name": "processedAt",
-              "description":
-                "The date and time when the order was imported.\nThis value can be set to dates in the past when importing from other systems.\nIf no value is provided, it will be auto-generated based on current date and time.\n",
+              "description": "The date and time when the order was imported.\nThis value can be set to dates in the past when importing from other systems.\nIf no value is provided, it will be auto-generated based on current date and time.\n",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -1253,6 +3065,46 @@
               "deprecationReason": null
             },
             {
+              "name": "shippingDiscountAllocations",
+              "description": "The discounts that have been allocated onto the shipping line by discount applications.\n",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "DiscountAllocation",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "statusUrl",
+              "description": "The unique URL for the order's status page.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "URL",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "subtotalPrice",
               "description": "Price of the order before shipping and taxes.",
               "args": [],
@@ -1265,9 +3117,39 @@
               "deprecationReason": null
             },
             {
+              "name": "successfulFulfillments",
+              "description": "List of the order’s successful fulfillments.",
+              "args": [
+                {
+                  "name": "first",
+                  "description": "Truncate the array result to this size.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Fulfillment",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "totalPrice",
-              "description":
-                "The sum of all the prices of all the items in the order, taxes and discounts included (must be positive).",
+              "description": "The sum of all the prices of all the items in the order, taxes and discounts included (must be positive).",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -1357,823 +3239,841 @@
           "enumValues": [
             {
               "name": "USD",
-              "description": "United States Dollars (USD)",
+              "description": "United States Dollars (USD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "EUR",
-              "description": "Euro (EUR)",
+              "description": "Euro (EUR).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "GBP",
-              "description": "United Kingdom Pounds (GBP)",
+              "description": "United Kingdom Pounds (GBP).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "CAD",
-              "description": "Canadian Dollars (CAD)",
+              "description": "Canadian Dollars (CAD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "AFN",
-              "description": "Afghan Afghani (AFN)",
+              "description": "Afghan Afghani (AFN).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ALL",
-              "description": "Albanian Lek (ALL)",
+              "description": "Albanian Lek (ALL).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "DZD",
-              "description": "Algerian Dinar (DZD)",
+              "description": "Algerian Dinar (DZD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "AOA",
-              "description": "Angolan Kwanza (AOA)",
+              "description": "Angolan Kwanza (AOA).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ARS",
-              "description": "Argentine Pesos (ARS)",
+              "description": "Argentine Pesos (ARS).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "AMD",
-              "description": "Armenian Dram (AMD)",
+              "description": "Armenian Dram (AMD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "AWG",
-              "description": "Aruban Florin (AWG)",
+              "description": "Aruban Florin (AWG).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "AUD",
-              "description": "Australian Dollars (AUD)",
+              "description": "Australian Dollars (AUD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "BBD",
-              "description": "Barbadian Dollar (BBD)",
+              "description": "Barbadian Dollar (BBD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "AZN",
-              "description": "Azerbaijani Manat (AZN)",
+              "description": "Azerbaijani Manat (AZN).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "BDT",
-              "description": "Bangladesh Taka (BDT)",
+              "description": "Bangladesh Taka (BDT).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "BSD",
-              "description": "Bahamian Dollar (BSD)",
+              "description": "Bahamian Dollar (BSD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "BHD",
-              "description": "Bahraini Dinar (BHD)",
+              "description": "Bahraini Dinar (BHD).",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BIF",
+              "description": "Burundian Franc (BIF).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "BYR",
-              "description": "Belarusian Ruble (BYR)",
+              "description": "Belarusian Ruble (BYR).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "BZD",
-              "description": "Belize Dollar (BZD)",
+              "description": "Belize Dollar (BZD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "BTN",
-              "description": "Bhutanese Ngultrum (BTN)",
+              "description": "Bhutanese Ngultrum (BTN).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "BAM",
-              "description": "Bosnia and Herzegovina Convertible Mark (BAM)",
+              "description": "Bosnia and Herzegovina Convertible Mark (BAM).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "BRL",
-              "description": "Brazilian Real (BRL)",
+              "description": "Brazilian Real (BRL).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "BOB",
-              "description": "Bolivian Boliviano (BOB)",
+              "description": "Bolivian Boliviano (BOB).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "BWP",
-              "description": "Botswana Pula (BWP)",
+              "description": "Botswana Pula (BWP).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "BND",
-              "description": "Brunei Dollar (BND)",
+              "description": "Brunei Dollar (BND).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "BGN",
-              "description": "Bulgarian Lev (BGN)",
+              "description": "Bulgarian Lev (BGN).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "MMK",
-              "description": "Burmese Kyat (MMK)",
+              "description": "Burmese Kyat (MMK).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "KHR",
-              "description": "Cambodian Riel",
+              "description": "Cambodian Riel.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "CVE",
-              "description": "Cape Verdean escudo (CVE)",
+              "description": "Cape Verdean escudo (CVE).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "KYD",
-              "description": "Cayman Dollars (KYD)",
+              "description": "Cayman Dollars (KYD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "XAF",
-              "description": "Central African CFA Franc (XAF)",
+              "description": "Central African CFA Franc (XAF).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "CLP",
-              "description": "Chilean Peso (CLP)",
+              "description": "Chilean Peso (CLP).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "CNY",
-              "description": "Chinese Yuan Renminbi (CNY)",
+              "description": "Chinese Yuan Renminbi (CNY).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "COP",
-              "description": "Colombian Peso (COP)",
+              "description": "Colombian Peso (COP).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "KMF",
-              "description": "Comorian Franc (KMF)",
+              "description": "Comorian Franc (KMF).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "CDF",
-              "description": "Congolese franc (CDF)",
+              "description": "Congolese franc (CDF).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "CRC",
-              "description": "Costa Rican Colones (CRC)",
+              "description": "Costa Rican Colones (CRC).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "HRK",
-              "description": "Croatian Kuna (HRK)",
+              "description": "Croatian Kuna (HRK).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "CZK",
-              "description": "Czech Koruny (CZK)",
+              "description": "Czech Koruny (CZK).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "DKK",
-              "description": "Danish Kroner (DKK)",
+              "description": "Danish Kroner (DKK).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "DOP",
-              "description": "Dominican Peso (DOP)",
+              "description": "Dominican Peso (DOP).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "XCD",
-              "description": "East Caribbean Dollar (XCD)",
+              "description": "East Caribbean Dollar (XCD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "EGP",
-              "description": "Egyptian Pound (EGP)",
+              "description": "Egyptian Pound (EGP).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ETB",
-              "description": "Ethiopian Birr (ETB)",
+              "description": "Ethiopian Birr (ETB).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "XPF",
-              "description": "CFP Franc (XPF)",
+              "description": "CFP Franc (XPF).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "FJD",
-              "description": "Fijian Dollars (FJD)",
+              "description": "Fijian Dollars (FJD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "GMD",
-              "description": "Gambian Dalasi (GMD)",
+              "description": "Gambian Dalasi (GMD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "GHS",
-              "description": "Ghanaian Cedi (GHS)",
+              "description": "Ghanaian Cedi (GHS).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "GTQ",
-              "description": "Guatemalan Quetzal (GTQ)",
+              "description": "Guatemalan Quetzal (GTQ).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "GYD",
-              "description": "Guyanese Dollar (GYD)",
+              "description": "Guyanese Dollar (GYD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "GEL",
-              "description": "Georgian Lari (GEL)",
+              "description": "Georgian Lari (GEL).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "HTG",
-              "description": "Haitian Gourde (HTG)",
+              "description": "Haitian Gourde (HTG).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "HNL",
-              "description": "Honduran Lempira (HNL)",
+              "description": "Honduran Lempira (HNL).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "HKD",
-              "description": "Hong Kong Dollars (HKD)",
+              "description": "Hong Kong Dollars (HKD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "HUF",
-              "description": "Hungarian Forint (HUF)",
+              "description": "Hungarian Forint (HUF).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ISK",
-              "description": "Icelandic Kronur (ISK)",
+              "description": "Icelandic Kronur (ISK).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "INR",
-              "description": "Indian Rupees (INR)",
+              "description": "Indian Rupees (INR).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "IDR",
-              "description": "Indonesian Rupiah (IDR)",
+              "description": "Indonesian Rupiah (IDR).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ILS",
-              "description": "Israeli New Shekel (NIS)",
+              "description": "Israeli New Shekel (NIS).",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "IQD",
+              "description": "Iraqi Dinar (IQD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "JMD",
-              "description": "Jamaican Dollars (JMD)",
+              "description": "Jamaican Dollars (JMD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "JPY",
-              "description": "Japanese Yen (JPY)",
+              "description": "Japanese Yen (JPY).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "JEP",
-              "description": "Jersey Pound",
+              "description": "Jersey Pound.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "JOD",
-              "description": "Jordanian Dinar (JOD)",
+              "description": "Jordanian Dinar (JOD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "KZT",
-              "description": "Kazakhstani Tenge (KZT)",
+              "description": "Kazakhstani Tenge (KZT).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "KES",
-              "description": "Kenyan Shilling (KES)",
+              "description": "Kenyan Shilling (KES).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "KWD",
-              "description": "Kuwaiti Dinar (KWD)",
+              "description": "Kuwaiti Dinar (KWD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "KGS",
-              "description": "Kyrgyzstani Som (KGS)",
+              "description": "Kyrgyzstani Som (KGS).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "LAK",
-              "description": "Laotian Kip (LAK)",
+              "description": "Laotian Kip (LAK).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "LVL",
-              "description": "Latvian Lati (LVL)",
+              "description": "Latvian Lati (LVL).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "LBP",
-              "description": "Lebanese Pounds (LBP)",
+              "description": "Lebanese Pounds (LBP).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "LSL",
-              "description": "Lesotho Loti (LSL)",
+              "description": "Lesotho Loti (LSL).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "LRD",
-              "description": "Liberian Dollar (LRD)",
+              "description": "Liberian Dollar (LRD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "LTL",
-              "description": "Lithuanian Litai (LTL)",
+              "description": "Lithuanian Litai (LTL).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "MGA",
-              "description": "Malagasy Ariary (MGA)",
+              "description": "Malagasy Ariary (MGA).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "MKD",
-              "description": "Macedonia Denar (MKD)",
+              "description": "Macedonia Denar (MKD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "MOP",
-              "description": "Macanese Pataca (MOP)",
+              "description": "Macanese Pataca (MOP).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "MWK",
-              "description": "Malawian Kwacha (MWK)",
+              "description": "Malawian Kwacha (MWK).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "MVR",
-              "description": "Maldivian Rufiyaa (MVR)",
+              "description": "Maldivian Rufiyaa (MVR).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "MXN",
-              "description": "Mexican Pesos (MXN)",
+              "description": "Mexican Pesos (MXN).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "MYR",
-              "description": "Malaysian Ringgits (MYR)",
+              "description": "Malaysian Ringgits (MYR).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "MUR",
-              "description": "Mauritian Rupee (MUR)",
+              "description": "Mauritian Rupee (MUR).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "MDL",
-              "description": "Moldovan Leu (MDL)",
+              "description": "Moldovan Leu (MDL).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "MAD",
-              "description": "Moroccan Dirham",
+              "description": "Moroccan Dirham.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "MNT",
-              "description": "Mongolian Tugrik",
+              "description": "Mongolian Tugrik.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "MZN",
-              "description": "Mozambican Metical",
+              "description": "Mozambican Metical.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "NAD",
-              "description": "Namibian Dollar",
+              "description": "Namibian Dollar.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "NPR",
-              "description": "Nepalese Rupee (NPR)",
+              "description": "Nepalese Rupee (NPR).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ANG",
-              "description": "Netherlands Antillean Guilder",
+              "description": "Netherlands Antillean Guilder.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "NZD",
-              "description": "New Zealand Dollars (NZD)",
+              "description": "New Zealand Dollars (NZD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "NIO",
-              "description": "Nicaraguan Córdoba (NIO)",
+              "description": "Nicaraguan Córdoba (NIO).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "NGN",
-              "description": "Nigerian Naira (NGN)",
+              "description": "Nigerian Naira (NGN).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "NOK",
-              "description": "Norwegian Kroner (NOK)",
+              "description": "Norwegian Kroner (NOK).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "OMR",
-              "description": "Omani Rial (OMR)",
+              "description": "Omani Rial (OMR).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "PKR",
-              "description": "Pakistani Rupee (PKR)",
+              "description": "Pakistani Rupee (PKR).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "PGK",
-              "description": "Papua New Guinean Kina (PGK)",
+              "description": "Papua New Guinean Kina (PGK).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "PYG",
-              "description": "Paraguayan Guarani (PYG)",
+              "description": "Paraguayan Guarani (PYG).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "PEN",
-              "description": "Peruvian Nuevo Sol (PEN)",
+              "description": "Peruvian Nuevo Sol (PEN).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "PHP",
-              "description": "Philippine Peso (PHP)",
+              "description": "Philippine Peso (PHP).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "PLN",
-              "description": "Polish Zlotych (PLN)",
+              "description": "Polish Zlotych (PLN).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "QAR",
-              "description": "Qatari Rial (QAR)",
+              "description": "Qatari Rial (QAR).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "RON",
-              "description": "Romanian Lei (RON)",
+              "description": "Romanian Lei (RON).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "RUB",
-              "description": "Russian Rubles (RUB)",
+              "description": "Russian Rubles (RUB).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "RWF",
-              "description": "Rwandan Franc (RWF)",
+              "description": "Rwandan Franc (RWF).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "WST",
-              "description": "Samoan Tala (WST)",
+              "description": "Samoan Tala (WST).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "SAR",
-              "description": "Saudi Riyal (SAR)",
+              "description": "Saudi Riyal (SAR).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "STD",
-              "description": "Sao Tome And Principe Dobra (STD)",
+              "description": "Sao Tome And Principe Dobra (STD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "RSD",
-              "description": "Serbian dinar (RSD)",
+              "description": "Serbian dinar (RSD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "SCR",
-              "description": "Seychellois Rupee (SCR)",
+              "description": "Seychellois Rupee (SCR).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "SGD",
-              "description": "Singapore Dollars (SGD)",
+              "description": "Singapore Dollars (SGD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "SDG",
-              "description": "Sudanese Pound (SDG)",
+              "description": "Sudanese Pound (SDG).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "SYP",
-              "description": "Syrian Pound (SYP)",
+              "description": "Syrian Pound (SYP).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ZAR",
-              "description": "South African Rand (ZAR)",
+              "description": "South African Rand (ZAR).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "KRW",
-              "description": "South Korean Won (KRW)",
+              "description": "South Korean Won (KRW).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "SSP",
-              "description": "South Sudanese Pound (SSP)",
+              "description": "South Sudanese Pound (SSP).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "SBD",
-              "description": "Solomon Islands Dollar (SBD)",
+              "description": "Solomon Islands Dollar (SBD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "LKR",
-              "description": "Sri Lankan Rupees (LKR)",
+              "description": "Sri Lankan Rupees (LKR).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "SRD",
-              "description": "Surinamese Dollar (SRD)",
+              "description": "Surinamese Dollar (SRD).",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SZL",
+              "description": "Swazi Lilangeni (SZL).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "SEK",
-              "description": "Swedish Kronor (SEK)",
+              "description": "Swedish Kronor (SEK).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "CHF",
-              "description": "Swiss Francs (CHF)",
+              "description": "Swiss Francs (CHF).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "TWD",
-              "description": "Taiwan Dollars (TWD)",
+              "description": "Taiwan Dollars (TWD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "THB",
-              "description": "Thai baht (THB)",
+              "description": "Thai baht (THB).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "TZS",
-              "description": "Tanzanian Shilling (TZS)",
+              "description": "Tanzanian Shilling (TZS).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "TTD",
-              "description": "Trinidad and Tobago Dollars (TTD)",
+              "description": "Trinidad and Tobago Dollars (TTD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "TND",
-              "description": "Tunisian Dinar (TND)",
+              "description": "Tunisian Dinar (TND).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "TRY",
-              "description": "Turkish Lira (TRY)",
+              "description": "Turkish Lira (TRY).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "TMT",
-              "description": "Turkmenistani Manat (TMT)",
+              "description": "Turkmenistani Manat (TMT).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "UGX",
-              "description": "Ugandan Shilling (UGX)",
+              "description": "Ugandan Shilling (UGX).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "UAH",
-              "description": "Ukrainian Hryvnia (UAH)",
+              "description": "Ukrainian Hryvnia (UAH).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "AED",
-              "description": "United Arab Emirates Dirham (AED)",
+              "description": "United Arab Emirates Dirham (AED).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "UYU",
-              "description": "Uruguayan Pesos (UYU)",
+              "description": "Uruguayan Pesos (UYU).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "UZS",
-              "description": "Uzbekistan som (UZS)",
+              "description": "Uzbekistan som (UZS).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "VUV",
-              "description": "Vanuatu Vatu (VUV)",
+              "description": "Vanuatu Vatu (VUV).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "VEF",
-              "description": "Venezuelan Bolivares (VEF)",
+              "description": "Venezuelan Bolivares (VEF).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "VND",
-              "description": "Vietnamese đồng (VND)",
+              "description": "Vietnamese đồng (VND).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "XOF",
-              "description": "West African CFA franc (XOF)",
+              "description": "West African CFA franc (XOF).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "YER",
-              "description": "Yemeni Rial (YER)",
+              "description": "Yemeni Rial (YER).",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ZMW",
-              "description": "Zambian Kwacha (ZMW)",
+              "description": "Zambian Kwacha (ZMW).",
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -2187,6 +4087,322 @@
           "fields": null,
           "inputFields": null,
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DiscountAllocation",
+          "description": "An amount discounting the line that has been allocated by a discount.\n",
+          "fields": [
+            {
+              "name": "allocatedAmount",
+              "description": "Amount of discount allocated.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MoneyV2",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "discountApplication",
+              "description": "The discount this allocated amount originated from.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "DiscountApplication",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "MoneyV2",
+          "description": "A monetary value with currency.\n\nTo format currencies, combine this type's amount and currencyCode fields with your client's locale.\n\nFor example, in JavaScript you could use Intl.NumberFormat:\n\n```js\nnew Intl.NumberFormat(locale, {\n  style: 'currency',\n  currency: currencyCode\n}).format(amount);\n```\n\nOther formatting libraries include:\n\n* iOS - [NumberFormatter](https://developer.apple.com/documentation/foundation/numberformatter)\n* Android - [NumberFormat](https://developer.android.com/reference/java/text/NumberFormat.html)\n* PHP - [NumberFormatter](http://php.net/manual/en/class.numberformatter.php)\n\nFor a more general solution, the [Unicode CLDR number formatting database] is available with many implementations\n(such as [TwitterCldr](https://github.com/twitter/twitter-cldr-rb)).\n",
+          "fields": [
+            {
+              "name": "amount",
+              "description": "Decimal money amount.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Decimal",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currencyCode",
+              "description": "Currency of the money.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyCode",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Decimal",
+          "description": "A signed decimal number, which supports arbitrary precision and is serialized as a string.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "DiscountApplication",
+          "description": "Discount applications capture the intentions of a discount source at\nthe time of application.\n",
+          "fields": [
+            {
+              "name": "allocationMethod",
+              "description": "The method by which the discount's value is allocated to its entitled items.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DiscountApplicationAllocationMethod",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "targetSelection",
+              "description": "Which lines of targetType that the discount is allocated over.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DiscountApplicationTargetSelection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "targetType",
+              "description": "The type of line that the discount is applicable towards.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DiscountApplicationTargetType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "value",
+              "description": "The value of the discount application.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "UNION",
+                  "name": "PricingValue",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "DiscountCodeApplication",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "ManualDiscountApplication",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "ScriptDiscountApplication",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "ENUM",
+          "name": "DiscountApplicationAllocationMethod",
+          "description": "The method by which the discount's value is allocated onto its entitled lines.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "ACROSS",
+              "description": "The value is spread across all entitled lines.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "EACH",
+              "description": "The value is applied onto every entitled line.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ONE",
+              "description": "The value is specifically applied onto a particular line.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "DiscountApplicationTargetSelection",
+          "description": "Which lines on the order that the discount is allocated over, of the type\ndefined by the Discount Application's target_type.\n",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "ALL",
+              "description": "The discount is allocated onto all the lines.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENTITLED",
+              "description": "The discount is allocated onto only the lines it is entitled for.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "EXPLICIT",
+              "description": "The discount is allocated onto explicitly chosen lines.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "DiscountApplicationTargetType",
+          "description": "The type of line (i.e. line item or shipping line) on an order that the discount is applicable towards.\n",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "LINE_ITEM",
+              "description": "The discount applies onto line items.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SHIPPING_LINE",
+              "description": "The discount applies onto shipping lines.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "UNION",
+          "name": "PricingValue",
+          "description": "The value of the pricing object.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "PricingPercentageValue",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "MoneyV2",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PricingPercentageValue",
+          "description": "The value of the percentage pricing object.",
+          "fields": [
+            {
+              "name": "percentage",
+              "description": "The percentage value of the object.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -2287,8 +4503,7 @@
         {
           "kind": "OBJECT",
           "name": "OrderLineItem",
-          "description":
-            "Represents a single line in an order. There is one line item for each distinct product variant.",
+          "description": "Represents a single line in an order. There is one line item for each distinct product variant.",
           "fields": [
             {
               "name": "customAttributes",
@@ -2306,6 +4521,30 @@
                     "ofType": {
                       "kind": "OBJECT",
                       "name": "Attribute",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "discountAllocations",
+              "description": "The discounts that have been allocated onto the order line item by discount applications.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "DiscountAllocation",
                       "ofType": null
                     }
                   }
@@ -2367,8 +4606,7 @@
         {
           "kind": "OBJECT",
           "name": "ProductVariant",
-          "description":
-            "A product variant represents a different version of a product, such as differing sizes or differing colors.",
+          "description": "A product variant represents a different version of a product, such as differing sizes or differing colors.",
           "fields": [
             {
               "name": "available",
@@ -2400,8 +4638,7 @@
             },
             {
               "name": "compareAtPrice",
-              "description":
-                "The compare at price of the variant. This can be used to mark a variant as on sale, when `compareAtPrice` is higher than `price`.",
+              "description": "The compare at price of the variant. This can be used to mark a variant as on sale, when `compareAtPrice` is higher than `price`.",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -2429,11 +4666,11 @@
             },
             {
               "name": "image",
-              "description": "Image associated with the product variant.",
+              "description": "Image associated with the product variant. This field falls back to the product image if no image is available.",
               "args": [
                 {
                   "name": "maxWidth",
-                  "description": "Image width in pixels between 1 and 2048",
+                  "description": "Image width in pixels between 1 and 2048. This argument is deprecated: Use `maxWidth` on `Image.transformedSrc` instead.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
@@ -2443,7 +4680,7 @@
                 },
                 {
                   "name": "maxHeight",
-                  "description": "Image height in pixels between 1 and 2048",
+                  "description": "Image height in pixels between 1 and 2048. This argument is deprecated: Use `maxHeight` on `Image.transformedSrc` instead.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
@@ -2453,7 +4690,7 @@
                 },
                 {
                   "name": "crop",
-                  "description": "If specified, crop the image keeping the specified region",
+                  "description": "Crops the image according to the specified region. This argument is deprecated: Use `crop` on `Image.transformedSrc` instead.",
                   "type": {
                     "kind": "ENUM",
                     "name": "CropRegion",
@@ -2463,7 +4700,7 @@
                 },
                 {
                   "name": "scale",
-                  "description": "Image size multiplier retina displays. Must be between 1 and 3",
+                  "description": "Image size multiplier for high-resolution retina displays. Must be between 1 and 3. This argument is deprecated: Use `scale` on `Image.transformedSrc` instead.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
@@ -2538,7 +4775,7 @@
             },
             {
               "name": "sku",
-              "description": "The SKU (Stock Keeping Unit) associated with the variant.",
+              "description": "The SKU (stock keeping unit) associated with the variant.",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -2607,32 +4844,32 @@
         {
           "kind": "ENUM",
           "name": "WeightUnit",
-          "description": "Units of measurements for weight.",
+          "description": "Units of measurement for weight.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
           "enumValues": [
             {
               "name": "KILOGRAMS",
-              "description": "1 equals 1000 grams",
+              "description": "1 kilogram equals 1000 grams.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "GRAMS",
-              "description": "Metric system unit of mass",
+              "description": "Metric system unit of mass.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "POUNDS",
-              "description": "1 equals 16 ounces",
+              "description": "1 pound equals 16 ounces.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "OUNCES",
-              "description": "Imperial system unit of mass",
+              "description": "Imperial system unit of mass.",
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -2669,9 +4906,92 @@
               "deprecationReason": null
             },
             {
+              "name": "originalSrc",
+              "description": "The location of the original (untransformed) image as a URL.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "URL",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "src",
               "description": "The location of the image as a URL.",
               "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "URL",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Previously an image had a single `src` field. This could either return the original image\nlocation or a URL that contained transformations such as sizing or scale.\n\nThese transformations were specified by arguments on the parent field.\n\nNow an image has two distinct URL fields: `originalSrc` and `transformedSrc`.\n\n* `originalSrc` - the original, untransformed image URL\n* `transformedSrc` - the image URL with transformations included\n\nTo migrate to the new fields, image transformations should be moved from the parent field to `transformedSrc`.\n\nBefore:\n```graphql\n{\n  shop {\n    productImages(maxWidth: 200, scale: 2) {\n      edges {\n        node {\n          src\n        }\n      }\n    }\n  }\n}\n```\n\nAfter:\n```graphql\n{\n  shop {\n    productImages {\n      edges {\n        node {\n          transformedSrc(maxWidth: 200, scale: 2)\n        }\n      }\n    }\n  }\n}\n```\n"
+            },
+            {
+              "name": "transformedSrc",
+              "description": "The location of the transformed image as a URL.\n\nAll transformation arguments are considered \"best-effort\". If they can be applied to an image, they will be.\nOtherwise any transformations which an image type does not support will be ignored.\n",
+              "args": [
+                {
+                  "name": "maxWidth",
+                  "description": "Image width in pixels between 1 and 5760.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "maxHeight",
+                  "description": "Image height in pixels between 1 and 5760.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "crop",
+                  "description": "Crops the image according to the specified region.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CropRegion",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "scale",
+                  "description": "Image size multiplier for high-resolution retina displays. Must be between 1 and 3.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": "1"
+                },
+                {
+                  "name": "preferredContentType",
+                  "description": "Best effort conversion of image into content type (SVG -> PNG, Anything -> JGP, Anything -> WEBP are supported).",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "ImageContentType",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2732,10 +5052,38 @@
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "ImageContentType",
+          "description": "List of supported image content types.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "PNG",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "JPG",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "WEBP",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "SelectedOption",
-          "description":
-            "Custom properties that a shop owner can use to define product variants.\nMultiple options can exist. Options are represented as: option1, option2, option3, etc.\n",
+          "description": "Custom properties that a shop owner can use to define product variants.\nMultiple options can exist. Options are represented as: option1, option2, option3, etc.\n",
           "fields": [
             {
               "name": "name",
@@ -2778,30 +5126,61 @@
         {
           "kind": "OBJECT",
           "name": "Product",
-          "description":
-            "A product represents an individual item for sale in a Shopify store. Products are often physical, but they don't have to be. \nFor example, a digital download (such as a movie, music or ebook file) also qualifies as a product, as do services (such as equipment rental, work for hire, customization of another product or an extended warranty).",
+          "description": "A product represents an individual item for sale in a Shopify store. Products are often physical, but they don't have to be.\nFor example, a digital download (such as a movie, music or ebook file) also qualifies as a product, as do services (such as equipment rental, work for hire, customization of another product or an extended warranty).",
           "fields": [
+            {
+              "name": "availableForSale",
+              "description": "Indicates if at least one product variant is available for sale.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "collections",
               "description": "List of collections a product belongs to.",
               "args": [
                 {
                   "name": "first",
-                  "description": null,
+                  "description": "Returns up to the first `n` elements from the list.",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
                   },
                   "defaultValue": null
                 },
                 {
                   "name": "after",
-                  "description": null,
+                  "description": "Returns the elements that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -2811,7 +5190,7 @@
                 },
                 {
                   "name": "reverse",
-                  "description": null,
+                  "description": "Reverse the order of the underlying list.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Boolean",
@@ -2893,8 +5272,7 @@
             },
             {
               "name": "handle",
-              "description":
-                "A human-friendly unique string for the Product automatically generated from its title.\nThey are used by the Liquid templating language to refer to objects.\n",
+              "description": "A human-friendly unique string for the Product automatically generated from its title.\nThey are used by the Liquid templating language to refer to objects.\n",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -2930,21 +5308,17 @@
               "args": [
                 {
                   "name": "first",
-                  "description": null,
+                  "description": "Returns up to the first `n` elements from the list.",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
                   },
                   "defaultValue": null
                 },
                 {
                   "name": "after",
-                  "description": null,
+                  "description": "Returns the elements that come after the specified cursor.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -2953,18 +5327,28 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "sortKey",
-                  "description": null,
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
                   "type": {
-                    "kind": "ENUM",
-                    "name": "ProductImageSortKeys",
+                    "kind": "SCALAR",
+                    "name": "Int",
                     "ofType": null
                   },
-                  "defaultValue": "POSITION"
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 },
                 {
                   "name": "reverse",
-                  "description": null,
+                  "description": "Reverse the order of the underlying list.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Boolean",
@@ -2973,8 +5357,18 @@
                   "defaultValue": "false"
                 },
                 {
+                  "name": "sortKey",
+                  "description": "Sort the underlying list by the given key.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "ProductImageSortKeys",
+                    "ofType": null
+                  },
+                  "defaultValue": "POSITION"
+                },
+                {
                   "name": "maxWidth",
-                  "description": "Image width in pixels between 1 and 2048",
+                  "description": "Image width in pixels between 1 and 2048. This argument is deprecated: Use `maxWidth` on `Image.transformedSrc` instead.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
@@ -2984,7 +5378,7 @@
                 },
                 {
                   "name": "maxHeight",
-                  "description": "Image height in pixels between 1 and 2048",
+                  "description": "Image height in pixels between 1 and 2048. This argument is deprecated: Use `maxHeight` on `Image.transformedSrc` instead.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
@@ -2994,7 +5388,7 @@
                 },
                 {
                   "name": "crop",
-                  "description": "If specified, crop the image keeping the specified region",
+                  "description": "Crops the image according to the specified region. This argument is deprecated: Use `crop` on `Image.transformedSrc` instead.",
                   "type": {
                     "kind": "ENUM",
                     "name": "CropRegion",
@@ -3004,7 +5398,7 @@
                 },
                 {
                   "name": "scale",
-                  "description": "Image size multiplier retina displays. Must be between 1 and 3",
+                  "description": "Image size multiplier for high-resolution retina displays. Must be between 1 and 3. This argument is deprecated: Use `scale` on `Image.transformedSrc` instead.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
@@ -3027,8 +5421,7 @@
             },
             {
               "name": "onlineStoreUrl",
-              "description":
-                "The online store URL for the product.\nA value of `null` indicates that the product is not published to the Online Store sales channel.\n",
+              "description": "The online store URL for the product.\nA value of `null` indicates that the product is not published to the Online Store sales channel.\n",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -3040,11 +5433,11 @@
             },
             {
               "name": "options",
-              "description": "Lst of custom product options (maximum of 3 per product).",
+              "description": "List of custom product options (maximum of 3 per product).",
               "args": [
                 {
                   "name": "first",
-                  "description": "Truncate the array result to this size",
+                  "description": "Truncate the array result to this size.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
@@ -3074,9 +5467,24 @@
               "deprecationReason": null
             },
             {
+              "name": "priceRange",
+              "description": "The price range.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProductPriceRange",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "productType",
-              "description":
-                "A categorization that a product can be tagged with, commonly used for filtering and searching.",
+              "description": "A categorization that a product can be tagged with, commonly used for filtering and searching.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -3108,8 +5516,7 @@
             },
             {
               "name": "tags",
-              "description":
-                "A categorization that a product can be tagged with, commonly used for filtering and searching.\nEach comma-separated tag has a character limit of 255.\n",
+              "description": "A categorization that a product can be tagged with, commonly used for filtering and searching.\nEach comma-separated tag has a character limit of 255.\n",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -3165,8 +5572,7 @@
             },
             {
               "name": "variantBySelectedOptions",
-              "description":
-                "Find a product’s variant based on its selected options.\nThis is useful for converting a user’s selection of product options into a single matching variant.\nIf there is not a variant for the selected options, `null` will be returned.\n",
+              "description": "Find a product’s variant based on its selected options.\nThis is useful for converting a user’s selection of product options into a single matching variant.\nIf there is not a variant for the selected options, `null` will be returned.\n",
               "args": [
                 {
                   "name": "selectedOptions",
@@ -3205,21 +5611,37 @@
               "args": [
                 {
                   "name": "first",
-                  "description": null,
+                  "description": "Returns up to the first `n` elements from the list.",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
                   },
                   "defaultValue": null
                 },
                 {
                   "name": "after",
-                  "description": null,
+                  "description": "Returns the elements that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -3229,13 +5651,23 @@
                 },
                 {
                   "name": "reverse",
-                  "description": null,
+                  "description": "Reverse the order of the underlying list.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": "false"
+                },
+                {
+                  "name": "sortKey",
+                  "description": "Sort the underlying list by the given key.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "ProductVariantSortKeys",
+                    "ofType": null
+                  },
+                  "defaultValue": "POSITION"
                 }
               ],
               "type": {
@@ -3375,8 +5807,7 @@
         {
           "kind": "OBJECT",
           "name": "Collection",
-          "description":
-            "A collection represents a grouping of products that a shop owner can create to organize them or make their shops easier to browse.",
+          "description": "A collection represents a grouping of products that a shop owner can create to organize them or make their shops easier to browse.",
           "fields": [
             {
               "name": "description",
@@ -3423,8 +5854,7 @@
             },
             {
               "name": "handle",
-              "description":
-                "A human-friendly unique string for the collection automatically generated from its title.\nLimit of 255 characters.\n",
+              "description": "A human-friendly unique string for the collection automatically generated from its title.\nLimit of 255 characters.\n",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -3460,7 +5890,7 @@
               "args": [
                 {
                   "name": "maxWidth",
-                  "description": "Image width in pixels between 1 and 2048",
+                  "description": "Image width in pixels between 1 and 2048. This argument is deprecated: Use `maxWidth` on `Image.transformedSrc` instead.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
@@ -3470,7 +5900,7 @@
                 },
                 {
                   "name": "maxHeight",
-                  "description": "Image height in pixels between 1 and 2048",
+                  "description": "Image height in pixels between 1 and 2048. This argument is deprecated: Use `maxHeight` on `Image.transformedSrc` instead.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
@@ -3480,7 +5910,7 @@
                 },
                 {
                   "name": "crop",
-                  "description": "If specified, crop the image keeping the specified region",
+                  "description": "Crops the image according to the specified region. This argument is deprecated: Use `crop` on `Image.transformedSrc` instead.",
                   "type": {
                     "kind": "ENUM",
                     "name": "CropRegion",
@@ -3490,7 +5920,7 @@
                 },
                 {
                   "name": "scale",
-                  "description": "Image size multiplier retina displays. Must be between 1 and 3",
+                  "description": "Image size multiplier for high-resolution retina displays. Must be between 1 and 3. This argument is deprecated: Use `scale` on `Image.transformedSrc` instead.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
@@ -3513,21 +5943,17 @@
               "args": [
                 {
                   "name": "first",
-                  "description": null,
+                  "description": "Returns up to the first `n` elements from the list.",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
                   },
                   "defaultValue": null
                 },
                 {
                   "name": "after",
-                  "description": null,
+                  "description": "Returns the elements that come after the specified cursor.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -3536,24 +5962,44 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "sortKey",
-                  "description": null,
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
                   "type": {
-                    "kind": "ENUM",
-                    "name": "ProductCollectionSortKeys",
+                    "kind": "SCALAR",
+                    "name": "Int",
                     "ofType": null
                   },
-                  "defaultValue": "COLLECTION_DEFAULT"
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 },
                 {
                   "name": "reverse",
-                  "description": null,
+                  "description": "Reverse the order of the underlying list.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": "false"
+                },
+                {
+                  "name": "sortKey",
+                  "description": "Sort the underlying list by the given key.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "ProductCollectionSortKeys",
+                    "ofType": null
+                  },
+                  "defaultValue": "COLLECTION_DEFAULT"
                 }
               ],
               "type": {
@@ -3725,50 +6171,50 @@
           "interfaces": null,
           "enumValues": [
             {
-              "name": "MANUAL",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BEST_SELLING",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "TITLE",
-              "description": null,
+              "description": "Sort by the `title` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "PRICE",
-              "description": null,
+              "description": "Sort by the `price` value.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BEST_SELLING",
+              "description": "Sort by the `best-selling` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "CREATED",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "COLLECTION_DEFAULT",
-              "description": null,
+              "description": "Sort by the `created` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ID",
-              "description": null,
+              "description": "Sort by the `id` value.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MANUAL",
+              "description": "Sort by the `manual` value.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "COLLECTION_DEFAULT",
+              "description": "Sort by the `collection-default` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "RELEVANCE",
-              "description": null,
+              "description": "During a search (i.e. when the `query` parameter has been specified on the connection) this sorts the\nresults by relevance to the search term(s). When no search query is specified, this sort key is not\ndeterministic and should not be used.\n",
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -3879,29 +6325,72 @@
           "enumValues": [
             {
               "name": "CREATED_AT",
-              "description": null,
+              "description": "Sort by the `created_at` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "POSITION",
-              "description": null,
+              "description": "Sort by the `position` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ID",
-              "description": null,
+              "description": "Sort by the `id` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "RELEVANCE",
-              "description": null,
+              "description": "During a search (i.e. when the `query` parameter has been specified on the connection) this sorts the\nresults by relevance to the search term(s). When no search query is specified, this sort key is not\ndeterministic and should not be used.\n",
               "isDeprecated": false,
               "deprecationReason": null
             }
           ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProductPriceRange",
+          "description": "The price range of the product.",
+          "fields": [
+            {
+              "name": "maxVariantPrice",
+              "description": "The highest variant's price.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MoneyV2",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minVariantPrice",
+              "description": "The lowest variant's price.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MoneyV2",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
           "possibleTypes": null
         },
         {
@@ -3946,8 +6435,7 @@
         {
           "kind": "OBJECT",
           "name": "ProductOption",
-          "description":
-            "Custom product property names like \"Size\", \"Color\", and \"Material\".\nProducts are based on permutations of these options.\nA product may have a maximum of 3 options.\n255 characters limit each.\n",
+          "description": "Custom product property names like \"Size\", \"Color\", and \"Material\".\nProducts are based on permutations of these options.\nA product may have a maximum of 3 options.\n255 characters limit each.\n",
           "fields": [
             {
               "name": "id",
@@ -4112,6 +6600,47 @@
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "ProductVariantSortKeys",
+          "description": "The set of valid sort keys for the variants query.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "TITLE",
+              "description": "Sort by the `title` value.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SKU",
+              "description": "Sort by the `sku` value.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "POSITION",
+              "description": "Sort by the `position` value.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ID",
+              "description": "Sort by the `id` value.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RELEVANCE",
+              "description": "During a search (i.e. when the `query` parameter has been specified on the connection) this sorts the\nresults by relevance to the search term(s). When no search query is specified, this sort key is not\ndeterministic and should not be used.\n",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "Attribute",
           "description": "Represents a generic custom attribute.",
@@ -4151,6 +6680,397 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "Fulfillment",
+          "description": "Represents a single fulfillment in an order.",
+          "fields": [
+            {
+              "name": "fulfillmentLineItems",
+              "description": "List of the fulfillment's line items.",
+              "args": [
+                {
+                  "name": "first",
+                  "description": "Returns up to the first `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "after",
+                  "description": "Returns the elements that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "reverse",
+                  "description": "Reverse the order of the underlying list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "FulfillmentLineItemConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "trackingCompany",
+              "description": "The name of the tracking company.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "trackingInfo",
+              "description": "Tracking information associated with the fulfillment,\nsuch as the tracking number and tracking URL.\n",
+              "args": [
+                {
+                  "name": "first",
+                  "description": "Truncate the array result to this size.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "FulfillmentTrackingInfo",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FulfillmentTrackingInfo",
+          "description": "Tracking information associated with the fulfillment.",
+          "fields": [
+            {
+              "name": "number",
+              "description": "The tracking number of the fulfillment.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": "The URL to track the fulfillment.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "URL",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FulfillmentLineItemConnection",
+          "description": null,
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "FulfillmentLineItemEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FulfillmentLineItemEdge",
+          "description": null,
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of FulfillmentLineItemEdge.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "FulfillmentLineItem",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FulfillmentLineItem",
+          "description": "Represents a single line item in a fulfillment. There is at most one fulfillment line item for each order line item.",
+          "fields": [
+            {
+              "name": "lineItem",
+              "description": "The associated order's line item.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "OrderLineItem",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quantity",
+              "description": "The amount fulfilled in this fulfillment.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DiscountApplicationConnection",
+          "description": null,
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "DiscountApplicationEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DiscountApplicationEdge",
+          "description": null,
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of DiscountApplicationEdge.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "DiscountApplication",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "ENUM",
           "name": "OrderSortKeys",
           "description": "The set of valid sort keys for the orders query.",
@@ -4160,29 +7080,974 @@
           "enumValues": [
             {
               "name": "PROCESSED_AT",
-              "description": null,
+              "description": "Sort by the `processed_at` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "TOTAL_PRICE",
-              "description": null,
+              "description": "Sort by the `total_price` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ID",
-              "description": null,
+              "description": "Sort by the `id` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "RELEVANCE",
-              "description": null,
+              "description": "During a search (i.e. when the `query` parameter has been specified on the connection) this sorts the\nresults by relevance to the search term(s). When no search query is specified, this sort key is not\ndeterministic and should not be used.\n",
               "isDeprecated": false,
               "deprecationReason": null
             }
           ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Checkout",
+          "description": "A container for all the information required to checkout items and pay.",
+          "fields": [
+            {
+              "name": "appliedGiftCards",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "AppliedGiftCard",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "availableShippingRates",
+              "description": "The available shipping rates for this Checkout.\nShould only be used when checkout `requiresShipping` is `true` and\nthe shipping address is valid.\n",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AvailableShippingRates",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "completedAt",
+              "description": "The date and time when the checkout was completed.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": "The date and time when the checkout was created.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currencyCode",
+              "description": "The currency code for the Checkout.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyCode",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customAttributes",
+              "description": "A list of extra information that is added to the checkout.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Attribute",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customer",
+              "description": "The customer associated with the checkout.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Customer",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "This field will always return null. If you have an authentication token for the customer, you can use the `customer` field on the query root to retrieve it."
+            },
+            {
+              "name": "discountApplications",
+              "description": "Discounts that have been applied on the checkout.",
+              "args": [
+                {
+                  "name": "first",
+                  "description": "Returns up to the first `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "after",
+                  "description": "Returns the elements that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "reverse",
+                  "description": "Reverse the order of the underlying list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "DiscountApplicationConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "email",
+              "description": "The email attached to this checkout.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "Globally unique identifier.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lineItems",
+              "description": "A list of line item objects, each one containing information about an item in the checkout.",
+              "args": [
+                {
+                  "name": "first",
+                  "description": "Returns up to the first `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "after",
+                  "description": "Returns the elements that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "reverse",
+                  "description": "Reverse the order of the underlying list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CheckoutLineItemConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "note",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order",
+              "description": "The resulting order from a paid checkout.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Order",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orderStatusUrl",
+              "description": "The Order Status Page for this Checkout, null when checkout is not completed.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "URL",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paymentDue",
+              "description": "The amount left to be paid. This is equal to the cost of the line items, taxes and shipping minus discounts and gift cards.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Money",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ready",
+              "description": "Whether or not the Checkout is ready and can be completed. Checkouts may have asynchronous operations that can take time to finish. If you want to complete a checkout or ensure all the fields are populated and up to date, polling is required until the value is true. ",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "requiresShipping",
+              "description": "States whether or not the fulfillment requires shipping.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shippingAddress",
+              "description": "The shipping address to where the line items will be shipped.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "MailingAddress",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shippingDiscountAllocations",
+              "description": "The discounts that have been allocated onto the shipping line by discount applications.\n",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "DiscountAllocation",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shippingLine",
+              "description": "Once a shipping rate is selected by the customer it is transitioned to a `shipping_line` object.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ShippingRate",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subtotalPrice",
+              "description": "Price of the checkout before shipping and taxes.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Money",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxExempt",
+              "description": "Specifies if the Checkout is tax exempt.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxesIncluded",
+              "description": "Specifies if taxes are included in the line item and shipping line prices.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalPrice",
+              "description": "The sum of all the prices of all the items in the checkout, taxes and discounts included.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Money",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalTax",
+              "description": "The sum of all the taxes applied to the line items and shipping lines in the checkout.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Money",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": "The date and time when the checkout was last updated.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "webUrl",
+              "description": "The url pointing to the checkout accessible from the web.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "URL",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CheckoutLineItemConnection",
+          "description": null,
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CheckoutLineItemEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CheckoutLineItemEdge",
+          "description": null,
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of CheckoutLineItemEdge.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CheckoutLineItem",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CheckoutLineItem",
+          "description": "A single line item in the checkout, grouped by variant and attributes.",
+          "fields": [
+            {
+              "name": "customAttributes",
+              "description": "Extra information in the form of an array of Key-Value pairs about the line item.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Attribute",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "discountAllocations",
+              "description": "The discounts that have been allocated onto the checkout line item by discount applications.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "DiscountAllocation",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "Globally unique identifier.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quantity",
+              "description": "The quantity of the line item.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "Title of the line item. Defaults to the product's title.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "variant",
+              "description": "Product variant of the line item.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProductVariant",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ShippingRate",
+          "description": "A shipping rate to be applied to a checkout.",
+          "fields": [
+            {
+              "name": "handle",
+              "description": "Human-readable unique identifier for this shipping rate.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "price",
+              "description": "Price of this shipping rate.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Money",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "Title of this shipping rate.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AvailableShippingRates",
+          "description": "A collection of available shipping rates for a checkout.",
+          "fields": [
+            {
+              "name": "ready",
+              "description": "Whether or not the shipping rates are ready.\nThe `shippingRates` field is `null` when this value is `false`.\nThis field should be polled until its value becomes `true`.\n",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shippingRates",
+              "description": "The fetched shipping rates. `null` until the `ready` field is `true`.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ShippingRate",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AppliedGiftCard",
+          "description": "Details about the gift card used on the checkout.",
+          "fields": [
+            {
+              "name": "amountUsed",
+              "description": "The amount that was used taken from the Gift Card by applying it.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Money",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "balance",
+              "description": "The amount left on the Gift Card.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Money",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "Globally unique identifier.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastCharacters",
+              "description": "The last characters of the Gift Card code",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
           "possibleTypes": null
         },
         {
@@ -4196,21 +8061,17 @@
               "args": [
                 {
                   "name": "first",
-                  "description": null,
+                  "description": "Returns up to the first `n` elements from the list.",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
                   },
                   "defaultValue": null
                 },
                 {
                   "name": "after",
-                  "description": null,
+                  "description": "Returns the elements that come after the specified cursor.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -4219,19 +8080,38 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "query",
-                  "description":
-                    "Supported filter parameters:\n - `author`\n - `updated_at`\n - `created_at`\n - `blog_title`\n - `tag`",
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "reverse",
+                  "description": "Reverse the order of the underlying list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
                 },
                 {
                   "name": "sortKey",
-                  "description": null,
+                  "description": "Sort the underlying list by the given key.",
                   "type": {
                     "kind": "ENUM",
                     "name": "ArticleSortKeys",
@@ -4240,14 +8120,14 @@
                   "defaultValue": "ID"
                 },
                 {
-                  "name": "reverse",
-                  "description": null,
+                  "name": "query",
+                  "description": "Supported filter parameters:\n - `author`\n - `updated_at`\n - `created_at`\n - `blog_title`\n - `tag`\n\nSee the detailed [search syntax](https://help.shopify.com/api/getting-started/search-syntax).\n",
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Boolean",
+                    "name": "String",
                     "ofType": null
                   },
-                  "defaultValue": "false"
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -4259,8 +8139,8 @@
                   "ofType": null
                 }
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "Use `QueryRoot.articles` instead."
             },
             {
               "name": "blogs",
@@ -4268,21 +8148,17 @@
               "args": [
                 {
                   "name": "first",
-                  "description": null,
+                  "description": "Returns up to the first `n` elements from the list.",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
                   },
                   "defaultValue": null
                 },
                 {
                   "name": "after",
-                  "description": null,
+                  "description": "Returns the elements that come after the specified cursor.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -4291,19 +8167,38 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "query",
-                  "description":
-                    "Supported filter parameters:\n - `handle`\n - `title`\n - `updated_at`\n - `created_at`",
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "reverse",
+                  "description": "Reverse the order of the underlying list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
                 },
                 {
                   "name": "sortKey",
-                  "description": null,
+                  "description": "Sort the underlying list by the given key.",
                   "type": {
                     "kind": "ENUM",
                     "name": "BlogSortKeys",
@@ -4312,14 +8207,14 @@
                   "defaultValue": "ID"
                 },
                 {
-                  "name": "reverse",
-                  "description": null,
+                  "name": "query",
+                  "description": "Supported filter parameters:\n - `handle`\n - `title`\n - `updated_at`\n - `created_at`\n\nSee the detailed [search syntax](https://help.shopify.com/api/getting-started/search-syntax).\n",
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Boolean",
+                    "name": "String",
                     "ofType": null
                   },
-                  "defaultValue": "false"
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -4331,8 +8226,8 @@
                   "ofType": null
                 }
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "Use `QueryRoot.blogs` instead."
             },
             {
               "name": "cardVaultUrl",
@@ -4356,7 +8251,7 @@
               "args": [
                 {
                   "name": "handle",
-                  "description": null,
+                  "description": "The handle of the collection.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -4383,21 +8278,17 @@
               "args": [
                 {
                   "name": "first",
-                  "description": null,
+                  "description": "Returns up to the first `n` elements from the list.",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
                   },
                   "defaultValue": null
                 },
                 {
                   "name": "after",
-                  "description": null,
+                  "description": "Returns the elements that come after the specified cursor.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -4406,18 +8297,38 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "query",
-                  "description": "Supported filter parameters:\n - `title`\n - `collection_type`\n - `updated_at`",
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "reverse",
+                  "description": "Reverse the order of the underlying list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
                 },
                 {
                   "name": "sortKey",
-                  "description": null,
+                  "description": "Sort the underlying list by the given key.",
                   "type": {
                     "kind": "ENUM",
                     "name": "CollectionSortKeys",
@@ -4426,14 +8337,14 @@
                   "defaultValue": "ID"
                 },
                 {
-                  "name": "reverse",
-                  "description": null,
+                  "name": "query",
+                  "description": "Supported filter parameters:\n - `title`\n - `collection_type`\n - `updated_at`\n\nSee the detailed [search syntax](https://help.shopify.com/api/getting-started/search-syntax).\n",
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Boolean",
+                    "name": "String",
                     "ofType": null
                   },
-                  "defaultValue": "false"
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -4558,7 +8469,7 @@
               "args": [
                 {
                   "name": "handle",
-                  "description": null,
+                  "description": "The handle of the product.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -4585,7 +8496,7 @@
               "args": [
                 {
                   "name": "first",
-                  "description": null,
+                  "description": "Returns up to the first `n` elements from the list.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -4616,21 +8527,17 @@
               "args": [
                 {
                   "name": "first",
-                  "description": null,
+                  "description": "Returns up to the first `n` elements from the list.",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
                   },
                   "defaultValue": null
                 },
                 {
                   "name": "after",
-                  "description": null,
+                  "description": "Returns the elements that come after the specified cursor.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -4639,19 +8546,38 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "query",
-                  "description":
-                    "Supported filter parameters:\n - `title`\n - `product_type`\n - `vendor`\n - `created_at`\n - `updated_at`\n - `tag`",
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "reverse",
+                  "description": "Reverse the order of the underlying list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
                 },
                 {
                   "name": "sortKey",
-                  "description": null,
+                  "description": "Sort the underlying list by the given key.",
                   "type": {
                     "kind": "ENUM",
                     "name": "ProductSortKeys",
@@ -4660,14 +8586,14 @@
                   "defaultValue": "ID"
                 },
                 {
-                  "name": "reverse",
-                  "description": null,
+                  "name": "query",
+                  "description": "Supported filter parameters:\n - `title`\n - `product_type`\n - `vendor`\n - `created_at`\n - `updated_at`\n - `variants.price`\n - `tag`\n\nSee the detailed [search syntax](https://help.shopify.com/api/getting-started/search-syntax).\n",
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Boolean",
+                    "name": "String",
                     "ofType": null
                   },
-                  "defaultValue": "false"
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -4690,6 +8616,30 @@
                 "kind": "OBJECT",
                 "name": "ShopPolicy",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shipsToCountries",
+              "description": "Countries that the shop ships to.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "CountryCode",
+                      "ofType": null
+                    }
+                  }
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -4845,1463 +8795,6 @@
         },
         {
           "kind": "ENUM",
-          "name": "CountryCode",
-          "description": "ISO 3166-1 alpha-2 country codes with some differences.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "CA",
-              "description": "Canada",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "US",
-              "description": "United States",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "GB",
-              "description": "United Kingdom",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "AF",
-              "description": "Afghanistan",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "AL",
-              "description": "Albania",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "DZ",
-              "description": "Algeria",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "AD",
-              "description": "Andorra",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "AO",
-              "description": "Angola",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "AG",
-              "description": "Antigua And Barbuda",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "AR",
-              "description": "Argentina",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "AM",
-              "description": "Armenia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "AW",
-              "description": "Aruba",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "AU",
-              "description": "Australia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "AT",
-              "description": "Austria",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "AZ",
-              "description": "Azerbaijan",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BS",
-              "description": "Bahamas",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BH",
-              "description": "Bahrain",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BD",
-              "description": "Bangladesh",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BB",
-              "description": "Barbados",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BY",
-              "description": "Belarus",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BE",
-              "description": "Belgium",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BZ",
-              "description": "Belize",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BJ",
-              "description": "Benin",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BM",
-              "description": "Bermuda",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BT",
-              "description": "Bhutan",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BO",
-              "description": "Bolivia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BA",
-              "description": "Bosnia And Herzegovina",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BW",
-              "description": "Botswana",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BR",
-              "description": "Brazil",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BN",
-              "description": "Brunei",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BG",
-              "description": "Bulgaria",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "NC",
-              "description": "New Caledonia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "KH",
-              "description": "Cambodia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CM",
-              "description": "Republic of Cameroon",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CV",
-              "description": "Cape Verde",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "KY",
-              "description": "Cayman Islands",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CL",
-              "description": "Chile",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CN",
-              "description": "China",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CO",
-              "description": "Colombia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "KM",
-              "description": "Comoros",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CG",
-              "description": "Congo",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CD",
-              "description": "Congo, The Democratic Republic Of The",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CR",
-              "description": "Costa Rica",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CI",
-              "description": "Côte d'Ivoire",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "HR",
-              "description": "Croatia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CW",
-              "description": "Curaçao",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CY",
-              "description": "Cyprus",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CZ",
-              "description": "Czech Republic",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "DK",
-              "description": "Denmark",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "DM",
-              "description": "Dominica",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "DO",
-              "description": "Dominican Republic",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "EC",
-              "description": "Ecuador",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "EG",
-              "description": "Egypt",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SV",
-              "description": "El Salvador",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "EE",
-              "description": "Estonia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ET",
-              "description": "Ethiopia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "GQ",
-              "description": "Equatorial Guinea",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FO",
-              "description": "Faroe Islands",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FJ",
-              "description": "Fiji",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FI",
-              "description": "Finland",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FR",
-              "description": "France",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "PF",
-              "description": "French Polynesia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "GA",
-              "description": "Gabon",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "GM",
-              "description": "Gambia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "GE",
-              "description": "Georgia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "DE",
-              "description": "Germany",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "GH",
-              "description": "Ghana",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "GI",
-              "description": "Gibraltar",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "GR",
-              "description": "Greece",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "GL",
-              "description": "Greenland",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "GD",
-              "description": "Grenada",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "GP",
-              "description": "Guadeloupe",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "GT",
-              "description": "Guatemala",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "GG",
-              "description": "Guernsey",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "GY",
-              "description": "Guyana",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "HT",
-              "description": "Haiti",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "HN",
-              "description": "Honduras",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "HK",
-              "description": "Hong Kong",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "HU",
-              "description": "Hungary",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "IS",
-              "description": "Iceland",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "IN",
-              "description": "India",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ID",
-              "description": "Indonesia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "IE",
-              "description": "Ireland",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "IM",
-              "description": "Isle Of Man",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "IL",
-              "description": "Israel",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "IT",
-              "description": "Italy",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "JM",
-              "description": "Jamaica",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "JP",
-              "description": "Japan",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "JE",
-              "description": "Jersey",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "JO",
-              "description": "Jordan",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "KZ",
-              "description": "Kazakhstan",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "KE",
-              "description": "Kenya",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "XK",
-              "description": "Kosovo",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "KW",
-              "description": "Kuwait",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "KG",
-              "description": "Kyrgyzstan",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "LA",
-              "description": "Lao People's Democratic Republic",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "LV",
-              "description": "Latvia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "LB",
-              "description": "Lebanon",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "LS",
-              "description": "Lesotho",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "LR",
-              "description": "Liberia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "LI",
-              "description": "Liechtenstein",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "LT",
-              "description": "Lithuania",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "LU",
-              "description": "Luxembourg",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MO",
-              "description": "Macao",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MK",
-              "description": "Macedonia, Republic Of",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MG",
-              "description": "Madagascar",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MW",
-              "description": "Malawi",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MY",
-              "description": "Malaysia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MV",
-              "description": "Maldives",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MT",
-              "description": "Malta",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MQ",
-              "description": "Martinique",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MU",
-              "description": "Mauritius",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "YT",
-              "description": "Mayotte",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MX",
-              "description": "Mexico",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MD",
-              "description": "Moldova, Republic of",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MC",
-              "description": "Monaco",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MN",
-              "description": "Mongolia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ME",
-              "description": "Montenegro",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MA",
-              "description": "Morocco",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MZ",
-              "description": "Mozambique",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MM",
-              "description": "Myanmar",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "NA",
-              "description": "Namibia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "NP",
-              "description": "Nepal",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "AN",
-              "description": "Netherlands Antilles",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "NL",
-              "description": "Netherlands",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "NZ",
-              "description": "New Zealand",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "NI",
-              "description": "Nicaragua",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "NE",
-              "description": "Niger",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "NG",
-              "description": "Nigeria",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "NO",
-              "description": "Norway",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "OM",
-              "description": "Oman",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "PK",
-              "description": "Pakistan",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "PS",
-              "description": "Palestinian Territory, Occupied",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "PA",
-              "description": "Panama",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "PG",
-              "description": "Papua New Guinea",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "PY",
-              "description": "Paraguay",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "PE",
-              "description": "Peru",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "PH",
-              "description": "Philippines",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "PL",
-              "description": "Poland",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "PT",
-              "description": "Portugal",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "QA",
-              "description": "Qatar",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "RE",
-              "description": "Reunion",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "RO",
-              "description": "Romania",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "RU",
-              "description": "Russia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "RW",
-              "description": "Rwanda",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "KN",
-              "description": "Saint Kitts And Nevis",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "LC",
-              "description": "Saint Lucia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MF",
-              "description": "Saint Martin",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ST",
-              "description": "Sao Tome And Principe",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "WS",
-              "description": "Samoa",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SA",
-              "description": "Saudi Arabia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SN",
-              "description": "Senegal",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "RS",
-              "description": "Serbia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SC",
-              "description": "Seychelles",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SG",
-              "description": "Singapore",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SX",
-              "description": "Sint Maarten",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SK",
-              "description": "Slovakia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SI",
-              "description": "Slovenia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SB",
-              "description": "Solomon Islands",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ZA",
-              "description": "South Africa",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "KR",
-              "description": "South Korea",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SS",
-              "description": "South Sudan",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ES",
-              "description": "Spain",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "LK",
-              "description": "Sri Lanka",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "VC",
-              "description": "St. Vincent",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SD",
-              "description": "Sudan",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SR",
-              "description": "Suriname",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SE",
-              "description": "Sweden",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CH",
-              "description": "Switzerland",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SY",
-              "description": "Syria",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TW",
-              "description": "Taiwan",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TZ",
-              "description": "Tanzania, United Republic Of",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TH",
-              "description": "Thailand",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TT",
-              "description": "Trinidad and Tobago",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TN",
-              "description": "Tunisia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TR",
-              "description": "Turkey",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TM",
-              "description": "Turkmenistan",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TC",
-              "description": "Turks and Caicos Islands",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "UG",
-              "description": "Uganda",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "UA",
-              "description": "Ukraine",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "AE",
-              "description": "United Arab Emirates",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "UY",
-              "description": "Uruguay",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "UZ",
-              "description": "Uzbekistan",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "VU",
-              "description": "Vanuatu",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "VE",
-              "description": "Venezuela",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "VN",
-              "description": "Vietnam",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "VG",
-              "description": "Virgin Islands, British",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "YE",
-              "description": "Yemen",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ZM",
-              "description": "Zambia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ZW",
-              "description": "Zimbabwe",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "AX",
-              "description": "Aland Islands",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "AI",
-              "description": "Anguilla",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BV",
-              "description": "Bouvet Island",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "IO",
-              "description": "British Indian Ocean Territory",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BF",
-              "description": "Burkina Faso",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BI",
-              "description": "Burundi",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CF",
-              "description": "Central African Republic",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TD",
-              "description": "Chad",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CX",
-              "description": "Christmas Island",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CC",
-              "description": "Cocos (Keeling) Islands",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CK",
-              "description": "Cook Islands",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CU",
-              "description": "Cuba",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "DJ",
-              "description": "Djibouti",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ER",
-              "description": "Eritrea",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FK",
-              "description": "Falkland Islands (Malvinas)",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "GF",
-              "description": "French Guiana",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TF",
-              "description": "French Southern Territories",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "GN",
-              "description": "Guinea",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "GW",
-              "description": "Guinea Bissau",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "HM",
-              "description": "Heard Island And Mcdonald Islands",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "VA",
-              "description": "Holy See (Vatican City State)",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "IR",
-              "description": "Iran, Islamic Republic Of",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "IQ",
-              "description": "Iraq",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "KI",
-              "description": "Kiribati",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "KP",
-              "description": "Korea, Democratic People's Republic Of",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "LY",
-              "description": "Libyan Arab Jamahiriya",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ML",
-              "description": "Mali",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MR",
-              "description": "Mauritania",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MS",
-              "description": "Montserrat",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "NR",
-              "description": "Nauru",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "NU",
-              "description": "Niue",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "NF",
-              "description": "Norfolk Island",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "PN",
-              "description": "Pitcairn",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BL",
-              "description": "Saint Barthélemy",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SH",
-              "description": "Saint Helena",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "PM",
-              "description": "Saint Pierre And Miquelon",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SM",
-              "description": "San Marino",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SL",
-              "description": "Sierra Leone",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SO",
-              "description": "Somalia",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "GS",
-              "description": "South Georgia And The South Sandwich Islands",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SJ",
-              "description": "Svalbard And Jan Mayen",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SZ",
-              "description": "Swaziland",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TJ",
-              "description": "Tajikistan",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TL",
-              "description": "Timor Leste",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TG",
-              "description": "Togo",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TK",
-              "description": "Tokelau",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TO",
-              "description": "Tonga",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TV",
-              "description": "Tuvalu",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "UM",
-              "description": "United States Minor Outlying Islands",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "WF",
-              "description": "Wallis And Futuna",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "EH",
-              "description": "Western Sahara",
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
           "name": "CardBrand",
           "description": "Card brand, such as Visa or Mastercard, which can be used for payments.",
           "fields": null,
@@ -6364,6 +8857,12 @@
             {
               "name": "ANDROID_PAY",
               "description": "Android Pay",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GOOGLE_PAY",
+              "description": "Google Pay",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -6438,8 +8937,7 @@
         {
           "kind": "OBJECT",
           "name": "ShopPolicy",
-          "description":
-            "Policy that a merchant has configured for their store, such as their refund or privacy policy.",
+          "description": "Policy that a merchant has configured for their store, such as their refund or privacy policy.",
           "fields": [
             {
               "name": "body",
@@ -6617,26 +9115,69 @@
           "description": null,
           "fields": [
             {
-              "name": "articles",
-              "description": "List of the blog's articles.",
+              "name": "articleByHandle",
+              "description": "Find an article by its handle.",
               "args": [
                 {
-                  "name": "first",
-                  "description": null,
+                  "name": "handle",
+                  "description": "The handle of the article.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
                     "ofType": {
                       "kind": "SCALAR",
-                      "name": "Int",
+                      "name": "String",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Article",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "articles",
+              "description": "List of the blog's articles.",
+              "args": [
+                {
+                  "name": "first",
+                  "description": "Returns up to the first `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
                   },
                   "defaultValue": null
                 },
                 {
                   "name": "after",
-                  "description": null,
+                  "description": "Returns the elements that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -6646,7 +9187,7 @@
                 },
                 {
                   "name": "reverse",
-                  "description": null,
+                  "description": "Reverse the order of the underlying list.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Boolean",
@@ -6661,6 +9202,46 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "ArticleConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "authors",
+              "description": "The authors who have contributed to the blog.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ArticleAuthor",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "handle",
+              "description": "A human-friendly unique string for the Blog automatically generated from its title.\n",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },
@@ -6729,100 +9310,6 @@
         },
         {
           "kind": "OBJECT",
-          "name": "ArticleConnection",
-          "description": null,
-          "fields": [
-            {
-              "name": "edges",
-              "description": "A list of edges.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "ArticleEdge",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "pageInfo",
-              "description": "Information to aid in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PageInfo",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "ArticleEdge",
-          "description": null,
-          "fields": [
-            {
-              "name": "cursor",
-              "description": "A cursor for use in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "node",
-              "description": "The item at the end of ArticleEdge.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Article",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
           "name": "Article",
           "description": null,
           "fields": [
@@ -6838,6 +9325,18 @@
                   "name": "ArticleAuthor",
                   "ofType": null
                 }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `authorV2` instead"
+            },
+            {
+              "name": "authorV2",
+              "description": "The article's author.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ArticleAuthor",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -6864,21 +9363,37 @@
               "args": [
                 {
                   "name": "first",
-                  "description": null,
+                  "description": "Returns up to the first `n` elements from the list.",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
                   },
                   "defaultValue": null
                 },
                 {
                   "name": "after",
-                  "description": null,
+                  "description": "Returns the elements that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -6888,7 +9403,7 @@
                 },
                 {
                   "name": "reverse",
-                  "description": null,
+                  "description": "Reverse the order of the underlying list.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Boolean",
@@ -6988,6 +9503,22 @@
               "deprecationReason": null
             },
             {
+              "name": "handle",
+              "description": "A human-friendly unique string for the Article automatically generated from its title.\n",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "Globally unique identifier.",
               "args": [],
@@ -7009,7 +9540,7 @@
               "args": [
                 {
                   "name": "maxWidth",
-                  "description": "Image width in pixels between 1 and 2048",
+                  "description": "Image width in pixels between 1 and 2048. This argument is deprecated: Use `maxWidth` on `Image.transformedSrc` instead.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
@@ -7019,7 +9550,7 @@
                 },
                 {
                   "name": "maxHeight",
-                  "description": "Image height in pixels between 1 and 2048",
+                  "description": "Image height in pixels between 1 and 2048. This argument is deprecated: Use `maxHeight` on `Image.transformedSrc` instead.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
@@ -7029,7 +9560,7 @@
                 },
                 {
                   "name": "crop",
-                  "description": "If specified, crop the image keeping the specified region",
+                  "description": "Crops the image according to the specified region. This argument is deprecated: Use `crop` on `Image.transformedSrc` instead.",
                   "type": {
                     "kind": "ENUM",
                     "name": "CropRegion",
@@ -7039,7 +9570,7 @@
                 },
                 {
                   "name": "scale",
-                  "description": "Image size multiplier retina displays. Must be between 1 and 3",
+                  "description": "Image size multiplier for high-resolution retina displays. Must be between 1 and 3. This argument is deprecated: Use `scale` on `Image.transformedSrc` instead.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
@@ -7207,7 +9738,7 @@
             },
             {
               "name": "name",
-              "description": "The author's full name",
+              "description": "The author's full name.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -7457,6 +9988,100 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ArticleConnection",
+          "description": null,
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ArticleEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ArticleEdge",
+          "description": null,
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of ArticleEdge.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Article",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "ENUM",
           "name": "BlogSortKeys",
           "description": "The set of valid sort keys for the blogs query.",
@@ -7466,25 +10091,25 @@
           "enumValues": [
             {
               "name": "HANDLE",
-              "description": null,
+              "description": "Sort by the `handle` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "TITLE",
-              "description": null,
+              "description": "Sort by the `title` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ID",
-              "description": null,
+              "description": "Sort by the `id` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "RELEVANCE",
-              "description": null,
+              "description": "During a search (i.e. when the `query` parameter has been specified on the connection) this sorts the\nresults by relevance to the search term(s). When no search query is specified, this sort key is not\ndeterministic and should not be used.\n",
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -7501,37 +10126,43 @@
           "enumValues": [
             {
               "name": "TITLE",
-              "description": null,
+              "description": "Sort by the `title` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "BLOG_TITLE",
-              "description": null,
+              "description": "Sort by the `blog_title` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "AUTHOR",
-              "description": null,
+              "description": "Sort by the `author` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "UPDATED_AT",
-              "description": null,
+              "description": "Sort by the `updated_at` value.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PUBLISHED_AT",
+              "description": "Sort by the `published_at` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ID",
-              "description": null,
+              "description": "Sort by the `id` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "RELEVANCE",
-              "description": null,
+              "description": "During a search (i.e. when the `query` parameter has been specified on the connection) this sorts the\nresults by relevance to the search term(s). When no search query is specified, this sort key is not\ndeterministic and should not be used.\n",
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -7548,25 +10179,25 @@
           "enumValues": [
             {
               "name": "TITLE",
-              "description": null,
+              "description": "Sort by the `title` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "UPDATED_AT",
-              "description": null,
+              "description": "Sort by the `updated_at` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ID",
-              "description": null,
+              "description": "Sort by the `id` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "RELEVANCE",
-              "description": null,
+              "description": "During a search (i.e. when the `query` parameter has been specified on the connection) this sorts the\nresults by relevance to the search term(s). When no search query is specified, this sort key is not\ndeterministic and should not be used.\n",
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -7583,43 +10214,55 @@
           "enumValues": [
             {
               "name": "TITLE",
-              "description": null,
+              "description": "Sort by the `title` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "PRODUCT_TYPE",
-              "description": null,
+              "description": "Sort by the `product_type` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "VENDOR",
-              "description": null,
+              "description": "Sort by the `vendor` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "UPDATED_AT",
-              "description": null,
+              "description": "Sort by the `updated_at` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "CREATED_AT",
-              "description": null,
+              "description": "Sort by the `created_at` value.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BEST_SELLING",
+              "description": "Sort by the `best_selling` value.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PRICE",
+              "description": "Sort by the `price` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ID",
-              "description": null,
+              "description": "Sort by the `id` value.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "RELEVANCE",
-              "description": null,
+              "description": "During a search (i.e. when the `query` parameter has been specified on the connection) this sorts the\nresults by relevance to the search term(s). When no search query is specified, this sort key is not\ndeterministic and should not be used.\n",
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -7723,8 +10366,7 @@
         {
           "kind": "OBJECT",
           "name": "Mutation",
-          "description":
-            "The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start.",
+          "description": "The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start.",
           "fields": [
             {
               "name": "checkoutAttributesUpdate",
@@ -7762,6 +10404,47 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "CheckoutAttributesUpdatePayload",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `checkoutAttributesUpdateV2` instead"
+            },
+            {
+              "name": "checkoutAttributesUpdateV2",
+              "description": "Updates the attributes of a checkout.",
+              "args": [
+                {
+                  "name": "checkoutId",
+                  "description": "The ID of the checkout.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "input",
+                  "description": "The checkout attributes to update.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "CheckoutAttributesUpdateV2Input",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CheckoutAttributesUpdateV2Payload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -7814,7 +10497,7 @@
                 },
                 {
                   "name": "payment",
-                  "description": null,
+                  "description": "The credit card info to apply as a payment.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -7830,6 +10513,47 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "CheckoutCompleteWithCreditCardPayload",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `checkoutCompleteWithCreditCardV2` instead"
+            },
+            {
+              "name": "checkoutCompleteWithCreditCardV2",
+              "description": "Completes a checkout using a credit card token from Shopify's Vault.",
+              "args": [
+                {
+                  "name": "checkoutId",
+                  "description": "The ID of the checkout.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "payment",
+                  "description": "The credit card info to apply as a payment.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "CreditCardPaymentInputV2",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CheckoutCompleteWithCreditCardV2Payload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -7855,7 +10579,7 @@
                 },
                 {
                   "name": "payment",
-                  "description": null,
+                  "description": "The info to apply as a tokenized payment.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -7871,6 +10595,47 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "CheckoutCompleteWithTokenizedPaymentPayload",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `checkoutCompleteWithTokenizedPaymentV2` instead"
+            },
+            {
+              "name": "checkoutCompleteWithTokenizedPaymentV2",
+              "description": "Completes a checkout with a tokenized payment.",
+              "args": [
+                {
+                  "name": "checkoutId",
+                  "description": "The ID of the checkout.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "payment",
+                  "description": "The info to apply as a tokenized payment.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "TokenizedPaymentInputV2",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CheckoutCompleteWithTokenizedPaymentV2Payload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -7972,6 +10737,74 @@
               "deprecationReason": null
             },
             {
+              "name": "checkoutDiscountCodeApply",
+              "description": "Applies a discount to an existing checkout using a discount code.",
+              "args": [
+                {
+                  "name": "discountCode",
+                  "description": "The discount code to apply to the checkout.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "checkoutId",
+                  "description": "The ID of the checkout.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CheckoutDiscountCodeApplyPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "checkoutDiscountCodeRemove",
+              "description": "Removes the applied discount from an existing checkout.",
+              "args": [
+                {
+                  "name": "checkoutId",
+                  "description": "The ID of the checkout.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CheckoutDiscountCodeRemovePayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "checkoutEmailUpdate",
               "description": "Updates the email on an existing checkout.",
               "args": [
@@ -8014,7 +10847,7 @@
             },
             {
               "name": "checkoutGiftCardApply",
-              "description": "Applies a gift card to an existing checkout using a gift card code.",
+              "description": "Applies a gift card to an existing checkout using a gift card code. This will replace all currently applied gift cards.",
               "args": [
                 {
                   "name": "giftCardCode",
@@ -8050,8 +10883,8 @@
                 "name": "CheckoutGiftCardApplyPayload",
                 "ofType": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "Use `checkoutGiftCardsAppend` instead"
             },
             {
               "name": "checkoutGiftCardRemove",
@@ -8073,7 +10906,7 @@
                 },
                 {
                   "name": "checkoutId",
-                  "description": "The ID of the Checkout",
+                  "description": "The ID of the checkout.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -8089,6 +10922,55 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "CheckoutGiftCardRemovePayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "checkoutGiftCardsAppend",
+              "description": "Appends gift cards to an existing checkout.",
+              "args": [
+                {
+                  "name": "giftCardCodes",
+                  "description": "A list of gift card codes to append to the checkout.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "String",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "checkoutId",
+                  "description": "The ID of the checkout.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CheckoutGiftCardsAppendPayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -8123,47 +11005,6 @@
                 {
                   "name": "checkoutId",
                   "description": "The ID of the checkout.",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "ID",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "CheckoutLineItemsAddPayload",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "checkoutDiscountCodeApply",
-              "description": "Adds a list of line items to a checkout.",
-              "args": [
-                {
-                  "name": "checkoutId",
-                  "description": "The ID of the checkout.",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "ID",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "discountCode",
-                  "description": "Discount Code.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -8343,8 +11184,7 @@
                 },
                 {
                   "name": "shippingRateHandle",
-                  "description":
-                    "A concatenation of a Checkout’s shipping provider, price, and title, enabling the customer to select the availableShippingRates.",
+                  "description": "A concatenation of a Checkout’s shipping provider, price, and title, enabling the customer to select the availableShippingRates.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -8367,8 +11207,7 @@
             },
             {
               "name": "customerAccessTokenCreate",
-              "description":
-                "Creates a customer access token.\nThe customer access token is required to modify the customer object in any way.\n",
+              "description": "Creates a customer access token.\nThe customer access token is required to modify the customer object in any way.\n",
               "args": [
                 {
                   "name": "input",
@@ -8422,7 +11261,7 @@
             },
             {
               "name": "customerAccessTokenRenew",
-              "description": "Renews a customer access token.",
+              "description": "Renews a customer access token.\n\nAccess token renewal must happen *before* a token expires.\nIf a token has already expired, a new one should be created instead via `customerAccessTokenCreate`.\n",
               "args": [
                 {
                   "name": "customerAccessToken",
@@ -8653,9 +11492,49 @@
               "deprecationReason": null
             },
             {
+              "name": "customerDefaultAddressUpdate",
+              "description": "Updates the default address of an existing customer.",
+              "args": [
+                {
+                  "name": "customerAccessToken",
+                  "description": "The access token used to identify the customer.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "addressId",
+                  "description": "ID of the address to set as the new default for the customer.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CustomerDefaultAddressUpdatePayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "customerRecover",
-              "description":
-                "Sends a reset password email to the customer, as the first step in the reset password process.",
+              "description": "Sends a reset password email to the customer, as the first step in the reset password process.",
               "args": [
                 {
                   "name": "email",
@@ -8716,6 +11595,47 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "CustomerResetPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customerResetByUrl",
+              "description": "Resets a customer’s password with the reset password url received from `CustomerRecover`.",
+              "args": [
+                {
+                  "name": "resetUrl",
+                  "description": "The customer's reset password url.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "URL",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "password",
+                  "description": "New password that will be set as part of the reset password process.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CustomerResetByUrlPayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -8826,7 +11746,7 @@
           "fields": [
             {
               "name": "field",
-              "description": "Path to input field which caused the error.",
+              "description": "Path to the input field which caused the error.",
               "args": [],
               "type": {
                 "kind": "LIST",
@@ -8862,442 +11782,10 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "Checkout",
-          "description": "A container for all the information required to checkout items and pay.",
-          "fields": [
-            {
-              "name": "appliedGiftCards",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "AppliedGiftCard",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "availableShippingRates",
-              "description":
-                "The available shipping rates for this Checkout.\nShould only be used when checkout `requiresShipping` is `true` and\nthe shipping address is valid.\n",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "AvailableShippingRates",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "completedAt",
-              "description": "The date and time when the checkout was completed.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "createdAt",
-              "description": "The date and time when the checkout was created.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "DateTime",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "currencyCode",
-              "description": "The currency code for the Checkout.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "CurrencyCode",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "customAttributes",
-              "description": "A list of extra information that is added to the checkout.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "Attribute",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "customer",
-              "description": "The customer associated with the checkout.",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Customer",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "email",
-              "description": "The email attached to this checkout.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id",
-              "description": "Globally unique identifier.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "lineItems",
-              "description":
-                "A list of line item objects, each one containing information about an item in the checkout.",
-              "args": [
-                {
-                  "name": "first",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "after",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "reverse",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  },
-                  "defaultValue": "false"
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "CheckoutLineItemConnection",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "note",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "order",
-              "description": "The resulting order from a paid checkout.",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Order",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "orderStatusUrl",
-              "description": "The Order Status Page for this Checkout, null when checkout is not completed.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "URL",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "paymentDue",
-              "description":
-                "The amount left to be paid. This is equal to the cost of the line items, taxes and shipping minus discounts and gift cards.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Money",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ready",
-              "description":
-                "Whether or not the Checkout is ready and can be completed. Checkouts may have asynchronous operations that can take time to finish. If you want to complete a checkout or ensure all the fields are populated and up to date, polling is required until the value is true. ",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "requiresShipping",
-              "description": "States whether or not the fulfillment requires shipping.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "shippingAddress",
-              "description": "The shipping address to where the line items will be shipped.",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "MailingAddress",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "shippingLine",
-              "description":
-                "Once a shipping rate is selected by the customer it is transitioned to a `shipping_line` object.",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "ShippingRate",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "subtotalPrice",
-              "description": "Price of the checkout before shipping, taxes, and discounts.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Money",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "taxExempt",
-              "description": "Specifies if the Checkout is tax exempt.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "taxesIncluded",
-              "description": "Specifies if taxes are included in the line item and shipping line prices.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "totalPrice",
-              "description":
-                "The sum of all the prices of all the items in the checkout, taxes and discounts included.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Money",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "totalTax",
-              "description": "The sum of all the taxes applied to the line items and shipping lines in the checkout.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Money",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "updatedAt",
-              "description": "The date and time when the checkout was last updated.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "DateTime",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "webUrl",
-              "description": "The url pointing to the checkout accessible from the web.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "URL",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "DisplayableError",
               "ofType": null
             }
           ],
@@ -9305,284 +11793,13 @@
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "CheckoutLineItemConnection",
-          "description": null,
+          "kind": "INTERFACE",
+          "name": "DisplayableError",
+          "description": "Represents an error in the input of a mutation.",
           "fields": [
             {
-              "name": "edges",
-              "description": "A list of edges.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "CheckoutLineItemEdge",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "pageInfo",
-              "description": "Information to aid in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PageInfo",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "CheckoutLineItemEdge",
-          "description": null,
-          "fields": [
-            {
-              "name": "cursor",
-              "description": "A cursor for use in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "node",
-              "description": "The item at the end of CheckoutLineItemEdge.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "CheckoutLineItem",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "CheckoutLineItem",
-          "description": "A single line item in the checkout, grouped by variant and attributes.",
-          "fields": [
-            {
-              "name": "customAttributes",
-              "description": "Extra information in the form of an array of Key-Value pairs about the line item.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "Attribute",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id",
-              "description": "Globally unique identifier.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "quantity",
-              "description": "The quantity of the line item.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "title",
-              "description": "Title of the line item. Defaults to the product's title.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "variant",
-              "description": "Product variant of the line item.",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "ProductVariant",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "Node",
-              "ofType": null
-            }
-          ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "ShippingRate",
-          "description": "A shipping rate to be applied to a checkout.",
-          "fields": [
-            {
-              "name": "handle",
-              "description": "Human-readable unique identifier for this shipping rate.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "price",
-              "description": "Price of this shipping rate.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Money",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "title",
-              "description": "Title of this shipping rate.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "AvailableShippingRates",
-          "description": "A collection of available shipping rates for a checkout.",
-          "fields": [
-            {
-              "name": "ready",
-              "description":
-                "Whether or not the shipping rates are ready.\nThe `shippingRates` field is `null` when this value is `false`.\nThis field should be polled until its value becomes `true`.\n",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "shippingRates",
-              "description": "The fetched shipping rates. `null` until the `ready` field is `true`.",
+              "name": "field",
+              "description": "Path to the input field which caused the error.",
               "args": [],
               "type": {
                 "kind": "LIST",
@@ -9591,77 +11808,18 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "OBJECT",
-                    "name": "ShippingRate",
+                    "kind": "SCALAR",
+                    "name": "String",
                     "ofType": null
                   }
                 }
               },
               "isDeprecated": false,
               "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "AppliedGiftCard",
-          "description": "Details about the gift card used on the checkout.",
-          "fields": [
-            {
-              "name": "amountUsed",
-              "description": "The amount that was used taken from the Gift Card by applying it.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Money",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
             },
             {
-              "name": "balance",
-              "description": "The amount left on the Gift Card.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Money",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id",
-              "description": "Globally unique identifier.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "lastCharacters",
-              "description": "The last characters of the Gift Card code",
+              "name": "message",
+              "description": "The error message.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -9677,20 +11835,30 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
             {
-              "kind": "INTERFACE",
-              "name": "Node",
+              "kind": "OBJECT",
+              "name": "CheckoutUserError",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "CustomerUserError",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "UserError",
               "ofType": null
             }
-          ],
-          "enumValues": null,
-          "possibleTypes": null
+          ]
         },
         {
           "kind": "INPUT_OBJECT",
           "name": "CheckoutAttributesUpdateInput",
-          "description": "Specifies the fields required to update a checkout's attributes.\n",
+          "description": "Specifies the fields required to update a checkout's attributes.",
           "fields": null,
           "inputFields": [
             {
@@ -9723,8 +11891,7 @@
             },
             {
               "name": "allowPartialAddresses",
-              "description":
-                "Allows setting partial addresses on a Checkout, skipping the full validation of attributes.\nThe required attributes are city, province, and country.\nFull validation of the addresses is still done at complete time.\n",
+              "description": "Allows setting partial addresses on a Checkout, skipping the full validation of attributes.\nThe required attributes are city, province, and country.\nFull validation of the addresses is still done at complete time.\n",
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
@@ -9745,7 +11912,7 @@
           "inputFields": [
             {
               "name": "key",
-              "description": null,
+              "description": "Key or name of the attribute.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -9759,7 +11926,7 @@
             },
             {
               "name": "value",
-              "description": null,
+              "description": "Value of the attribute.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -9773,53 +11940,6 @@
             }
           ],
           "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "CheckoutCompleteFreePayload",
-          "description": null,
-          "fields": [
-            {
-              "name": "checkout",
-              "description": "The updated checkout object.",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Checkout",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "userErrors",
-              "description": "List of errors that occurred executing the mutation.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "UserError",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -10005,8 +12125,7 @@
             },
             {
               "name": "test",
-              "description":
-                "A flag to indicate if the payment is to be done in test mode for gateways that support it.",
+              "description": "A flag to indicate if the payment is to be done in test mode for gateways that support it.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -10022,8 +12141,7 @@
             },
             {
               "name": "transaction",
-              "description":
-                "The actual transaction recorded by Shopify after having processed the payment with the gateway.",
+              "description": "The actual transaction recorded by Shopify after having processed the payment with the gateway.",
               "args": [],
               "type": {
                 "kind": "OBJECT",
@@ -10306,8 +12424,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "CreditCardPaymentInput",
-          "description":
-            "Specifies the fields required to complete a checkout with\na Shopify vaulted credit card payment.\n",
+          "description": "Specifies the fields required to complete a checkout with\na Shopify vaulted credit card payment.\n",
           "fields": null,
           "inputFields": [
             {
@@ -10326,8 +12443,7 @@
             },
             {
               "name": "idempotencyKey",
-              "description":
-                "A unique client generated key used to avoid duplicate charges. When a duplicate payment is found, the original is returned instead of creating a new one.",
+              "description": "A unique client generated key used to avoid duplicate charges. When a duplicate payment is found, the original is returned instead of creating a new one.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -10578,8 +12694,7 @@
             },
             {
               "name": "idempotencyKey",
-              "description":
-                "A unique client generated key used to avoid duplicate charges. When a duplicate payment is found, the original is returned instead of creating a new one.",
+              "description": "A unique client generated key used to avoid duplicate charges. When a duplicate payment is found, the original is returned instead of creating a new one.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -10660,16 +12775,32 @@
         },
         {
           "kind": "OBJECT",
-          "name": "CheckoutCreatePayload",
+          "name": "CheckoutCustomerAssociatePayload",
           "description": null,
           "fields": [
             {
               "name": "checkout",
-              "description": "The new checkout object.",
+              "description": "The updated checkout object.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Checkout",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customer",
+              "description": "The associated customer object.",
               "args": [],
               "type": {
                 "kind": "OBJECT",
-                "name": "Checkout",
+                "name": "Customer",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -10706,154 +12837,8 @@
           "possibleTypes": null
         },
         {
-          "kind": "INPUT_OBJECT",
-          "name": "CheckoutCreateInput",
-          "description": "Specifies the fields required to create a checkout.\n",
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "email",
-              "description": "The email with which the customer wants to checkout.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "lineItems",
-              "description":
-                "A list of line item objects, each one containing information about an item in the checkout.",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "CheckoutLineItemInput",
-                    "ofType": null
-                  }
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "shippingAddress",
-              "description": "The shipping address to where the line items will be shipped.",
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "MailingAddressInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "note",
-              "description": "The text of an optional note that a shop owner can attach to the checkout.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "customAttributes",
-              "description": "A list of extra information that is added to the checkout.",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "AttributeInput",
-                    "ofType": null
-                  }
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "allowPartialAddresses",
-              "description":
-                "Allows setting partial addresses on a Checkout, skipping the full validation of attributes.\nThe required attributes are city, province, and country.\nFull validation of addresses is still done at complete time.\n",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "CheckoutLineItemInput",
-          "description": "Specifies the input fields to create a line item on a checkout.",
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "customAttributes",
-              "description": "Extra information in the form of an array of Key-Value pairs about the line item.",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "AttributeInput",
-                    "ofType": null
-                  }
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "quantity",
-              "description": "The quantity of the line item.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "variantId",
-              "description": "The identifier of the product variant for the line item.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "OBJECT",
-          "name": "CheckoutCustomerAssociatePayload",
+          "name": "CheckoutCustomerDisassociatePayload",
           "description": null,
           "fields": [
             {
@@ -10904,7 +12889,7 @@
         },
         {
           "kind": "OBJECT",
-          "name": "CheckoutCustomerDisassociatePayload",
+          "name": "CheckoutDiscountCodeApplyPayload",
           "description": null,
           "fields": [
             {
@@ -11072,6 +13057,1052 @@
                   "name": "Checkout",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "userErrors",
+              "description": "List of errors that occurred executing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "UserError",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CheckoutShippingAddressUpdatePayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "checkout",
+              "description": "The updated checkout object.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Checkout",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "userErrors",
+              "description": "List of errors that occurred executing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "UserError",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CheckoutAttributesUpdateV2Payload",
+          "description": null,
+          "fields": [
+            {
+              "name": "checkout",
+              "description": "The updated checkout object.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Checkout",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "userErrors",
+              "description": "List of errors that occurred executing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "UserError",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CheckoutAttributesUpdateV2Input",
+          "description": "Specifies the fields required to update a checkout's attributes.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "note",
+              "description": "The text of an optional note that a shop owner can attach to the checkout.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "customAttributes",
+              "description": "A list of extra information that is added to the checkout.",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AttributeInput",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "allowPartialAddresses",
+              "description": "Allows setting partial addresses on a Checkout, skipping the full validation of attributes.\nThe required attributes are city, province, and country.\nFull validation of the addresses is still done at complete time.\n",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "false"
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CheckoutCompleteWithCreditCardV2Payload",
+          "description": null,
+          "fields": [
+            {
+              "name": "checkout",
+              "description": "The checkout on which the payment was applied.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Checkout",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "payment",
+              "description": "A representation of the attempted payment.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Payment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "userErrors",
+              "description": "List of errors that occurred executing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "UserError",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CreditCardPaymentInputV2",
+          "description": "Specifies the fields required to complete a checkout with\na Shopify vaulted credit card payment.\n",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "paymentAmount",
+              "description": "The amount and currency of the payment.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "MoneyInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "idempotencyKey",
+              "description": "A unique client generated key used to avoid duplicate charges. When a duplicate payment is found, the original is returned instead of creating a new one.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "billingAddress",
+              "description": "The billing address for the payment.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "MailingAddressInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "vaultId",
+              "description": "The ID returned by Shopify's Card Vault.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "test",
+              "description": "Executes the payment in test mode if possible. Defaults to `false`.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "false"
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "MoneyInput",
+          "description": "Specifies the fields for a monetary value with currency.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "amount",
+              "description": "Decimal money amount.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Decimal",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "currencyCode",
+              "description": "Currency of the money.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyCode",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CheckoutCompleteWithTokenizedPaymentV2Payload",
+          "description": null,
+          "fields": [
+            {
+              "name": "checkout",
+              "description": "The checkout on which the payment was applied.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Checkout",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "payment",
+              "description": "A representation of the attempted payment.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Payment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "userErrors",
+              "description": "List of errors that occurred executing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "UserError",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "TokenizedPaymentInputV2",
+          "description": "Specifies the fields required to complete a checkout with\na tokenized payment.\n",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "paymentAmount",
+              "description": "The amount and currency of the payment.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "MoneyInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "idempotencyKey",
+              "description": "A unique client generated key used to avoid duplicate charges. When a duplicate payment is found, the original is returned instead of creating a new one.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "billingAddress",
+              "description": "The billing address for the payment.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "MailingAddressInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "type",
+              "description": "The type of payment token.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "paymentData",
+              "description": "A simple string or JSON containing the required payment data for the tokenized payment.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "test",
+              "description": "Executes the payment in test mode if possible. Defaults to `false`.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "false"
+            },
+            {
+              "name": "identifier",
+              "description": "Public Hash Key used for AndroidPay payments only.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CheckoutCompleteFreePayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "checkout",
+              "description": "The updated checkout object.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Checkout",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "userErrors",
+              "description": "List of errors that occurred executing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "UserError",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CheckoutCreatePayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "checkout",
+              "description": "The new checkout object.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Checkout",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "checkoutUserErrors",
+              "description": "List of errors that occurred executing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CheckoutUserError",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "userErrors",
+              "description": "List of errors that occurred executing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "UserError",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `checkoutUserErrors` instead"
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CheckoutUserError",
+          "description": "Represents an error that happens during execution of a checkout mutation.",
+          "fields": [
+            {
+              "name": "code",
+              "description": "Error code to uniquely identify the error.",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "CheckoutErrorCode",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "field",
+              "description": "Path to the input field which caused the error.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "message",
+              "description": "The error message.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "DisplayableError",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "CheckoutErrorCode",
+          "description": "Possible error codes that could be returned by a checkout mutation.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "BLANK",
+              "description": "Input value is blank.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INVALID",
+              "description": "Input value is invalid.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TOO_LONG",
+              "description": "Input value is too long.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PRESENT",
+              "description": "Input value is not present.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LESS_THAN",
+              "description": "Input value should be less than maximum allowed value.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ALREADY_COMPLETED",
+              "description": "Checkout is already completed.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LOCKED",
+              "description": "Checkout is locked.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NOT_SUPPORTED",
+              "description": "Input value is not supported.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INVALID_FOR_COUNTRY_AND_PROVINCE",
+              "description": "Input Zip is invalid for country and province provided.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INVALID_STATE_IN_COUNTRY",
+              "description": "Invalid state in country.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INVALID_PROVINCE_IN_COUNTRY",
+              "description": "Invalid province in country.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INVALID_REGION_IN_COUNTRY",
+              "description": "Invalid region in country.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SHIPPING_RATE_EXPIRED",
+              "description": "Shipping rate expired.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GIFT_CARD_UNUSABLE",
+              "description": "Gift card unusable.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CART_DOES_NOT_MEET_DISCOUNT_REQUIREMENTS_NOTICE",
+              "description": "Cart does not meet discount requirements notice.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DISCOUNT_EXPIRED",
+              "description": "Discount expired.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DISCOUNT_DISABLED",
+              "description": "Discount disabled.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DISCOUNT_LIMIT_REACHED",
+              "description": "Discount limit reached.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DISCOUNT_NOT_FOUND",
+              "description": "Discount not found.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CUSTOMER_ALREADY_USED_ONCE_PER_CUSTOMER_DISCOUNT_NOTICE",
+              "description": "Customer already used once per customer discount notice.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "EMPTY",
+              "description": "Checkout is already completed.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NOT_ENOUGH_IN_STOCK",
+              "description": "Not enough in stock.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CheckoutCreateInput",
+          "description": "Specifies the fields required to create a checkout.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "email",
+              "description": "The email with which the customer wants to checkout.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lineItems",
+              "description": "A list of line item objects, each one containing information about an item in the checkout.",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CheckoutLineItemInput",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "shippingAddress",
+              "description": "The shipping address to where the line items will be shipped.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "MailingAddressInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "note",
+              "description": "The text of an optional note that a shop owner can attach to the checkout.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "customAttributes",
+              "description": "A list of extra information that is added to the checkout.",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AttributeInput",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "allowPartialAddresses",
+              "description": "Allows setting partial addresses on a Checkout, skipping the full validation of attributes.\nThe required attributes are city, province, and country.\nFull validation of addresses is still done at complete time.\n",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CheckoutLineItemInput",
+          "description": "Specifies the input fields to create a line item on a checkout.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "customAttributes",
+              "description": "Extra information in the form of an array of Key-Value pairs about the line item.",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AttributeInput",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "quantity",
+              "description": "The quantity of the line item.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "variantId",
+              "description": "The identifier of the product variant for the line item.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CheckoutDiscountCodeRemovePayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "checkout",
+              "description": "The updated checkout object.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Checkout",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "userErrors",
+              "description": "List of errors that occurred executing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "UserError",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CheckoutGiftCardsAppendPayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "checkout",
+              "description": "The updated checkout object.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Checkout",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -11308,57 +14339,6 @@
         },
         {
           "kind": "OBJECT",
-          "name": "CheckoutShippingAddressUpdatePayload",
-          "description": null,
-          "fields": [
-            {
-              "name": "checkout",
-              "description": "The updated checkout object.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Checkout",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "userErrors",
-              "description": "List of errors that occurred executing the mutation.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "UserError",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
           "name": "CheckoutShippingLineUpdatePayload",
           "description": null,
           "fields": [
@@ -11422,6 +14402,30 @@
               "deprecationReason": null
             },
             {
+              "name": "customerUserErrors",
+              "description": "List of errors that occurred executing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CustomerUserError",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "userErrors",
               "description": "List of errors that occurred executing the mutation.",
               "args": [],
@@ -11442,8 +14446,8 @@
                   }
                 }
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "Use `customerUserErrors` instead"
             }
           ],
           "inputFields": null,
@@ -11453,9 +14457,144 @@
         },
         {
           "kind": "OBJECT",
+          "name": "CustomerUserError",
+          "description": "Represents an error that happens during execution of a customer mutation.",
+          "fields": [
+            {
+              "name": "code",
+              "description": "Error code to uniquely identify the error.",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "CustomerErrorCode",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "field",
+              "description": "Path to the input field which caused the error.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "message",
+              "description": "The error message.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "DisplayableError",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "CustomerErrorCode",
+          "description": "Possible error codes that could be returned by a customer mutation.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "BLANK",
+              "description": "Input value is blank.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INVALID",
+              "description": "Input value is invalid.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TAKEN",
+              "description": "Input value is already taken.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TOO_LONG",
+              "description": "Input value is too long.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TOO_SHORT",
+              "description": "Input value is too short.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNIDENTIFIED_CUSTOMER",
+              "description": "Unidentified customer.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CUSTOMER_DISABLED",
+              "description": "Customer is disabled.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PASSWORD_STARTS_OR_ENDS_WITH_WHITESPACE",
+              "description": "Input password starts or ends with whitespace.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CONTAINS_HTML_TAGS",
+              "description": "Input contains HTML tags.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CONTAINS_URL",
+              "description": "Input contains URL.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "CustomerAccessToken",
-          "description":
-            "A CustomerAccessToken represents the unique token required to make modifications to the customer object.",
+          "description": "A CustomerAccessToken represents the unique token required to make modifications to the customer object.",
           "fields": [
             {
               "name": "accessToken",
@@ -11658,6 +14797,18 @@
               "deprecationReason": null
             },
             {
+              "name": "customerAccessToken",
+              "description": "A newly created customer access token object for the customer.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CustomerAccessToken",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "userErrors",
               "description": "List of errors that occurred executing the mutation.",
               "args": [],
@@ -11695,7 +14846,7 @@
           "inputFields": [
             {
               "name": "activationToken",
-              "description": "The activation token required to activate the customer",
+              "description": "The activation token required to activate the customer.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -11709,7 +14860,7 @@
             },
             {
               "name": "password",
-              "description": "The login password used by the customer.",
+              "description": "New password that will be set during activation.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -11885,6 +15036,30 @@
               "deprecationReason": null
             },
             {
+              "name": "customerUserErrors",
+              "description": "List of errors that occurred executing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CustomerUserError",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "userErrors",
               "description": "List of errors that occurred executing the mutation.",
               "args": [],
@@ -11905,8 +15080,8 @@
                   }
                 }
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "Use `customerUserErrors` instead"
             }
           ],
           "inputFields": null,
@@ -11995,6 +15170,53 @@
         },
         {
           "kind": "OBJECT",
+          "name": "CustomerDefaultAddressUpdatePayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "customer",
+              "description": "The updated customer object.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Customer",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "userErrors",
+              "description": "List of errors that occurred executing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "UserError",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "CustomerRecoverPayload",
           "description": null,
           "fields": [
@@ -12040,6 +15262,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Customer",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customerAccessToken",
+              "description": "A newly created customer access token object for the customer.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CustomerAccessToken",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -12116,6 +15350,65 @@
         },
         {
           "kind": "OBJECT",
+          "name": "CustomerResetByUrlPayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "customer",
+              "description": "The customer object which was reset.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Customer",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customerAccessToken",
+              "description": "A newly created customer access token object for the customer.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CustomerAccessToken",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "userErrors",
+              "description": "List of errors that occurred executing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "UserError",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "CustomerUpdatePayload",
           "description": null,
           "fields": [
@@ -12126,6 +15419,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Customer",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customerAccessToken",
+              "description": "The newly created customer access token. If the customer's password is updated, all previous access tokens\n(including the one used to perform this mutation) become invalid, and a new token is generated.\n",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CustomerAccessToken",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -12235,8 +15540,7 @@
         {
           "kind": "OBJECT",
           "name": "__Schema",
-          "description":
-            "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+          "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
           "fields": [
             {
               "name": "directives",
@@ -12292,8 +15596,7 @@
             },
             {
               "name": "subscriptionType",
-              "description":
-                "If this server support subscription, the type that subscription operations will be rooted at.",
+              "description": "If this server support subscription, the type that subscription operations will be rooted at.",
               "args": [],
               "type": {
                 "kind": "OBJECT",
@@ -12336,8 +15639,7 @@
         {
           "kind": "OBJECT",
           "name": "__Type",
-          "description":
-            "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+          "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
           "fields": [
             {
               "name": "description",
@@ -12512,6 +15814,18 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "requiredAccess",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -12520,69 +15834,9 @@
           "possibleTypes": null
         },
         {
-          "kind": "ENUM",
-          "name": "__TypeKind",
-          "description": "An enum describing what kind of type a given `__Type` is.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "SCALAR",
-              "description": "Indicates this type is a scalar.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "OBJECT",
-              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "INTERFACE",
-              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "UNION",
-              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ENUM",
-              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "INPUT_OBJECT",
-              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "LIST",
-              "description": "Indicates this type is a list. `ofType` is a valid field.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "NON_NULL",
-              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
           "kind": "OBJECT",
           "name": "__Field",
-          "description":
-            "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+          "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
           "fields": [
             {
               "name": "accessRestrictedReason",
@@ -12693,69 +15947,13 @@
               "deprecationReason": null
             },
             {
-              "name": "type",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "__Type",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "__InputValue",
-          "description":
-            "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
-          "fields": [
-            {
-              "name": "defaultValue",
-              "description": "A GraphQL-formatted string representing the default value for this input value.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "description",
+              "name": "requiredAccess",
               "description": null,
               "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -12770,74 +15968,6 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "__Type",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "__EnumValue",
-          "description":
-            "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
-          "fields": [
-            {
-              "name": "deprecationReason",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "description",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "isDeprecated",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
                   "ofType": null
                 }
               },
@@ -12853,8 +15983,7 @@
         {
           "kind": "OBJECT",
           "name": "__Directive",
-          "description":
-            "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+          "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
           "fields": [
             {
               "name": "args",
@@ -12987,10 +16116,202 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "__EnumValue",
+          "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+          "fields": [
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__InputValue",
+          "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+          "fields": [
+            {
+              "name": "defaultValue",
+              "description": "A GraphQL-formatted string representing the default value for this input value.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__TypeKind",
+          "description": "An enum describing what kind of type a given `__Type` is.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "SCALAR",
+              "description": "Indicates this type is a scalar.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LIST",
+              "description": "Indicates this type is a list. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NON_NULL",
+              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
           "kind": "ENUM",
           "name": "__DirectiveLocation",
-          "description":
-            "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+          "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -13105,13 +16426,336 @@
             }
           ],
           "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DiscountCodeApplication",
+          "description": "Discount code applications capture the intentions of a discount code at\nthe time that it is applied.\n",
+          "fields": [
+            {
+              "name": "allocationMethod",
+              "description": "The method by which the discount's value is allocated to its entitled items.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DiscountApplicationAllocationMethod",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "applicable",
+              "description": "Specifies whether the discount code was applied successfully.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "code",
+              "description": "The string identifying the discount code that was used at the time of application.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "targetSelection",
+              "description": "Which lines of targetType that the discount is allocated over.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DiscountApplicationTargetSelection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "targetType",
+              "description": "The type of line that the discount is applicable towards.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DiscountApplicationTargetType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "value",
+              "description": "The value of the discount application.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "UNION",
+                  "name": "PricingValue",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "DiscountApplication",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ManualDiscountApplication",
+          "description": "Manual discount applications capture the intentions of a discount that was manually created.\n",
+          "fields": [
+            {
+              "name": "allocationMethod",
+              "description": "The method by which the discount's value is allocated to its entitled items.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DiscountApplicationAllocationMethod",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": "The description of the application.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "targetSelection",
+              "description": "Which lines of targetType that the discount is allocated over.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DiscountApplicationTargetSelection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "targetType",
+              "description": "The type of line that the discount is applicable towards.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DiscountApplicationTargetType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "The title of the application.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "value",
+              "description": "The value of the discount application.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "UNION",
+                  "name": "PricingValue",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "DiscountApplication",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ScriptDiscountApplication",
+          "description": "Script discount applications capture the intentions of a discount that\nwas created by a Shopify Script.\n",
+          "fields": [
+            {
+              "name": "allocationMethod",
+              "description": "The method by which the discount's value is allocated to its entitled items.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DiscountApplicationAllocationMethod",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": "The description of the application as defined by the Script.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "targetSelection",
+              "description": "Which lines of targetType that the discount is allocated over.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DiscountApplicationTargetSelection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "targetType",
+              "description": "The type of line that the discount is applicable towards.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DiscountApplicationTargetType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "value",
+              "description": "The value of the discount application.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "UNION",
+                  "name": "PricingValue",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "DiscountApplication",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
         }
       ],
       "directives": [
         {
           "name": "include",
           "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
-          "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
           "args": [
             {
               "name": "if",
@@ -13132,7 +16776,11 @@
         {
           "name": "skip",
           "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
-          "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
           "args": [
             {
               "name": "if",
@@ -13153,12 +16801,14 @@
         {
           "name": "deprecated",
           "description": "Marks an element of a GraphQL schema as no longer supported.",
-          "locations": ["FIELD_DEFINITION", "ENUM_VALUE"],
+          "locations": [
+            "FIELD_DEFINITION",
+            "ENUM_VALUE"
+          ],
           "args": [
             {
               "name": "reason",
-              "description":
-                "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).",
+              "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13171,7 +16821,9 @@
         {
           "name": "accessRestricted",
           "description": "Marks an element of a GraphQL schema as having restricted access.",
-          "locations": ["FIELD_DEFINITION"],
+          "locations": [
+            "FIELD_DEFINITION"
+          ],
           "args": [
             {
               "name": "reason",

--- a/src/checkout-resource.js
+++ b/src/checkout-resource.js
@@ -10,6 +10,7 @@ import checkoutLineItemsRemoveMutation from './graphql/checkoutLineItemsRemoveMu
 import checkoutLineItemsUpdateMutation from './graphql/checkoutLineItemsUpdateMutation.graphql';
 import checkoutAttributesUpdateMutation from './graphql/checkoutAttributesUpdateMutation.graphql';
 import checkoutDiscountCodeApplyMutation from './graphql/checkoutDiscountCodeApplyMutation.graphql';
+import checkoutDiscountCodeRemoveMutation from './graphql/checkoutDiscountCodeRemoveMutation.graphql';
 import checkoutEmailUpdateMutation from './graphql/checkoutEmailUpdateMutation.graphql';
 
 /**
@@ -155,6 +156,25 @@ class CheckoutResource extends Resource {
     return this.graphQLClient
       .send(checkoutDiscountCodeApplyMutation, {checkoutId, discountCode})
       .then(handleCheckoutMutation('checkoutDiscountCodeApply', this.graphQLClient));
+  }
+
+  /**
+   * Removes the applied discount from an existing checkout.
+   *
+   * @example
+   * const checkoutId = 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9kMTZmM2EzMDM4Yjc4N=';
+   *
+   * client.checkout.removeDiscount(checkoutId).then((checkout) => {
+   *   // Do something with the updated checkout
+   * });
+   *
+   * @param {String} checkoutId The ID of the checkout to remove the discount from.
+   * @return {Promise|GraphModel} A promise resolving with the updated checkout.
+   */
+  removeDiscount(checkoutId) {
+    return this.graphQLClient
+      .send(checkoutDiscountCodeRemoveMutation, {checkoutId})
+      .then(handleCheckoutMutation('checkoutDiscountCodeRemove', this.graphQLClient));
   }
 
   /**

--- a/src/checkout-resource.js
+++ b/src/checkout-resource.js
@@ -105,7 +105,7 @@ class CheckoutResource extends Resource {
    *   // Do something with the updated checkout
    * });
    *
-   * @param {String} checkoutId The ID of the checkout to add discount to.
+   * @param {String} checkoutId The ID of the checkout to update.
    * @param {String} email The email address to apply to the checkout.
    * @return {Promise|GraphModel} A promise resolving with the updated checkout.
    */

--- a/src/graphql/CheckoutFragment.graphql
+++ b/src/graphql/CheckoutFragment.graphql
@@ -36,6 +36,13 @@ fragment CheckoutFragment on Checkout {
   createdAt
   updatedAt
   email
+  discountApplications(first: 10) {
+    edges {
+      node {
+        ...DiscountApplicationFragment
+      }
+    }
+  }
   shippingAddress {
     ...MailingAddressFragment
   }
@@ -105,6 +112,9 @@ fragment CheckoutFragment on Checkout {
           allocatedAmount {
             amount
             currencyCode
+          }
+          discountApplication {
+            ...DiscountApplicationFragment
           }
         }
       }

--- a/src/graphql/CheckoutFragment.graphql
+++ b/src/graphql/CheckoutFragment.graphql
@@ -101,6 +101,12 @@ fragment CheckoutFragment on Checkout {
           key
           value
         }
+        discountAllocations {
+          allocatedAmount {
+            amount
+            currencyCode
+          }
+        }
       }
     }
   }

--- a/src/graphql/DiscountApplicationFragment.graphql
+++ b/src/graphql/DiscountApplicationFragment.graphql
@@ -1,0 +1,16 @@
+fragment DiscountApplicationFragment on DiscountApplication {
+  targetSelection
+  allocationMethod
+  targetType
+  ... on ManualDiscountApplication {
+    title
+    description
+  }
+  ... on DiscountCodeApplication {
+    code
+    applicable
+  }
+  ... on ScriptDiscountApplication {
+    description
+  }
+}

--- a/src/graphql/checkoutDiscountCodeRemoveMutation.graphql
+++ b/src/graphql/checkoutDiscountCodeRemoveMutation.graphql
@@ -1,0 +1,10 @@
+mutation checkoutDiscountCodeRemove($checkoutId: ID!) {
+  checkoutDiscountCodeRemove(checkoutId: $checkoutId) {
+    userErrors {
+      ...UserErrorFragment
+    }
+    checkout {
+      ...CheckoutFragment
+    }
+  }
+}

--- a/test/client-checkout-integration-test.js
+++ b/test/client-checkout-integration-test.js
@@ -13,6 +13,7 @@ import checkoutLineItemsRemoveFixture from '../fixtures/checkout-line-items-remo
 import checkoutUpdateAttributesFixture from '../fixtures/checkout-update-custom-attrs-fixture';
 import checkoutUpdateEmailFixture from '../fixtures/checkout-update-email-fixture';
 import checkoutDiscountCodeApplyFixture from '../fixtures/checkout-discount-code-apply-fixture';
+import checkoutDiscountCodeRemoveFixture from '../fixtures/checkout-discount-code-remove-fixture';
 
 suite('client-checkout-integration-test', () => {
   const domain = 'client-integration-tests.myshopify.io';
@@ -150,6 +151,17 @@ suite('client-checkout-integration-test', () => {
     const discountCode = 'TENPERCENTOFF';
 
     return client.checkout.addDiscount(checkoutId, discountCode).then((checkout) => {
+      assert.equal(checkout.id, checkoutId);
+      assert.ok(fetchMock.done());
+    });
+  });
+
+  test('it resolves with a checkout on Client.checkout#removeDiscount', () => {
+    fetchMock.postOnce(apiUrl, checkoutDiscountCodeRemoveFixture);
+
+    const checkoutId = checkoutDiscountCodeRemoveFixture.data.checkoutDiscountCodeRemove.checkout.id;
+
+    return client.checkout.removeDiscount(checkoutId).then((checkout) => {
       assert.equal(checkout.id, checkoutId);
       assert.ok(fetchMock.done());
     });

--- a/test/client-checkout-integration-test.js
+++ b/test/client-checkout-integration-test.js
@@ -12,6 +12,7 @@ import checkoutLineItemsUpdateFixture from '../fixtures/checkout-line-items-upda
 import checkoutLineItemsRemoveFixture from '../fixtures/checkout-line-items-remove-fixture';
 import checkoutUpdateAttributesFixture from '../fixtures/checkout-update-custom-attrs-fixture';
 import checkoutUpdateEmailFixture from '../fixtures/checkout-update-email-fixture';
+import checkoutDiscountCodeApplyFixture from '../fixtures/checkout-discount-code-apply-fixture';
 
 suite('client-checkout-integration-test', () => {
   const domain = 'client-integration-tests.myshopify.io';
@@ -137,6 +138,18 @@ suite('client-checkout-integration-test', () => {
     const checkoutId = checkoutLineItemsRemoveFixture.data.checkoutLineItemsRemove.checkout.id;
 
     return client.checkout.removeLineItems(checkoutId, ['line-item-id']).then((checkout) => {
+      assert.equal(checkout.id, checkoutId);
+      assert.ok(fetchMock.done());
+    });
+  });
+
+  test('it resolves with a checkout on Client.checkout#addDiscount', () => {
+    fetchMock.postOnce(apiUrl, checkoutDiscountCodeApplyFixture);
+
+    const checkoutId = checkoutDiscountCodeApplyFixture.data.checkoutDiscountCodeApply.checkout.id;
+    const discountCode = 'TENPERCENTOFF';
+
+    return client.checkout.addDiscount(checkoutId, discountCode).then((checkout) => {
       assert.equal(checkout.id, checkoutId);
       assert.ok(fetchMock.done());
     });


### PR DESCRIPTION
This updates `schema.json` to include: articles, blogByHandle, blogs, discountAllocation, discountCodeApplication, manualDiscountApplication, scriptDiscountApplication, some other fields on the customer, checkout and order objects and some additional mutations.

Other changes:
- Add a mutation to remove an applied discount code
- Exposes discountApplications on the checkout object
- Exposes discountAllocations on the checkoutLineItem object
- Add a test for the addDiscount mutation

