### PR TITLE
Remove tags field from Product fragment #597

### DIFF
--- a/fixtures/collection-with-products-fixture.js
+++ b/fixtures/collection-with-products-fixture.js
@@ -27,9 +27,6 @@ export default {
               "productType": "cat",
               "title": "Cat",
               "vendor": "sendmecats",
-              "tags": [
-                "vintage"
-              ],
               "publishedAt": "2017-01-12T19:44:42Z",
               "options": [
                 {
@@ -185,9 +182,6 @@ export default {
               "productType": "cat",
               "title": "Cat 2",
               "vendor": "sendmecats",
-              "tags": [
-                "fluffy"
-              ],
               "publishedAt": "2017-02-03T18:52:27Z",
               "options": [
                 {

--- a/fixtures/product-by-handle-fixture.js
+++ b/fixtures/product-by-handle-fixture.js
@@ -11,11 +11,6 @@ export default {
         "handle": "cape-dress-1",
         "productType": "women's dresses",
         "vendor": "Co",
-        "tags": [
-          "arrivals",
-          "AW15",
-          "black",
-        ],
         "publishedAt": "2017-02-15T15:09:45Z",
         "options": [
           {

--- a/fixtures/product-fixture.js
+++ b/fixtures/product-fixture.js
@@ -11,9 +11,6 @@ export default {
       "productType": "cat",
       "title": "Cat",
       "vendor": "sendmecats",
-      "tags": [
-        "vintage"
-      ],
       "publishedAt": "2017-01-12T19:44:42Z",
       "options": [
         {

--- a/fixtures/product-with-paginated-images-fixture.js
+++ b/fixtures/product-with-paginated-images-fixture.js
@@ -19,7 +19,6 @@ export default {
               "productType": "",
               "title": "Cat",
               "vendor": "sendmecats",
-              "tags": [],
               "publishedAt": "2016-09-25T21:29:00Z",
               "options": [
                 {

--- a/fixtures/shop-with-collections-with-pagination-fixture.js
+++ b/fixtures/shop-with-collections-with-pagination-fixture.js
@@ -35,9 +35,6 @@ export default {
                       "productType": "cat",
                       "title": "Cat",
                       "vendor": "sendmecats",
-                      "tags": [
-                        "vintage"
-                      ],
                       "publishedAt": "2017-01-12T19:44:42Z",
                       "options": [
                         {
@@ -169,9 +166,6 @@ export default {
                       "productType": "cat",
                       "title": "Cat 2",
                       "vendor": "sendmecats",
-                      "tags": [
-                        "fluffy"
-                      ],
                       "publishedAt": "2017-02-03T18:52:27Z",
                       "options": [
                         {
@@ -256,7 +250,6 @@ export default {
                       "productType": "really not cat",
                       "title": "Not Cat",
                       "vendor": "sendmecats",
-                      "tags": [],
                       "publishedAt": "2017-01-16T15:43:38Z",
                       "options": [
                         {

--- a/fixtures/shop-with-collections-with-products-fixture.js
+++ b/fixtures/shop-with-collections-with-products-fixture.js
@@ -35,9 +35,6 @@ export default {
                       "productType": "cat",
                       "title": "Cat",
                       "vendor": "sendmecats",
-                      "tags": [
-                        "vintage"
-                      ],
                       "publishedAt": "2017-01-12T19:44:42Z",
                       "options": [
                         {
@@ -193,9 +190,6 @@ export default {
                       "productType": "cat",
                       "title": "Cat 2",
                       "vendor": "sendmecats",
-                      "tags": [
-                        "fluffy"
-                      ],
                       "publishedAt": "2017-02-03T18:52:27Z",
                       "options": [
                         {
@@ -280,7 +274,6 @@ export default {
                       "productType": "really not cat",
                       "title": "Not Cat",
                       "vendor": "sendmecats",
-                      "tags": [],
                       "publishedAt": "2017-01-16T15:43:38Z",
                       "options": [
                         {

--- a/fixtures/shop-with-products-fixture.js
+++ b/fixtures/shop-with-products-fixture.js
@@ -19,7 +19,6 @@ export default {
               "productType": "",
               "title": "Cat",
               "vendor": "sendmecats",
-              "tags": [],
               "publishedAt": "2016-09-25T21:29:00Z",
               "options": [
                 {
@@ -134,7 +133,6 @@ export default {
               "productType": "",
               "title": "Not Cat",
               "vendor": "sendmecats",
-              "tags": [],
               "publishedAt": "2017-01-16T15:42:00Z",
               "options": [
                 {

--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -8,7 +8,6 @@ fragment ProductFragment on Product {
   productType
   title
   vendor
-  tags
   publishedAt
   onlineStoreUrl
   options {


### PR DESCRIPTION
The default ProductFragment provided by this SDK comes with a `tags` field,
but since the permission to read product tags is disabled by default in the
Storefront API settings, an error would occur with the message "access denied"
when using `client.product.fetchAll()`.

This PR fixes the issue by removing the `tags` field from the Product fragment.