### PR TITLE
Checkout shipping address update

### DIFF
--- a/fixtures/checkout-shipping-address-update-v2-fixture.js
+++ b/fixtures/checkout-shipping-address-update-v2-fixture.js
@@ -1,0 +1,71 @@
+export default {
+  "data": {
+    "checkoutShippingAddressUpdateV2": {
+      "userErrors": [],
+      "checkout": {
+        "id": "Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",
+        "createdAt": "2017-03-17T16:00:40Z",
+        "updatedAt": "2017-03-17T16:00:40Z",
+        "requiresShipping": true,
+        "shippingLine": null,
+        "order": null,
+        "orderStatusUrl": null,
+        "taxExempt": false,
+        "taxesIncluded": false,
+        "currencyCode": "CAD",
+        "totalPrice": "80.28",
+        "subtotalPrice": "67.50",
+        "totalTax": "8.78",
+        "paymentDue": "80.28",
+        "taxExempt": false,
+        "taxesIncluded": false,
+        "completedAt": null,
+        "shippingAddress": {
+          "id": "Z2lkOi8vc2hvcGlmeS9NYWlsaW5nQWRkcmVzcy8xMTAyNDgxNzE5MzE4P21vZGVsX25hbWU9QWRkcmVzcw==",
+          "address1": "Chestnut Street 92",
+          "address2": "Apartment 2",
+          "city": "Louisville",
+          "company": null,
+          "country": "United States",
+          "firstName": "Bob",
+          "formatted": [
+            "Chestnut Street 92",
+            "Apartment 2",
+            "Louisville KY 40202",
+            "United States"
+          ],
+          "lastName": "Norman",
+          "latitude": null,
+          "longitude": null,
+          "phone": "555-625-1199",
+          "province": "Kentucky",
+          "zip": "40202",
+          "name": "Bob Norman",
+          "countryCode": "US",
+          "provinceCode": "KY"
+        },
+        "lineItems": {
+          "pageInfo": {
+            "hasNextPage": false,
+            "hasPreviousPage": false
+          },
+          "edges": [
+            {
+              "cursor": "eyJsYXN0X2lkIjoiZDUyZWU5ZTEwYmQxMWE0NDlkNmQzMWNkMzBhMGFjNzMifQ==",
+              "node": {
+                "title": "Intelligent Granite Table",
+                "variant": {
+                  "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
+                  "price": "74.99"
+                },
+                "quantity": 5,
+                "customAttributes": [],
+                "discountAllocations": []
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+};

--- a/fixtures/checkout-shipping-address-update-v2-with-user-errors-fixture.js
+++ b/fixtures/checkout-shipping-address-update-v2-with-user-errors-fixture.js
@@ -1,0 +1,12 @@
+export default {
+  "data": {
+    "checkoutShippingAddressUpdateV2": {
+      "userErrors": [
+        {
+          "message": 'Country is not supported',
+          "field": ['shippingAddress country']
+        }
+      ]
+    }
+  }
+};

--- a/src/checkout-resource.js
+++ b/src/checkout-resource.js
@@ -13,6 +13,7 @@ import checkoutAttributesUpdateV2Mutation from './graphql/checkoutAttributesUpda
 import checkoutDiscountCodeApplyV2Mutation from './graphql/checkoutDiscountCodeApplyV2Mutation.graphql';
 import checkoutDiscountCodeRemoveMutation from './graphql/checkoutDiscountCodeRemoveMutation.graphql';
 import checkoutEmailUpdateV2Mutation from './graphql/checkoutEmailUpdateV2Mutation.graphql';
+import checkoutShippingAddressUpdateV2Mutation from './graphql/checkoutShippingAddressUpdateV2Mutation.graphql';
 
 /**
  * The JS Buy SDK checkout resource
@@ -247,6 +248,38 @@ class CheckoutResource extends Resource {
     return this.graphQLClient
       .send(checkoutLineItemsUpdateMutation, {checkoutId, lineItems})
       .then(handleCheckoutMutation('checkoutLineItemsUpdate', this.graphQLClient));
+  }
+
+  /**
+   * Updates shipping address on an existing checkout.
+   *
+   * @example
+   * const checkoutId = 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9kMTZmM2EzMDM4Yjc4N=';
+   * const shippingAddress = {
+   *    address1: 'Chestnut Street 92',
+   *    address2: 'Apartment 2"',
+   *    city: 'Louisville',
+   *    company: null,
+   *    country: 'United States',
+   *    firstName: 'Bob',
+   *    lastName: 'Norman',
+   *    phone: '555-625-1199',
+   *    province: 'Kentucky',
+   *    zip: '40202'
+   *  };
+   *
+   * client.checkout.updateShippingAddress(checkoutId, shippingAddress).then(checkout => {
+   *   // Do something with the updated checkout
+   * });
+   *
+   * @param  {String} checkoutId The ID of the checkout to update shipping address.
+   * @param  {Object} shippingAddress A shipping address.
+   * @return {Promise|GraphModel} A promise resolving with the updated checkout.
+   */
+  updateShippingAddress(checkoutId, shippingAddress) {
+    return this.graphQLClient
+      .send(checkoutShippingAddressUpdateV2Mutation, {checkoutId, shippingAddress})
+      .then(handleCheckoutMutation('checkoutShippingAddressUpdateV2', this.graphQLClient));
   }
 }
 

--- a/src/graphql/checkoutShippingAddressUpdateV2Mutation.graphql
+++ b/src/graphql/checkoutShippingAddressUpdateV2Mutation.graphql
@@ -1,0 +1,10 @@
+mutation checkoutShippingAddressUpdateV2($shippingAddress: MailingAddressInput!, $checkoutId: ID!) {
+  checkoutShippingAddressUpdateV2(shippingAddress: $shippingAddress, checkoutId: $checkoutId) {
+    userErrors {
+      ...UserErrorFragment
+    }
+    checkout {
+      ...CheckoutFragment
+    }
+  }
+}


### PR DESCRIPTION
Successor to https://github.com/Shopify/js-buy-sdk/pull/548.

Adds support for Client.checkout#updateShippingAddress, which allows clients to update the shipping address for a checkout.

This could probably benefit from rebasing before merging...