### PR TITLE
Add field aliases for deprecated fields

### DIFF
--- a/src/graphql/CheckoutFragment.graphql
+++ b/src/graphql/CheckoutFragment.graphql
@@ -14,7 +14,7 @@ fragment MailingAddressFragment on MailingAddress {
   province
   zip
   name
-  countryCode
+  countryCode: countryCodeV2
   provinceCode
 }
 

--- a/src/graphql/CollectionFragment.graphql
+++ b/src/graphql/CollectionFragment.graphql
@@ -7,7 +7,7 @@ fragment CollectionFragment on Collection {
   title
   image {
     id
-    src
+    src: originalSrc
     altText
   }
 }

--- a/src/graphql/VariantFragment.graphql
+++ b/src/graphql/VariantFragment.graphql
@@ -3,12 +3,12 @@ fragment VariantFragment on ProductVariant {
   title
   price
   weight
-  available
+  available: availableForSale
   sku
   compareAtPrice
   image {
     id
-    src
+    src: originalSrc
     altText
   }
   selectedOptions {


### PR DESCRIPTION
Successor to https://github.com/Shopify/js-buy-sdk/pull/596.

Adds field aliasing for deprecated fields:
* `src` -> `originalSrc`
* `countryCode` -> `countryCodeV2`
* `available` -> `availableForSale`

This allows us to keep the public API in this library consistent for now, while querying the new non-deprecated fields from the Storefront API.