### PR TITLE
Add correct documentation for variantForOptions from product helpers

### DIFF
--- a/src/product-helpers.js
+++ b/src/product-helpers.js
@@ -7,7 +7,7 @@ export default {
    * Returns the variant of a product corresponding to the options given.
    *
    * @example
-   * const selectedVariant = client.product.variantForOptions(product, {
+   * const selectedVariant = client.product.helpers.variantForOptions(product, {
    *   size: "Small",
    *   color: "Red"
    * });


### PR DESCRIPTION
Updates the documentation decorator to use the correct call to the product resource helpers – it should be `client.product.helpers.variantForOptions`, rather than `client.product.variantForOptions` as `variantForOptions` is made available in the product resource through the `helpers` object.

https://github.com/Shopify/js-buy-sdk/blob/master/src/product-resource.js#L16-L19