### PR TITLE
[DNM] Replace deprecated fields with their non-deprecated counterparts

### DIFF
--- a/fixtures/checkout-create-fixture.js
+++ b/fixtures/checkout-create-fixture.js
@@ -54,7 +54,7 @@ export default {
           "province": "Ontario",
           "zip": "M3O 0W1",
           "name": "Meow Meowington",
-          "countryCode": "CA",
+          "countryCodeV2": "CA",
           "provinceCode": "ON",
           "id": "Z2lkOi8vc2hvcGlmeS9QcmdfnAU8nakdWMnAbh890hyOTEwNjA2NDU4NA=="
         },

--- a/fixtures/checkout-discount-code-apply-fixture.js
+++ b/fixtures/checkout-discount-code-apply-fixture.js
@@ -40,7 +40,7 @@ export default {
           "province": "Ontario",
           "zip": "M3O 0W1",
           "name": "Meow Meowington",
-          "countryCode": "CA",
+          "countryCodeV2": "CA",
           "provinceCode": "ON",
           "id": "291dC9lM2JkNzHJnnf8a89njNJNKAhu1gn7lMzM5MzFlZj9rZXk9NDcwOTJ=="
         },

--- a/fixtures/checkout-discount-code-remove-fixture.js
+++ b/fixtures/checkout-discount-code-remove-fixture.js
@@ -40,7 +40,7 @@ export default {
           "province": "Ontario",
           "zip": "M3O 0W1",
           "name": "Meow Meowington",
-          "countryCode": "CA",
+          "countryCodeV2": "CA",
           "provinceCode": "ON",
           "id": "291dC9lM2JkNzHJnnf8a89njNJNKAhu1gn7lMzM5MzFlZj9rZXk9NDcwOTJ=="
         },

--- a/fixtures/checkout-line-items-add-fixture.js
+++ b/fixtures/checkout-line-items-add-fixture.js
@@ -28,7 +28,7 @@ export default {
           "province": "Ontario",
           "zip": "M3O 0W1",
           "name": "Meow Meowington",
-          "countryCode": "CA",
+          "countryCodeV2": "CA",
           "provinceCode": "ON",
           "id": "291dC9lM2JkNzHJnnf8a89njNJNKAhu1gn7lMzM5MzFlZj9rZXk9NDcwOTJ=="
         },

--- a/fixtures/checkout-line-items-remove-fixture.js
+++ b/fixtures/checkout-line-items-remove-fixture.js
@@ -32,7 +32,7 @@ export default {
           "province": "Ontario",
           "zip": "M3O 0W1",
           "name": "Meow Meowington",
-          "countryCode": "CA",
+          "countryCodeV2": "CA",
           "provinceCode": "ON",
           "id": "Z2lkOi8vc2hvcGlmeSsiujh8aQJbnkl9Qcm9kdWN0VmaJKN8flqAnq8TEwNjA2NDU4NA=="
         },

--- a/fixtures/checkout-line-items-update-fixture.js
+++ b/fixtures/checkout-line-items-update-fixture.js
@@ -25,7 +25,7 @@ export default {
                            "weight":0,
                            "image": {
                               "id":"Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
-                              "src":"https://cdn.shopify.com/s/files/1/1312/0893/products/003_3e206539-20d3-49c0-8bff-006e449906ca.jpg?v=1491850970",
+                              "originalSrc":"https://cdn.shopify.com/s/files/1/1312/0893/products/003_3e206539-20d3-49c0-8bff-006e449906ca.jpg?v=1491850970",
                               "altText":null
                            },
                            "selectedOptions":[

--- a/fixtures/checkout-update-custom-attrs-fixture.js
+++ b/fixtures/checkout-update-custom-attrs-fixture.js
@@ -54,7 +54,7 @@ export default {
           "province": "Ontario",
           "zip": "M3O 0W1",
           "name": "Meow Meowington",
-          "countryCode": "CA",
+          "countryCodeV2": "CA",
           "provinceCode": "ON",
           "id": "Z2lkOi8vc2hvcGlmeS9QcmdfnAU8nakdWMnAbh890hyOTEwNjA2NDU4NA=="
         },

--- a/fixtures/checkout-update-email-fixture.js
+++ b/fixtures/checkout-update-email-fixture.js
@@ -54,7 +54,7 @@ export default {
           "province": "Ontario",
           "zip": "M3O 0W1",
           "name": "Meow Meowington",
-          "countryCode": "CA",
+          "countryCodeV2": "CA",
           "provinceCode": "ON",
           "id": "Z2lkOi8vc2hvcGlmeS9QcmdfnAU8nakdWMnAbh890hyOTEwNjA2NDU4NA=="
         },

--- a/fixtures/collection-with-products-fixture.js
+++ b/fixtures/collection-with-products-fixture.js
@@ -61,7 +61,7 @@ export default {
                     "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTYzMDY4MTI2ODA=",
-                      "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
+                      "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
                       "altText": "fettucine"
                     }
                   },
@@ -69,7 +69,7 @@ export default {
                     "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
-                      "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
+                      "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
                       "altText": null
                     }
                   },
@@ -77,7 +77,7 @@ export default {
                     "cursor": "eyJsYXN0X2lkIjoxODIxNzc5MDY2NH0=",
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
-                      "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
+                      "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
                       "altText": null
                     }
                   },
@@ -85,7 +85,7 @@ export default {
                     "cursor": "eyJsYXN0X2lkIjoxOTYxNjczNjg0MH0=",
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
-                      "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
+                      "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
                       "altText": null
                     }
                   }
@@ -106,7 +106,7 @@ export default {
                       "weight": 18,
                       "image": {
                         "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
-                        "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
+                        "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
                         "altText": null
                       },
                       "selectedOptions": [
@@ -130,7 +130,7 @@ export default {
                       "weight": 18,
                       "image": {
                         "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
-                        "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
+                        "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
                         "altText": null
                       },
                       "selectedOptions": [
@@ -154,7 +154,7 @@ export default {
                       "weight": 0,
                       "image": {
                         "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
-                        "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
+                        "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
                         "altText": null
                       },
                       "selectedOptions": [
@@ -208,7 +208,7 @@ export default {
                     "cursor": "eyJsYXN0X2lkIjoyMDE0MzA0MTg2NH0=",
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjAxNDMwNDE4NjQ=",
-                      "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/image.dots.morethings.jpg?v=1490898420",
+                      "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/image.dots.morethings.jpg?v=1490898420",
                       "altText": null
                     }
                   }

--- a/fixtures/dynamic-product-fixture.js
+++ b/fixtures/dynamic-product-fixture.js
@@ -16,21 +16,21 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTYzMDY4MTI2ODA=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096"
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096"
             }
           },
           {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581332"
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581332"
             }
           },
           {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc5MDY2NH0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1484581340"
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1484581340"
             }
           }
         ]

--- a/fixtures/paginated-images-fixtures.js
+++ b/fixtures/paginated-images-fixtures.js
@@ -13,7 +13,7 @@ export const secondPageImagesFixture = {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTYzMDY4MTI2ODA=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581332",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581332",
               "altText": null
             }
           }
@@ -38,7 +38,7 @@ export const thirdPageImagesFixture = {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc5MDY2NH0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4MTk0MDA=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1484581340",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1484581340",
               "altText": null
             }
           }
@@ -63,7 +63,7 @@ export const fourthPageImagesFixture = {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI4MjkzODQ=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581340",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581340",
               "altText": null
             }
           }
@@ -88,7 +88,7 @@ export const fifthPageImagesFixture = {
             "cursor": "eyJsYXN0X2lkIjoxOTYxNjczNjg0MH0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
               "altText": null
             }
           }

--- a/fixtures/product-by-handle-fixture.js
+++ b/fixtures/product-by-handle-fixture.js
@@ -38,79 +38,79 @@ export default {
           }
         ],
         "images": {
-          "pageInfo": { 
-            "hasNextPage": false, 
-            "hasPreviousPage": false 
+          "pageInfo": {
+            "hasNextPage": false,
+            "hasPreviousPage": false
           },
           "edges": [
             {
               "node": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDgxNjY=",
-                "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/babyandco5.jpg?v=1487171332",
+                "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/babyandco5.jpg?v=1487171332",
                 "altText": null
               }
             },
             {
               "node": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDgyMzA=",
-                "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24008.jpg?v=1487171332",
+                "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24008.jpg?v=1487171332",
                 "altText": null
               }
             },
             {
               "node": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDgyOTQ=",
-                "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24015.jpg?v=1487171332",
+                "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24015.jpg?v=1487171332",
                 "altText": null
               }
             },
             {
               "node": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDgzNTg=",
-                "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24020.jpg?v=1487171332",
+                "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24020.jpg?v=1487171332",
                 "altText": null
               }
             },
             {
               "node": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg0MjI=",
-                "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_34_51031_24037.jpg?v=1487171332",
+                "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_34_51031_24037.jpg?v=1487171332",
                 "altText": null
               }
             },
             {
               "node": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg0ODY=",
-                "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24024.jpg?v=1487171332",
+                "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24024.jpg?v=1487171332",
                 "altText": null
               }
             },
             {
               "node": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg1NTA=",
-                "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24034.jpg?v=1487171332",
+                "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24034.jpg?v=1487171332",
                 "altText": null
               }
             },
             {
               "node": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg2MTQ=",
-                "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_34_51031_24040.jpg?v=1487171332",
+                "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_34_51031_24040.jpg?v=1487171332",
                 "altText": null
               }
             }
           ]
         },
         "variants": {
-          "pageInfo": { 
-            "hasNextPage": false, 
-            "hasPreviousPage": false 
+          "pageInfo": {
+            "hasNextPage": false,
+            "hasPreviousPage": false
           },
           "edges": [
             {
               "node": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zNTgzMTE3NDIxNA==",
-                "available": true,
+                "availableForSale": true,
                 "weight": 0,
                 "price": "788.00",
                 "title": "Black / X-Small",
@@ -130,7 +130,7 @@ export default {
             {
               "node": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zNTgzMTE3NDQwNg==",
-                "available": true,
+                "availableForSale": true,
                 "weight": 0,
                 "price": "788.00",
                 "title": "Black / Small",
@@ -150,7 +150,7 @@ export default {
             {
               "node": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zNTgzMTE3NDUzNA==",
-                "available": false,
+                "availableForSale": false,
                 "weight": 0,
                 "price": "788.00",
                 "title": "Black / Medium",
@@ -170,13 +170,13 @@ export default {
             {
               "node": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zNTgzMTE3NDcyNg==",
-                "available": true,
+                "availableForSale": true,
                 "weight": 0,
                 "price": "750.00",
                 "title": "Dark Green / X-Small",
                 "image": {
                   "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg0MjI=",
-                  "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_34_51031_24037.jpg?v=1487171332"
+                  "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_34_51031_24037.jpg?v=1487171332"
                 },
                 "selectedOptions": [
                   {
@@ -193,13 +193,13 @@ export default {
             {
               "node": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zNTgzMTE3NDkxOA==",
-                "available": false,
+                "availableForSale": false,
                 "weight": 0,
                 "price": "750.00",
                 "title": "Dark Green / Small",
                 "image": {
                   "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg2MTQ=",
-                  "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_34_51031_24040.jpg?v=1487171332"
+                  "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_34_51031_24040.jpg?v=1487171332"
                 },
                 "selectedOptions": [
                   {
@@ -216,13 +216,13 @@ export default {
             {
               "node": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zNTgzMTE3NTExMA==",
-                "available": true,
+                "availableForSale": true,
                 "weight": 0,
                 "price": "788.00",
                 "title": "Dark Green / Medium",
                 "image": {
                   "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg1NTA=",
-                  "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24034.jpg?v=1487171332"
+                  "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24034.jpg?v=1487171332"
                 },
                 "selectedOptions": [
                   {
@@ -239,13 +239,13 @@ export default {
             {
               "node": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC80MjgyNzA5NjcyNQ==",
-                "available": true,
+                "availableForSale": true,
                 "weight": 0,
                 "price": "788.00",
                 "title": "Dark Green / Large",
                 "image": {
                   "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg0ODY=",
-                  "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24024.jpg?v=1487171332"
+                  "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24024.jpg?v=1487171332"
                 },
                 "selectedOptions": [
                   {

--- a/fixtures/product-fixture.js
+++ b/fixtures/product-fixture.js
@@ -45,7 +45,7 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
               "altText": "fettucine"
             }
           },
@@ -53,7 +53,7 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
               "altText": null
             }
           },
@@ -61,7 +61,7 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc5MDY2NH0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
               "altText": null
             }
           },
@@ -69,7 +69,7 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoxOTYxNjczNjg0MH0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
               "altText": null
             }
           }
@@ -90,7 +90,7 @@ export default {
               "weight": 18,
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
+                "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
                 "altText": null
               },
               "selectedOptions": [
@@ -114,7 +114,7 @@ export default {
               "weight": 18,
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
+                "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
                 "altText": null
               },
               "selectedOptions": [
@@ -138,7 +138,7 @@ export default {
               "weight": 0,
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
+                "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
                 "altText": null
               },
               "selectedOptions": [

--- a/fixtures/product-with-paginated-images-fixture.js
+++ b/fixtures/product-with-paginated-images-fixture.js
@@ -42,7 +42,7 @@ export default {
                     "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
-                      "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096",
+                      "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096",
                       "altText": null
                     }
                   }

--- a/fixtures/product-with-paginated-variants-fixture.js
+++ b/fixtures/product-with-paginated-variants-fixture.js
@@ -16,7 +16,7 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTYzMDY4MTI2ODA=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096"
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096"
             }
           }
         ]

--- a/fixtures/shop-with-collections-with-pagination-fixture.js
+++ b/fixtures/shop-with-collections-with-pagination-fixture.js
@@ -69,7 +69,7 @@ export default {
                             "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
                             "node": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTYzMDY4MTI2ODA=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
                               "altText": "fettucine"
                             }
                           }
@@ -90,7 +90,7 @@ export default {
                               "weight": 18,
                               "image": {
                                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
-                                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
+                                "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
                                 "altText": null
                               },
                               "selectedOptions": [
@@ -114,7 +114,7 @@ export default {
                               "weight": 18,
                               "image": {
                                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
-                                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
+                                "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
                                 "altText": null
                               },
                               "selectedOptions": [
@@ -138,7 +138,7 @@ export default {
                               "weight": 0,
                               "image": {
                                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
-                                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
+                                "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
                                 "altText": null
                               },
                               "selectedOptions": [
@@ -192,7 +192,7 @@ export default {
                             "cursor": "eyJsYXN0X2lkIjoyMDE0MzA0MTg2NH0=",
                             "node": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjAxNDMwNDE4NjQ=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/image.dots.morethings.jpg?v=1490898420",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/image.dots.morethings.jpg?v=1490898420",
                               "altText": null
                             }
                           }
@@ -279,7 +279,7 @@ export default {
                             "cursor": "eyJsYXN0X2lkIjoxODIxNzgxOTQwMH0=",
                             "node": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4MTk0MDA=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/notcat.jpeg?v=1490363658",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/notcat.jpeg?v=1490363658",
                               "altText": null
                             }
                           }
@@ -300,7 +300,7 @@ export default {
                               "weight": 0,
                               "image": {
                                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
-                                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/054cca77f1be90654f4f70db263a3822.jpg?v=1490363658",
+                                "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/054cca77f1be90654f4f70db263a3822.jpg?v=1490363658",
                                 "altText": null
                               },
                               "selectedOptions": [
@@ -320,7 +320,7 @@ export default {
                               "weight": 0,
                               "image": {
                                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NTk3MjA=",
-                                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/23695_pets_vertical_store_dogs_small_tile_8._CB312176604.jpg?v=1490363658",
+                                "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/23695_pets_vertical_store_dogs_small_tile_8._CB312176604.jpg?v=1490363658",
                                 "altText": null
                               },
                               "selectedOptions": [
@@ -340,7 +340,7 @@ export default {
                               "weight": 0,
                               "image": {
                                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI4MjkzODQ=",
-                                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/original.jpg?v=1490363713",
+                                "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/original.jpg?v=1490363713",
                                 "altText": null
                               },
                               "selectedOptions": [

--- a/fixtures/shop-with-collections-with-products-fixture.js
+++ b/fixtures/shop-with-collections-with-products-fixture.js
@@ -69,7 +69,7 @@ export default {
                             "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
                             "node": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTYzMDY4MTI2ODA=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
                               "altText": "fettucine"
                             }
                           },
@@ -77,7 +77,7 @@ export default {
                             "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
                             "node": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
                               "altText": null
                             }
                           },
@@ -85,7 +85,7 @@ export default {
                             "cursor": "eyJsYXN0X2lkIjoxODIxNzc5MDY2NH0=",
                             "node": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
                               "altText": null
                             }
                           },
@@ -93,7 +93,7 @@ export default {
                             "cursor": "eyJsYXN0X2lkIjoxOTYxNjczNjg0MH0=",
                             "node": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
                               "altText": null
                             }
                           }
@@ -114,7 +114,7 @@ export default {
                               "weight": 18,
                               "image": {
                                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
-                                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
+                                "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
                                 "altText": null
                               },
                               "selectedOptions": [
@@ -138,7 +138,7 @@ export default {
                               "weight": 18,
                               "image": {
                                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
-                                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
+                                "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
                                 "altText": null
                               },
                               "selectedOptions": [
@@ -162,7 +162,7 @@ export default {
                               "weight": 0,
                               "image": {
                                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
-                                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
+                                "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
                                 "altText": null
                               },
                               "selectedOptions": [
@@ -216,7 +216,7 @@ export default {
                             "cursor": "eyJsYXN0X2lkIjoyMDE0MzA0MTg2NH0=",
                             "node": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjAxNDMwNDE4NjQ=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/image.dots.morethings.jpg?v=1490898420",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/image.dots.morethings.jpg?v=1490898420",
                               "altText": null
                             }
                           }
@@ -303,7 +303,7 @@ export default {
                             "cursor": "eyJsYXN0X2lkIjoxODIxNzgxOTQwMH0=",
                             "node": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4MTk0MDA=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/notcat.jpeg?v=1490363658",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/notcat.jpeg?v=1490363658",
                               "altText": null
                             }
                           },
@@ -311,7 +311,7 @@ export default {
                             "cursor": "eyJsYXN0X2lkIjoxODIxNzg0NzYyNH0=",
                             "node": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NDc2MjQ=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/hqdefault.jpg?v=1490363658",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/hqdefault.jpg?v=1490363658",
                               "altText": null
                             }
                           },
@@ -319,7 +319,7 @@ export default {
                             "cursor": "eyJsYXN0X2lkIjoxODIxNzg1OTcyMH0=",
                             "node": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NTk3MjA=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/23695_pets_vertical_store_dogs_small_tile_8._CB312176604.jpg?v=1490363658",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/23695_pets_vertical_store_dogs_small_tile_8._CB312176604.jpg?v=1490363658",
                               "altText": null
                             }
                           },
@@ -327,7 +327,7 @@ export default {
                             "cursor": "eyJsYXN0X2lkIjoxOTg5Mjc4MzU2MH0=",
                             "node": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/054cca77f1be90654f4f70db263a3822.jpg?v=1490363658",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/054cca77f1be90654f4f70db263a3822.jpg?v=1490363658",
                               "altText": null
                             }
                           },
@@ -335,7 +335,7 @@ export default {
                             "cursor": "eyJsYXN0X2lkIjoxOTg5MjgyOTM4NH0=",
                             "node": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI4MjkzODQ=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/original.jpg?v=1490363713",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/original.jpg?v=1490363713",
                               "altText": null
                             }
                           }
@@ -356,7 +356,7 @@ export default {
                               "weight": 0,
                               "image": {
                                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
-                                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/054cca77f1be90654f4f70db263a3822.jpg?v=1490363658",
+                                "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/054cca77f1be90654f4f70db263a3822.jpg?v=1490363658",
                                 "altText": null
                               },
                               "selectedOptions": [
@@ -376,7 +376,7 @@ export default {
                               "weight": 0,
                               "image": {
                                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NTk3MjA=",
-                                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/23695_pets_vertical_store_dogs_small_tile_8._CB312176604.jpg?v=1490363658",
+                                "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/23695_pets_vertical_store_dogs_small_tile_8._CB312176604.jpg?v=1490363658",
                                 "altText": null
                               },
                               "selectedOptions": [
@@ -396,7 +396,7 @@ export default {
                               "weight": 0,
                               "image": {
                                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI4MjkzODQ=",
-                                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/original.jpg?v=1490363713",
+                                "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/original.jpg?v=1490363713",
                                 "altText": null
                               },
                               "selectedOptions": [

--- a/fixtures/shop-with-products-fixture.js
+++ b/fixtures/shop-with-products-fixture.js
@@ -42,7 +42,7 @@ export default {
                     "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-                      "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096",
+                      "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096",
                       "altText": null
                     }
                   },
@@ -50,7 +50,7 @@ export default {
                     "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-                      "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581332",
+                      "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581332",
                       "altText": null
                     }
                   },
@@ -58,7 +58,7 @@ export default {
                     "cursor": "eyJsYXN0X2lkIjoxODIxNzc5MDY2NH0=",
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-                      "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1484581340",
+                      "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1484581340",
                       "altText": null
                     }
                   }
@@ -157,7 +157,7 @@ export default {
                     "cursor": "eyJsYXN0X2lkIjoxODIxNzgxOTQwMH0=",
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-                      "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/notcat.jpeg?v=1484581419",
+                      "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/notcat.jpeg?v=1484581419",
                       "altText": null
                     }
                   },
@@ -165,7 +165,7 @@ export default {
                     "cursor": "eyJsYXN0X2lkIjoxODIxNzg0NzYyNH0=",
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-                      "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/hqdefault.jpg?v=1484581502",
+                      "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/hqdefault.jpg?v=1484581502",
                       "altText": null
                     }
                   },
@@ -173,7 +173,7 @@ export default {
                     "cursor": "eyJsYXN0X2lkIjoxODIxNzg1OTcyMH0=",
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-                      "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/23695_pets_vertical_store_dogs_small_tile_8._CB312176604.jpg?v=1484581539",
+                      "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/23695_pets_vertical_store_dogs_small_tile_8._CB312176604.jpg?v=1484581539",
                       "altText": null
                     }
                   },
@@ -181,7 +181,7 @@ export default {
                     "cursor": "eyJsYXN0X2lkIjoxODIxNzg2ODQ4OH0=",
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-                      "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/images.jpg?v=1484581568",
+                      "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/images.jpg?v=1484581568",
                       "altText": null
                     }
                   }

--- a/src/graphql/CheckoutFragment.graphql
+++ b/src/graphql/CheckoutFragment.graphql
@@ -14,7 +14,7 @@ fragment MailingAddressFragment on MailingAddress {
   province
   zip
   name
-  countryCode
+  countryCodeV2
   provinceCode
 }
 

--- a/src/graphql/CollectionFragment.graphql
+++ b/src/graphql/CollectionFragment.graphql
@@ -7,7 +7,7 @@ fragment CollectionFragment on Collection {
   title
   image {
     id
-    src
+    originalSrc
     altText
   }
 }

--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -24,7 +24,7 @@ fragment ProductFragment on Product {
       cursor
       node {
         id
-        src
+        originalSrc
         altText
       }
     }

--- a/src/graphql/VariantFragment.graphql
+++ b/src/graphql/VariantFragment.graphql
@@ -3,12 +3,12 @@ fragment VariantFragment on ProductVariant {
   title
   price
   weight
-  available
+  availableForSale
   sku
   compareAtPrice
   image {
     id
-    src
+    originalSrc
     altText
   }
   selectedOptions {

--- a/src/image-helpers.js
+++ b/src/image-helpers.js
@@ -19,7 +19,7 @@ export default {
    * @return {String} The image src for the resized image.
    */
   imageForSize(image, {maxWidth, maxHeight}) {
-    const splitUrl = image.src.split('?');
+    const splitUrl = image.originalSrc.split('?');
     const notQuery = splitUrl[0];
     const query = splitUrl[1] ? `?${splitUrl[1]}` : '';
 

--- a/test/image-helpers-test.js
+++ b/test/image-helpers-test.js
@@ -3,25 +3,25 @@ import imageHelpers from '../src/image-helpers';
 
 suite('image-helpers-test', () => {
   test('it returns the image src with the specified width and height', () => {
-    const resizedImageSrc = imageHelpers.imageForSize({src: 'https://cdn.shopify.com/s/files/1/1019/0495/products/babyandco5.jpg?v=1487171332'}, {maxWidth: 280, maxHeight: 560});
+    const resizedImageSrc = imageHelpers.imageForSize({originalSrc: 'https://cdn.shopify.com/s/files/1/1019/0495/products/babyandco5.jpg?v=1487171332'}, {maxWidth: 280, maxHeight: 560});
 
     assert.equal(resizedImageSrc, 'https://cdn.shopify.com/s/files/1/1019/0495/products/babyandco5_280x560.jpg?v=1487171332');
   });
 
   test('it returns the correct url for an image without any url params', () => {
-    const resizedImageSrc = imageHelpers.imageForSize({src: 'https://cdn.shopify.com/s/files/1/1019/0495/products/babyandco5.jpg'}, {maxWidth: 280, maxHeight: 560});
+    const resizedImageSrc = imageHelpers.imageForSize({originalSrc: 'https://cdn.shopify.com/s/files/1/1019/0495/products/babyandco5.jpg'}, {maxWidth: 280, maxHeight: 560});
 
     assert.equal(resizedImageSrc, 'https://cdn.shopify.com/s/files/1/1019/0495/products/babyandco5_280x560.jpg');
   });
 
   test('it returns the correct url for filenames with .', () => {
-    const resizedImageSrc = imageHelpers.imageForSize({src: 'https://cdn.shopify.com/s/files/1/1019/0495/products/Ashley.34.51031.test.jpg?v=1505141764'}, {maxWidth: 280, maxHeight: 560});
+    const resizedImageSrc = imageHelpers.imageForSize({originalSrc: 'https://cdn.shopify.com/s/files/1/1019/0495/products/Ashley.34.51031.test.jpg?v=1505141764'}, {maxWidth: 280, maxHeight: 560});
 
     assert.equal(resizedImageSrc, 'https://cdn.shopify.com/s/files/1/1019/0495/products/Ashley.34.51031.test_280x560.jpg?v=1505141764');
   });
 
   test('it returns the correct url for an image src with . in the query param', () => {
-    const resizedImageSrc = imageHelpers.imageForSize({src: 'https://cdn.shopify.com/s/files/1/1019/0495/products/babyandco5.jpg?v=148.71713.32'}, {maxWidth: 280, maxHeight: 560});
+    const resizedImageSrc = imageHelpers.imageForSize({originalSrc: 'https://cdn.shopify.com/s/files/1/1019/0495/products/babyandco5.jpg?v=148.71713.32'}, {maxWidth: 280, maxHeight: 560});
 
     assert.equal(resizedImageSrc, 'https://cdn.shopify.com/s/files/1/1019/0495/products/babyandco5_280x560.jpg?v=148.71713.32');
   });


### PR DESCRIPTION
Closes https://github.com/Shopify/shopify/issues/178821.

Updates the SDK to remove the use of deprecated fields and replace them with their non-deprecated counterparts.

* Replace `countryCode` on MailingAddress with `countryCodeV2`
* Replace `src` on Image with `originalSrc`
* Replace `available` on Productvariant with `availableForSale`