### PR TITLE
Create unoptimized packages as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "prepublish": "yarn run build",
     "build": "yarn run build:optimized && yarn run build:unoptimized",
-    "build:optimized": "rollup -c && yarn run minify-umd",
+    "build:optimized": "rollup -c && yarn run minify-umd:optimized",
     "build:unoptimized": "rollup -c rollup-unoptimized.config.js && yarn run minify-umd:unoptimized",
     "start": "yarn run clean && yarn run setup-paths && concurrently --names DEPS,LIVERELOAD,ROLLUP,HTTP,NOTIFIER 'yarn run test:web-deps' 'yarn run test:livereload-server' 'yarn run test:watch' 'http-server -p 4200 .tmp/test' 'yarn run print-start-message'",
     "clean": "rimraf .tmp index.*",
@@ -29,7 +29,7 @@
     "lint:reporter-args": "test -n \"${CI}\" && >&2 echo -o $CIRCLE_TEST_REPORTS/junit/eslint.xml -f junit",
     "print-start-message": "wait-on file:.tmp/test/index.html file:.tmp/test/tests.js tcp:35729 tcp:4200 && echo \"\n\n⚡️⚡️⚡️  Good to go at http://localhost:4200 ⚡️⚡️⚡️\"",
     "schema:fetch": "graphql-js-schema-fetch --url 'https://graphql.myshopify.com/api/graphql' --header 'Authorization: Basic MzUxYzEyMjAxN2QwZjJhOTU3ZDMyYWU3MjhhZDc0OWM=' | jq '.' > schema.json",
-    "minify-umd": "echo \"/*\n$(cat LICENSE.txt)\n*/\" > index.umd.min.js && babel-minify index.umd.js >> index.umd.min.js",
+    "minify-umd:optimized": "echo \"/*\n$(cat LICENSE.txt)\n*/\" > index.umd.min.js && babel-minify index.umd.js >> index.umd.min.js",
     "minify-umd:unoptimized": "echo \"/*\n$(cat LICENSE.txt)\n*/\" > index.unoptimized.umd.min.js && babel-minify index.unoptimized.umd.js >> index.unoptimized.umd.min.js"
   },
   "author": "Shopify Inc.",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   },
   "scripts": {
     "prepublish": "yarn run build",
-    "build": "rollup -c && yarn run minify-umd",
+    "build": "yarn run build:optimized && yarn run build:unoptimized",
+    "build:optimized": "rollup -c && yarn run minify-umd",
+    "build:unoptimized": "rollup -c rollup-unoptimized.config.js && yarn run minify-umd:unoptimized",
     "start": "yarn run clean && yarn run setup-paths && concurrently --names DEPS,LIVERELOAD,ROLLUP,HTTP,NOTIFIER 'yarn run test:web-deps' 'yarn run test:livereload-server' 'yarn run test:watch' 'http-server -p 4200 .tmp/test' 'yarn run print-start-message'",
     "clean": "rimraf .tmp index.*",
     "doc:build": "jsdoc -c jsdoc.json",
@@ -27,7 +29,8 @@
     "lint:reporter-args": "test -n \"${CI}\" && >&2 echo -o $CIRCLE_TEST_REPORTS/junit/eslint.xml -f junit",
     "print-start-message": "wait-on file:.tmp/test/index.html file:.tmp/test/tests.js tcp:35729 tcp:4200 && echo \"\n\n⚡️⚡️⚡️  Good to go at http://localhost:4200 ⚡️⚡️⚡️\"",
     "schema:fetch": "graphql-js-schema-fetch --url 'https://graphql.myshopify.com/api/graphql' --header 'Authorization: Basic MzUxYzEyMjAxN2QwZjJhOTU3ZDMyYWU3MjhhZDc0OWM=' | jq '.' > schema.json",
-    "minify-umd": "echo \"/*\n$(cat LICENSE.txt)\n*/\" > index.umd.min.js && babel-minify index.umd.js >> index.umd.min.js"
+    "minify-umd": "echo \"/*\n$(cat LICENSE.txt)\n*/\" > index.umd.min.js && babel-minify index.umd.js >> index.umd.min.js",
+    "minify-umd:unoptimized": "echo \"/*\n$(cat LICENSE.txt)\n*/\" > index.unoptimized.umd.min.js && babel-minify index.unoptimized.umd.js >> index.unoptimized.umd.min.js"
   },
   "author": "Shopify Inc.",
   "license": "MIT",

--- a/rollup-common.config.js
+++ b/rollup-common.config.js
@@ -31,25 +31,12 @@ const plugins = [
   sizes()
 ];
 
-const targets = [
-  {format: 'cjs', suffix: ''},
-  {format: 'amd', suffix: '.amd'},
-  {format: 'es', suffix: '.es'},
-  {format: 'umd', suffix: '.umd'}
-].map((config) => {
-  return {
-    dest: `index${config.suffix}.js`,
-    format: config.format
-  };
-});
-
 const banner = `/*
 ${readFileSync('./LICENSE.txt')}
 */`;
 
 export default {
   plugins: plugins,
-  targets: targets,
   banner: banner,
   entry: 'src/client.js',
   moduleName: 'ShopifyBuy',

--- a/rollup-common.config.js
+++ b/rollup-common.config.js
@@ -1,0 +1,57 @@
+/* eslint-env node */
+import {readFileSync} from 'fs';
+import babel from 'rollup-plugin-babel';
+import json from 'rollup-plugin-json';
+import nodeResolve from 'rollup-plugin-node-resolve';
+import sizes from 'rollup-plugin-sizes';
+
+const plugins = [
+  json({
+    exclude: './schema.json'
+  }),
+  nodeResolve({
+    jsnext: true,
+    main: true
+  }),
+  babel({
+    babelrc: false,
+    presets: [
+      [`${process.cwd()}/node_modules/babel-preset-env/lib/index`, {
+        targets: {
+          browsers: ['last 2 versions'],
+          node: '8.1.2'
+        },
+        modules: false
+      }]
+    ],
+    plugins: [
+      `${process.cwd()}/node_modules/babel-plugin-external-helpers/lib/index`
+    ]
+  }),
+  sizes()
+];
+
+const targets = [
+  {format: 'cjs', suffix: ''},
+  {format: 'amd', suffix: '.amd'},
+  {format: 'es', suffix: '.es'},
+  {format: 'umd', suffix: '.umd'}
+].map((config) => {
+  return {
+    dest: `index${config.suffix}.js`,
+    format: config.format
+  };
+});
+
+const banner = `/*
+${readFileSync('./LICENSE.txt')}
+*/`;
+
+export default {
+  plugins: plugins,
+  targets: targets,
+  banner: banner,
+  entry: 'src/client.js',
+  moduleName: 'ShopifyBuy',
+  sourceMap: true
+};

--- a/rollup-common.config.js
+++ b/rollup-common.config.js
@@ -5,40 +5,38 @@ import json from 'rollup-plugin-json';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import sizes from 'rollup-plugin-sizes';
 
-const plugins = [
-  json({
-    exclude: './schema.json'
-  }),
-  nodeResolve({
-    jsnext: true,
-    main: true
-  }),
-  babel({
-    babelrc: false,
-    presets: [
-      [`${process.cwd()}/node_modules/babel-preset-env/lib/index`, {
-        targets: {
-          browsers: ['last 2 versions'],
-          node: '8.1.2'
-        },
-        modules: false
-      }]
-    ],
+export default function generateBaseRollupConfig() {
+  return {
     plugins: [
-      `${process.cwd()}/node_modules/babel-plugin-external-helpers/lib/index`
-    ]
-  }),
-  sizes()
-];
-
-const banner = `/*
-${readFileSync('./LICENSE.txt')}
-*/`;
-
-export default {
-  plugins: plugins,
-  banner: banner,
-  entry: 'src/client.js',
-  moduleName: 'ShopifyBuy',
-  sourceMap: true
-};
+      json({
+        exclude: './schema.json'
+      }),
+      nodeResolve({
+        jsnext: true,
+        main: true
+      }),
+      babel({
+        babelrc: false,
+        presets: [
+          [`${process.cwd()}/node_modules/babel-preset-env/lib/index`, {
+            targets: {
+              browsers: ['last 2 versions'],
+              node: '8.1.2'
+            },
+            modules: false
+          }]
+        ],
+        plugins: [
+          `${process.cwd()}/node_modules/babel-plugin-external-helpers/lib/index`
+        ]
+      }),
+      sizes()
+    ],
+    banner: `/*
+      ${readFileSync('./LICENSE.txt')}
+      */`,
+    entry: 'src/client.js',
+    moduleName: 'ShopifyBuy',
+    sourceMap: true
+  };
+}

--- a/rollup-unoptimized.config.js
+++ b/rollup-unoptimized.config.js
@@ -1,8 +1,10 @@
 /* eslint-env node */
 import graphqlCompiler from 'rollup-plugin-graphql-js-client-compiler';
-import baseConfig from './rollup-common.config';
+import generateBaseRollupConfig from './rollup-common.config';
 
-baseConfig.plugins.unshift(
+const config = generateBaseRollupConfig();
+
+config.plugins.unshift(
   graphqlCompiler({
     schema: './schema.json',
     optimize: false,
@@ -10,13 +12,13 @@ baseConfig.plugins.unshift(
   })
 );
 
-baseConfig.targets = [
+config.targets = [
   {format: 'umd', suffix: '.umd'}
-].map((config) => {
+].map((c) => {
   return {
-    dest: `index.unoptimized${config.suffix}.js`,
-    format: config.format
+    dest: `index.unoptimized${c.suffix}.js`,
+    format: c.format
   };
 });
 
-export default baseConfig;
+export default config;

--- a/rollup-unoptimized.config.js
+++ b/rollup-unoptimized.config.js
@@ -5,9 +5,18 @@ import baseConfig from './rollup-common.config';
 baseConfig.plugins.unshift(
   graphqlCompiler({
     schema: './schema.json',
-    optimize: true,
+    optimize: false,
     profileDocuments: ['src/graphql/**/*.graphql']
   })
 );
+
+baseConfig.targets = [
+  {format: 'umd', suffix: '.umd'}
+].map((config) => {
+  return {
+    dest: `index.unoptimized${config.suffix}.js`,
+    format: config.format
+  };
+});
 
 export default baseConfig;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,4 +10,16 @@ baseConfig.plugins.unshift(
   })
 );
 
+baseConfig.targets = [
+  {format: 'cjs', suffix: ''},
+  {format: 'amd', suffix: '.amd'},
+  {format: 'es', suffix: '.es'},
+  {format: 'umd', suffix: '.umd'}
+].map((config) => {
+  return {
+    dest: `index${config.suffix}.js`,
+    format: config.format
+  };
+});
+
 export default baseConfig;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,10 @@
 /* eslint-env node */
 import graphqlCompiler from 'rollup-plugin-graphql-js-client-compiler';
-import baseConfig from './rollup-common.config';
+import generateBaseRollupConfig from './rollup-common.config';
 
-baseConfig.plugins.unshift(
+const config = generateBaseRollupConfig();
+
+config.plugins.unshift(
   graphqlCompiler({
     schema: './schema.json',
     optimize: true,
@@ -10,16 +12,16 @@ baseConfig.plugins.unshift(
   })
 );
 
-baseConfig.targets = [
+config.targets = [
   {format: 'cjs', suffix: ''},
   {format: 'amd', suffix: '.amd'},
   {format: 'es', suffix: '.es'},
   {format: 'umd', suffix: '.umd'}
-].map((config) => {
+].map((c) => {
   return {
-    dest: `index${config.suffix}.js`,
-    format: config.format
+    dest: `index${c.suffix}.js`,
+    format: c.format
   };
 });
 
-export default baseConfig;
+export default config;


### PR DESCRIPTION
Looking for feedback on:
1) I couldn't figure out how to have an array of exports from `rollup.config.js` on our current rollup version, so I duped the file. Is there a better way to do this?
2) I'm only generating an unoptimized version of the umd file (and a minified one). Is this sufficient or should I regenerate them all?
3) This was my first time really working with `package.json`. Can the scripts be rewritten to be less competitive?
4) How should I test this?