### PR TITLE
Bump graphql-js-client to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "expect.js": "0.3.1",
     "fetch-mock": "5.12.2",
     "fs-extra": "1.0.0",
-    "graphql-js-client": "0.9.2",
+    "graphql-js-client": "0.11.0",
     "graphql-js-schema": "0.7.1",
     "graphql-js-schema-fetch": "1.1.2",
     "http-server": "0.10.0",

--- a/test/client-checkout-integration-test.js
+++ b/test/client-checkout-integration-test.js
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import Client from '../src/client';
 import fetchMock from './isomorphic-fetch-mock'; // eslint-disable-line import/no-unresolved
+import fetchMockPostOnce from './fetch-mock-helper';
 
 // fixtures
 import checkoutFixture from '../fixtures/checkout-fixture';
@@ -57,7 +58,7 @@ suite('client-checkout-integration-test', () => {
   });
 
   test('it resolves with a checkout on Client.checkout#fetch', () => {
-    fetchMock.postOnce(apiUrl, checkoutFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutFixture);
 
     const checkoutId = checkoutFixture.data.node.id;
 
@@ -68,7 +69,7 @@ suite('client-checkout-integration-test', () => {
   });
 
   test('it resolves with null on Client.checkout#fetch for a bad checkoutId', () => {
-    fetchMock.postOnce(apiUrl, checkoutNullFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutNullFixture);
 
     const checkoutId = checkoutFixture.data.node.id;
 
@@ -89,7 +90,7 @@ suite('client-checkout-integration-test', () => {
       shippingAddress: {}
     };
 
-    fetchMock.postOnce(apiUrl, checkoutCreateFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutCreateFixture);
 
     return client.checkout.create(input).then((checkout) => {
       assert.equal(checkout.id, checkoutCreateFixture.data.checkoutCreate.checkout.id);
@@ -108,7 +109,7 @@ suite('client-checkout-integration-test', () => {
       ]
     };
 
-    fetchMock.postOnce(apiUrl, checkoutUpdateAttributesV2Fixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutUpdateAttributesV2Fixture);
 
     return client.checkout.updateAttributes(checkoutId, input).then((checkout) => {
       assert.equal(checkout.id, checkoutUpdateAttributesV2Fixture.data.checkoutAttributesUpdateV2.checkout.id);
@@ -124,7 +125,7 @@ suite('client-checkout-integration-test', () => {
       note: 'Very long note'
     };
 
-    fetchMock.postOnce(apiUrl, checkoutUpdateAttributesV2WithUserErrorsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutUpdateAttributesV2WithUserErrorsFixture);
 
     return client.checkout.updateAttributes(checkoutId, input).then(() => {
       assert.ok(false, 'Promise should not resolve');
@@ -139,7 +140,7 @@ suite('client-checkout-integration-test', () => {
       email: 'user@example.com'
     };
 
-    fetchMock.postOnce(apiUrl, checkoutUpdateEmailV2Fixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutUpdateEmailV2Fixture);
 
     return client.checkout.updateEmail(checkoutId, input).then((checkout) => {
       assert.equal(checkout.id, checkoutUpdateEmailV2Fixture.data.checkoutEmailUpdateV2.checkout.id);
@@ -151,7 +152,7 @@ suite('client-checkout-integration-test', () => {
   test('it resolve with user errors on Client.checkout#updateEmail when email is invalid', () => {
     const checkoutId = checkoutUpdateEmailV2Fixture.data.checkoutEmailUpdateV2.checkout.id;
 
-    fetchMock.postOnce(apiUrl, checkoutUpdateEmailV2WithUserErrorsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutUpdateEmailV2WithUserErrorsFixture);
 
     return client.checkout.updateEmail(checkoutId, {email: 'invalid-email'}).then(() => {
       assert.ok(false, 'Promise should not resolve');
@@ -167,7 +168,7 @@ suite('client-checkout-integration-test', () => {
       {variantId: 'id2', quantity: 2}
     ];
 
-    fetchMock.postOnce(apiUrl, checkoutLineItemsAddFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutLineItemsAddFixture);
 
     return client.checkout.addLineItems(checkoutId, lineItems).then((checkout) => {
       assert.equal(checkout.id, checkoutId);
@@ -181,7 +182,7 @@ suite('client-checkout-integration-test', () => {
       {variantId: '', quantity: 1}
     ];
 
-    fetchMock.postOnce(apiUrl, checkoutLineItemsAddWithUserErrorsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutLineItemsAddWithUserErrorsFixture);
 
     return client.checkout.addLineItems(checkoutId, lineItems).then(() => {
       assert.ok(false, 'Promise should not resolve');
@@ -197,7 +198,7 @@ suite('client-checkout-integration-test', () => {
       {variantId: 'id2', quantity: 2}
     ];
 
-    fetchMock.postOnce(apiUrl, checkoutLineItemsReplaceFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutLineItemsReplaceFixture);
 
     return client.checkout.replaceLineItems(checkoutId, lineItems).then((checkout) => {
       assert.equal(checkout.id, checkoutId);
@@ -211,7 +212,7 @@ suite('client-checkout-integration-test', () => {
       {variantId: '', quantity: 1}
     ];
 
-    fetchMock.postOnce(apiUrl, checkoutLineItemsReplaceWithUserErrorsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutLineItemsReplaceWithUserErrorsFixture);
 
     return client.checkout.replaceLineItems(checkoutId, lineItems).then(() => {
       assert.ok(false, 'Promise should not resolve');
@@ -230,7 +231,7 @@ suite('client-checkout-integration-test', () => {
       }
     ];
 
-    fetchMock.postOnce(apiUrl, checkoutLineItemsUpdateFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutLineItemsUpdateFixture);
 
     return client.checkout.updateLineItems(checkoutId, lineItems).then((checkout) => {
       assert.equal(checkout.id, checkoutId);
@@ -248,7 +249,7 @@ suite('client-checkout-integration-test', () => {
       }
     ];
 
-    fetchMock.postOnce(apiUrl, checkoutLineItemsUpdateWithUserErrorsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutLineItemsUpdateWithUserErrorsFixture);
 
     return client.checkout.updateLineItems(checkoutId, lineItems).then(() => {
       assert.ok(false, 'Promise should not resolve');
@@ -260,7 +261,7 @@ suite('client-checkout-integration-test', () => {
   test('it resolves with a checkout on Client.checkout#removeLineItems', () => {
     const checkoutId = checkoutLineItemsRemoveFixture.data.checkoutLineItemsRemove.checkout.id;
 
-    fetchMock.postOnce(apiUrl, checkoutLineItemsRemoveFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutLineItemsRemoveFixture);
 
     return client.checkout.removeLineItems(checkoutId, ['line-item-id']).then((checkout) => {
       assert.equal(checkout.id, checkoutId);
@@ -271,7 +272,7 @@ suite('client-checkout-integration-test', () => {
   test('it resolves with user errors on Client.checkout#removeLineItems when line item is invalid', () => {
     const checkoutId = checkoutLineItemsRemoveFixture.data.checkoutLineItemsRemove.checkout.id;
 
-    fetchMock.postOnce(apiUrl, checkoutLineItemsRemoveWithUserErrorsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutLineItemsRemoveWithUserErrorsFixture);
 
     return client.checkout.removeLineItems(checkoutId, ['invalid-line-item-id']).then(() => {
       assert.ok(false, 'Promise should not resolve');
@@ -284,7 +285,7 @@ suite('client-checkout-integration-test', () => {
     const checkoutId = checkoutDiscountCodeApplyV2Fixture.data.checkoutDiscountCodeApplyV2.checkout.id;
     const discountCode = 'TENPERCENTOFF';
 
-    fetchMock.postOnce(apiUrl, checkoutDiscountCodeApplyV2Fixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutDiscountCodeApplyV2Fixture);
 
     return client.checkout.addDiscount(checkoutId, discountCode).then((checkout) => {
       assert.equal(checkout.id, checkoutId);
@@ -314,7 +315,7 @@ suite('client-checkout-integration-test', () => {
       }
     };
 
-    fetchMock.postOnce(apiUrl, checkoutDiscountCodeApplyV2WithCheckoutUserErrorsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutDiscountCodeApplyV2WithCheckoutUserErrorsFixture);
 
     const checkoutId = checkoutDiscountCodeApplyV2Fixture.data.checkoutDiscountCodeApplyV2.checkout.id;
     const discountCode = 'INVALIDCODE';
@@ -329,7 +330,7 @@ suite('client-checkout-integration-test', () => {
   test('it resolves with a checkout on Client.checkout#removeDiscount', () => {
     const checkoutId = checkoutDiscountCodeRemoveFixture.data.checkoutDiscountCodeRemove.checkout.id;
 
-    fetchMock.postOnce(apiUrl, checkoutDiscountCodeRemoveFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutDiscountCodeRemoveFixture);
 
     return client.checkout.removeDiscount(checkoutId).then((checkout) => {
       assert.equal(checkout.id, checkoutId);
@@ -345,7 +346,7 @@ suite('client-checkout-integration-test', () => {
       countryCode: shippingCountry
     } = checkoutShippingAddressUpdateV2Fixture.data.checkoutShippingAddressUpdateV2.checkout.shippingAddress;
 
-    fetchMock.postOnce(apiUrl, checkoutShippingAddressUpdateV2Fixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutShippingAddressUpdateV2Fixture);
 
     return client.checkout.updateShippingAddress(checkoutId, shippingAddress).then((checkout) => {
       assert.equal(checkout.id, checkoutId);
@@ -359,7 +360,7 @@ suite('client-checkout-integration-test', () => {
   test('it resolves with user errors on Client.checkout#updateShippingAddress with invalid address', () => {
     const checkoutId = checkoutShippingAddressUpdateV2Fixture.data.checkoutShippingAddressUpdateV2.checkout.id;
 
-    fetchMock.postOnce(apiUrl, checkoutShippingAdddressUpdateV2WithUserErrorsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutShippingAdddressUpdateV2WithUserErrorsFixture);
 
     return client.checkout.updateShippingAddress(checkoutId, shippingAddress).then(() => {
       assert.ok(false, 'Promise should not resolve.');
@@ -377,9 +378,9 @@ suite('client-checkout-integration-test', () => {
       ]
     };
 
-    fetchMock.postOnce(apiUrl, checkoutCreateWithPaginatedLineItemsFixture)
-      .postOnce(apiUrl, secondPageLineItemsFixture)
-      .postOnce(apiUrl, thirdPageLineItemsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutCreateWithPaginatedLineItemsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, secondPageLineItemsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, thirdPageLineItemsFixture);
 
     return client.checkout.create(input).then(() => {
       assert.ok(fetchMock.done());
@@ -411,7 +412,7 @@ suite('client-checkout-integration-test', () => {
       ]
     };
 
-    fetchMock.postOnce(apiUrl, checkoutCreateWithUserErrorsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutCreateWithUserErrorsFixture);
 
     return client.checkout.create(input).then(() => {
       assert.ok(false, 'Promise should not resolve');
@@ -432,7 +433,7 @@ suite('client-checkout-integration-test', () => {
       ]
     };
 
-    fetchMock.postOnce(apiUrl, checkoutCreateWithUserErrorsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutCreateWithUserErrorsFixture);
 
     return client.checkout.create(input).then(() => {
       assert.ok(false, 'Promise should not resolve');
@@ -452,9 +453,9 @@ suite('client-checkout-integration-test', () => {
       ]
     };
 
-    fetchMock.postOnce(apiUrl, checkoutCreateWithPaginatedLineItemsFixture)
-      .postOnce(apiUrl, secondPageLineItemsFixture)
-      .postOnce(apiUrl, thirdPageLineItemsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutCreateWithPaginatedLineItemsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, secondPageLineItemsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, thirdPageLineItemsFixture);
 
     return client.checkout.create(input).then((checkout) => {
       assert.ok(checkout.errors);

--- a/test/client-integration-test.js
+++ b/test/client-integration-test.js
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import Client from '../src/client';
 import fetchMock from './isomorphic-fetch-mock'; // eslint-disable-line import/no-unresolved
+import fetchMockPostOnce from './fetch-mock-helper';
 
 // fixtures
 import shopWithProductsFixture from '../fixtures/query-products-fixture';
@@ -40,7 +41,7 @@ suite('client-integration-test', () => {
   });
 
   test('it resolves with an array of products on Client.product#fetchAllProducts', () => {
-    fetchMock.postOnce(apiUrl, shopWithProductsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, shopWithProductsFixture);
 
     return client.product.fetchAll().then((products) => {
       assert.ok(Array.isArray(products), 'products is an array');
@@ -53,7 +54,7 @@ suite('client-integration-test', () => {
   });
 
   test('it resolves with a single product on Client.product#fetch', () => {
-    fetchMock.postOnce(apiUrl, singleProductFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, singleProductFixture);
 
     const id = singleProductFixture.data.node.id;
 
@@ -65,7 +66,7 @@ suite('client-integration-test', () => {
   });
 
   test('it resolves with an array of products on Client.product#fetchMultiple', () => {
-    fetchMock.postOnce(apiUrl, multipleProductsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, multipleProductsFixture);
 
     const id1 = multipleProductsFixture.data.nodes[0].id;
     const id2 = multipleProductsFixture.data.nodes[1].id;
@@ -79,9 +80,9 @@ suite('client-integration-test', () => {
   });
 
   test('it fetches all images on products on Client.product#fetchAll', () => {
-    fetchMock.postOnce(apiUrl, productWithPaginatedImagesFixture)
-      .postOnce(apiUrl, secondPageImagesFixture)
-      .postOnce(apiUrl, thirdPageImagesFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, productWithPaginatedImagesFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, secondPageImagesFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, thirdPageImagesFixture);
 
     return client.product.fetchAll().then((products) => {
       const images = products[0].images;
@@ -97,9 +98,9 @@ suite('client-integration-test', () => {
   });
 
   test('it fetches all variants on Client.product#fetch', () => {
-    fetchMock.postOnce(apiUrl, productWithPaginatedVariantsFixture)
-      .postOnce(apiUrl, secondPageVariantsFixture)
-      .postOnce(apiUrl, thirdPageVariantsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, productWithPaginatedVariantsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, secondPageVariantsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, thirdPageVariantsFixture);
 
     return client.product.fetch(productWithPaginatedVariantsFixture.data.node.id).then((product) => {
       const variants = product.variants;
@@ -115,7 +116,7 @@ suite('client-integration-test', () => {
   });
 
   test('it does not fetch paginated images if the images query result was empty on Client.product#fetch', () => {
-    fetchMock.postOnce(apiUrl, {
+    fetchMockPostOnce(fetchMock, apiUrl, {
       data: {
         node: {
           images: {
@@ -136,7 +137,7 @@ suite('client-integration-test', () => {
   });
 
   test('it can fetch a product by handle through Client.product#fetchByHandle', () => {
-    fetchMock.postOnce(apiUrl, productByHandleFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, productByHandleFixture);
 
     const handle = productByHandleFixture.data.productByHandle.handle;
 
@@ -148,7 +149,7 @@ suite('client-integration-test', () => {
   });
 
   test('it resolves products with Client.product#fetchQuery', () => {
-    fetchMock.postOnce(apiUrl, shopWithProductsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, shopWithProductsFixture);
 
     return client.product.fetchQuery({}).then((products) => {
       assert.equal(products.length, 2);
@@ -159,7 +160,7 @@ suite('client-integration-test', () => {
   });
 
   test('it resolves with an array of collections on Client.collection#fetchAll', () => {
-    fetchMock.postOnce(apiUrl, shopWithCollectionsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, shopWithCollectionsFixture);
 
     return client.collection.fetchAll().then((collections) => {
       assert.ok(Array.isArray(collections), 'collections is an array');
@@ -172,7 +173,7 @@ suite('client-integration-test', () => {
   });
 
   test('it resolves with a single collection on Client.collection#fetch', () => {
-    fetchMock.postOnce(apiUrl, singleCollectionFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, singleCollectionFixture);
 
     const id = singleCollectionFixture.data.node.id;
 
@@ -184,7 +185,7 @@ suite('client-integration-test', () => {
   });
 
   test('it can fetch a collection by handle through Client.collection#fetchByHandle', () => {
-    fetchMock.postOnce(apiUrl, collectionByHandleFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, collectionByHandleFixture);
 
     const handle = collectionByHandleFixture.data.collectionByHandle.handle;
 
@@ -196,7 +197,7 @@ suite('client-integration-test', () => {
   });
 
   test('it can fetch collections with the query arg on Client.collection#fetchQuery', () => {
-    fetchMock.postOnce(apiUrl, shopWithCollectionsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, shopWithCollectionsFixture);
 
     return client.collection.fetchQuery({}).then((collections) => {
       assert.equal(collections.length, 2);
@@ -207,7 +208,7 @@ suite('client-integration-test', () => {
   });
 
   test('it can fetch all collections with products on Client.collection#fetchAllWithProducts', () => {
-    fetchMock.postOnce(apiUrl, shopWithCollectionsWithProductsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, shopWithCollectionsWithProductsFixture);
 
     return client.collection.fetchAllWithProducts().then((collections) => {
       assert.ok(Array.isArray(collections), 'collections is an array');
@@ -219,7 +220,7 @@ suite('client-integration-test', () => {
   });
 
   test('it can fetch a single collection with products on Client.collection#fetchWithProducts', () => {
-    fetchMock.postOnce(apiUrl, collectionWithProductsFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, collectionWithProductsFixture);
 
     const id = collectionWithProductsFixture.data.node.id;
 
@@ -232,10 +233,10 @@ suite('client-integration-test', () => {
   });
 
   test('it paginates on images on products within collections on Client.collection#fetchAllWithProducts', () => {
-    fetchMock.postOnce(apiUrl, shopWithCollectionsWithPaginationFixture)
-      .postOnce(apiUrl, thirdPageImagesFixture)
-      .postOnce(apiUrl, fourthPageImagesFixture)
-      .postOnce(apiUrl, fifthPageImagesFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, shopWithCollectionsWithPaginationFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, thirdPageImagesFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, fourthPageImagesFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, fifthPageImagesFixture);
 
     return client.collection.fetchAllWithProducts().then((collections) => {
       assert.equal(collections.length, 2);
@@ -248,7 +249,7 @@ suite('client-integration-test', () => {
   });
 
   test('it resolves with `shop` on Client.shop#fetchInfo', () => {
-    fetchMock.postOnce(apiUrl, shopInfoFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, shopInfoFixture);
 
     return client.shop.fetchInfo().then((shop) => {
       assert.equal(shop.name, shopInfoFixture.data.shop.name);
@@ -258,7 +259,7 @@ suite('client-integration-test', () => {
   });
 
   test('it resolves with `shop` on Client.shop#fetchPolicies', () => {
-    fetchMock.postOnce(apiUrl, shopPoliciesFixture);
+    fetchMockPostOnce(fetchMock, apiUrl, shopPoliciesFixture);
 
     return client.shop.fetchPolicies().then((shop) => {
       assert.equal(shop.privacyPolicy.id, shopPoliciesFixture.data.shop.privacyPolicy.id);

--- a/test/fetch-mock-helper.js
+++ b/test/fetch-mock-helper.js
@@ -1,0 +1,12 @@
+export function fixtureWithHeaders(fixture) {
+  return {
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: fixture
+  };
+}
+
+export default function fetchMockPostOnce(fetchMock, apiUrl, fixture) {
+  fetchMock.postOnce(apiUrl, fixtureWithHeaders(fixture));
+}

--- a/test/test/fetch-mock-helper-test.js
+++ b/test/test/fetch-mock-helper-test.js
@@ -1,0 +1,14 @@
+import assert from 'assert';
+import {fixtureWithHeaders} from '../fetch-mock-helper';
+
+// fixtures
+import shopInfoFixture from '../../fixtures/shop-info-fixture';
+
+suite('fetch-mock-helper-test', () => {
+  test('it wraps the fixture with headers and a body', () => {
+    const shopInfoFixtureWithHeaders = fixtureWithHeaders(shopInfoFixture);
+
+    assert.equal(shopInfoFixtureWithHeaders.headers['Content-Type'], 'application/json');
+    assert.equal(shopInfoFixtureWithHeaders.body, shopInfoFixture);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3681,15 +3681,15 @@ graphql-js-client-compiler@0.2.0:
     minimist "1.2.0"
     mkdirp "0.5.1"
 
+graphql-js-client@0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/graphql-js-client/-/graphql-js-client-0.11.0.tgz#66da0acbb1910ec46c78fd8cbe529bc16c580fce"
+  integrity sha512-SYDLZ7NSEMx7n5c/GBD7W0EUp6n15LbanM3YdKXTTD5L4LzUT9pLp/lG979YZI08Bsw9RFPWj5c6zklxSOsDmw==
+
 graphql-js-client@0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/graphql-js-client/-/graphql-js-client-0.7.0.tgz#6d6006680c4e6eaf2e4d284d430b0fae687de154"
   integrity sha512-Qb4EDM2s4JVeDVnm1evH8Q7GMR8qwj+jZJFqXsZ8BijADBkr8y9SX1Qd+JP0kdvDSIvQPZ3ePVc0v+lVxwlxSA==
-
-graphql-js-client@0.9.2:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/graphql-js-client/-/graphql-js-client-0.9.2.tgz#dba572d2feefcc84075e1aad1f95e69a5128270d"
-  integrity sha512-l//xNDoMP303GpjVrkbJudF0jTiH1xQJ/WwYmMMgLvAMCaUDt7C3tPZVIFqeuAss4jyyaJC3oqrFhqB59UqhAw==
 
 graphql-js-schema-fetch@1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Forward fix for https://github.com/Shopify/js-buy-sdk/issues/614 as it includes https://github.com/Shopify/graphql-js-client/pull/121

