### PR TITLE
Bump schema

### DIFF
--- a/fixtures/checkout-create-fixture.js
+++ b/fixtures/checkout-create-fixture.js
@@ -70,6 +70,10 @@ export default {
         "taxesIncluded": false,
         "currencyCode": "CAD",
         "totalTax": "42.24",
+        "lineItemsSubtotalPrice": {
+          "amount": "324.95",
+          "currencyCode": "CAD"
+        },
         "subtotalPrice": "324.95",
         "totalPrice": "367.19",
         "completedAt": null,

--- a/fixtures/checkout-create-with-paginated-line-items-fixture.js
+++ b/fixtures/checkout-create-with-paginated-line-items-fixture.js
@@ -48,6 +48,10 @@ export default {
         "taxesIncluded": false,
         "currencyCode": "CAD",
         "totalTax": "42.24",
+        "lineItemsSubtotalPrice": {
+          "amount": "324.95",
+          "currencyCode": "CAD"
+        },
         "subtotalPrice": "324.95",
         "totalPrice": "367.19",
         "completedAt": null,

--- a/fixtures/checkout-discount-code-apply-fixture.js
+++ b/fixtures/checkout-discount-code-apply-fixture.js
@@ -15,6 +15,10 @@ export default {
         "taxesIncluded": false,
         "currencyCode": "CAD",
         "totalPrice": "80.28",
+        "lineItemsSubtotalPrice": {
+          "amount": "74.99",
+          "currencyCode": "CAD"
+        },
         "subtotalPrice": "67.50",
         "totalTax": "8.78",
         "paymentDue": "80.28",

--- a/fixtures/checkout-discount-code-remove-fixture.js
+++ b/fixtures/checkout-discount-code-remove-fixture.js
@@ -15,6 +15,10 @@ export default {
         "taxesIncluded": false,
         "currencyCode": "CAD",
         "totalPrice": "88.74",
+        "lineItemsSubtotalPrice": {
+          "amount": "74.99",
+          "currencyCode": "CAD"
+        },
         "subtotalPrice": "74.99",
         "totalTax": "9.75",
         "paymentDue": "88.74",

--- a/fixtures/checkout-fixture.js
+++ b/fixtures/checkout-fixture.js
@@ -24,6 +24,10 @@ export default {
       "taxesIncluded": false,
       "currencyCode": "CAD",
       "totalTax": "0.00",
+      "lineItemsSubtotalPrice": {
+        "amount": "0.00",
+        "currencyCode": "CAD"
+      },
       "subtotalPrice": "0.00",
       "totalPrice": "0.00",
       "completedAt": null,

--- a/fixtures/checkout-line-items-remove-fixture.js
+++ b/fixtures/checkout-line-items-remove-fixture.js
@@ -48,6 +48,10 @@ export default {
         "taxesIncluded": false,
         "currencyCode": "CAD",
         "totalTax": "42.24",
+        "lineItemsSubtotalPrice": {
+          "amount": "0.00",
+          "currencyCode": "CAD"
+        },
         "subtotalPrice": "324.95",
         "totalPrice": "367.19",
         "completedAt": null,

--- a/fixtures/checkout-line-items-update-fixture.js
+++ b/fixtures/checkout-line-items-update-fixture.js
@@ -61,6 +61,10 @@ export default {
             "taxesIncluded":false,
             "currencyCode":"CAD",
             "totalTax":"0.00",
+            "lineItemsSubtotalPrice": {
+              "amount": "376.00",
+              "currencyCode": "CAD"
+            },
             "subtotalPrice":"376.00",
             "totalPrice":"376.00",
             "completedAt":null,

--- a/fixtures/checkout-shipping-address-update-v2-fixture.js
+++ b/fixtures/checkout-shipping-address-update-v2-fixture.js
@@ -14,6 +14,10 @@ export default {
         "taxExempt": false,
         "taxesIncluded": false,
         "currencyCode": "CAD",
+        "lineItemsSubtotalPrice": {
+          "amount": "374.95",
+          "currencyCode": "CAD"
+        },
         "totalPrice": "80.28",
         "subtotalPrice": "67.50",
         "totalTax": "8.78",

--- a/fixtures/checkout-update-custom-attrs-fixture.js
+++ b/fixtures/checkout-update-custom-attrs-fixture.js
@@ -70,6 +70,10 @@ export default {
         "taxesIncluded": false,
         "currencyCode": "CAD",
         "totalTax": "42.24",
+        "lineItemsSubtotalPrice": {
+          "amount": "324.95",
+          "currencyCode": "CAD"
+        },
         "subtotalPrice": "324.95",
         "totalPrice": "367.19",
         "completedAt": null,

--- a/fixtures/checkout-update-email-fixture.js
+++ b/fixtures/checkout-update-email-fixture.js
@@ -71,6 +71,10 @@ export default {
         "taxesIncluded": false,
         "currencyCode": "CAD",
         "totalTax": "42.24",
+        "lineItemsSubtotalPrice": {
+          "amount": "324.95",
+          "currencyCode": "CAD"
+        },
         "subtotalPrice": "324.95",
         "totalPrice": "367.19",
         "completedAt": null,

--- a/fixtures/checkout-with-paginated-line-items-fixture.js
+++ b/fixtures/checkout-with-paginated-line-items-fixture.js
@@ -45,6 +45,10 @@ export default {
       "taxesIncluded": false,
       "currencyCode": "CAD",
       "totalTax": "42.24",
+      "lineItemsSubtotalPrice": {
+        "amount": "324.95",
+        "currencyCode": "CAD"
+      },
       "subtotalPrice": "324.95",
       "totalPrice": "367.19",
       "completedAt": null,

--- a/schema.json
+++ b/schema.json
@@ -1507,7 +1507,7 @@
         {
           "kind": "SCALAR",
           "name": "Float",
-          "description": "Represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).",
+          "description": "Represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -3791,6 +3791,12 @@
               "deprecationReason": null
             },
             {
+              "name": "BMD",
+              "description": "Bermudian Dollar (BMD).",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "BTN",
               "description": "Bhutanese Ngultrum (BTN).",
               "isDeprecated": false,
@@ -5365,421 +5371,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "ENUM",
-          "name": "WeightUnit",
-          "description": "Units of measurement for weight.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "KILOGRAMS",
-              "description": "1 kilogram equals 1000 grams.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "GRAMS",
-              "description": "Metric system unit of mass.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "POUNDS",
-              "description": "1 pound equals 16 ounces.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "OUNCES",
-              "description": "Imperial system unit of mass.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "ProductVariantPricePairConnection",
-          "description": null,
-          "fields": [
-            {
-              "name": "edges",
-              "description": "A list of edges.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "ProductVariantPricePairEdge",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "pageInfo",
-              "description": "Information to aid in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PageInfo",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "ProductVariantPricePairEdge",
-          "description": null,
-          "fields": [
-            {
-              "name": "cursor",
-              "description": "A cursor for use in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "node",
-              "description": "The item at the end of ProductVariantPricePairEdge.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "ProductVariantPricePair",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "ProductVariantPricePair",
-          "description": "The compare-at price and price of a variant sharing a currency.\n",
-          "fields": [
-            {
-              "name": "compareAtPrice",
-              "description": "The compare-at price of the variant with associated currency.",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "MoneyV2",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "price",
-              "description": "The price of the variant with associated currency.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "MoneyV2",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "Image",
-          "description": "Represents an image resource.",
-          "fields": [
-            {
-              "name": "altText",
-              "description": "A word or phrase to share the nature or contents of an image.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id",
-              "description": "A unique identifier for the image.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "originalSrc",
-              "description": "The location of the original image as a URL.\n\nIf there are any existing transformations in the original source URL, they will remain and not be stripped.\n",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "URL",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "src",
-              "description": "The location of the image as a URL.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "URL",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Previously an image had a single `src` field. This could either return the original image\nlocation or a URL that contained transformations such as sizing or scale.\n\nThese transformations were specified by arguments on the parent field.\n\nNow an image has two distinct URL fields: `originalSrc` and `transformedSrc`.\n\n* `originalSrc` - the original unmodified image URL\n* `transformedSrc` - the image URL with the specified transformations included\n\nTo migrate to the new fields, image transformations should be moved from the parent field to `transformedSrc`.\n\nBefore:\n```graphql\n{\n  shop {\n    productImages(maxWidth: 200, scale: 2) {\n      edges {\n        node {\n          src\n        }\n      }\n    }\n  }\n}\n```\n\nAfter:\n```graphql\n{\n  shop {\n    productImages {\n      edges {\n        node {\n          transformedSrc(maxWidth: 200, scale: 2)\n        }\n      }\n    }\n  }\n}\n```\n"
-            },
-            {
-              "name": "transformedSrc",
-              "description": "The location of the transformed image as a URL.\n\nAll transformation arguments are considered \"best-effort\". If they can be applied to an image, they will be.\nOtherwise any transformations which an image type does not support will be ignored.\n",
-              "args": [
-                {
-                  "name": "maxWidth",
-                  "description": "Image width in pixels between 1 and 5760.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "maxHeight",
-                  "description": "Image height in pixels between 1 and 5760.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "crop",
-                  "description": "Crops the image according to the specified region.",
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "CropRegion",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "scale",
-                  "description": "Image size multiplier for high-resolution retina displays. Must be between 1 and 3.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": "1"
-                },
-                {
-                  "name": "preferredContentType",
-                  "description": "Best effort conversion of image into content type (SVG -> PNG, Anything -> JGP, Anything -> WEBP are supported).",
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "ImageContentType",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "URL",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "CropRegion",
-          "description": "The part of the image that should remain after cropping.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "CENTER",
-              "description": "Keep the center of the image",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TOP",
-              "description": "Keep the top of the image",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BOTTOM",
-              "description": "Keep the bottom of the image",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "LEFT",
-              "description": "Keep the left of the image",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "RIGHT",
-              "description": "Keep the right of the image",
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "ImageContentType",
-          "description": "List of supported image content types.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "PNG",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "JPG",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "WEBP",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "SelectedOption",
-          "description": "Custom properties that a shop owner can use to define product variants.\nMultiple options can exist. Options are represented as: option1, option2, option3, etc.\n",
-          "fields": [
-            {
-              "name": "name",
-              "description": "The product option’s name.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "value",
-              "description": "The product option’s value.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "OBJECT",
           "name": "Product",
           "description": "A product represents an individual item for sale in a Shopify store. Products are often physical, but they don't have to be.\nFor example, a digital download (such as a movie, music or ebook file) also qualifies as a product, as do services (such as equipment rental, work for hire, customization of another product or an extended warranty).",
@@ -6726,6 +6317,210 @@
         },
         {
           "kind": "OBJECT",
+          "name": "Image",
+          "description": "Represents an image resource.",
+          "fields": [
+            {
+              "name": "altText",
+              "description": "A word or phrase to share the nature or contents of an image.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "A unique identifier for the image.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "originalSrc",
+              "description": "The location of the original image as a URL.\n\nIf there are any existing transformations in the original source URL, they will remain and not be stripped.\n",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "URL",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "src",
+              "description": "The location of the image as a URL.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "URL",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Previously an image had a single `src` field. This could either return the original image\nlocation or a URL that contained transformations such as sizing or scale.\n\nThese transformations were specified by arguments on the parent field.\n\nNow an image has two distinct URL fields: `originalSrc` and `transformedSrc`.\n\n* `originalSrc` - the original unmodified image URL\n* `transformedSrc` - the image URL with the specified transformations included\n\nTo migrate to the new fields, image transformations should be moved from the parent field to `transformedSrc`.\n\nBefore:\n```graphql\n{\n  shop {\n    productImages(maxWidth: 200, scale: 2) {\n      edges {\n        node {\n          src\n        }\n      }\n    }\n  }\n}\n```\n\nAfter:\n```graphql\n{\n  shop {\n    productImages {\n      edges {\n        node {\n          transformedSrc(maxWidth: 200, scale: 2)\n        }\n      }\n    }\n  }\n}\n```\n"
+            },
+            {
+              "name": "transformedSrc",
+              "description": "The location of the transformed image as a URL.\n\nAll transformation arguments are considered \"best-effort\". If they can be applied to an image, they will be.\nOtherwise any transformations which an image type does not support will be ignored.\n",
+              "args": [
+                {
+                  "name": "maxWidth",
+                  "description": "Image width in pixels between 1 and 5760.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "maxHeight",
+                  "description": "Image height in pixels between 1 and 5760.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "crop",
+                  "description": "Crops the image according to the specified region.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CropRegion",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "scale",
+                  "description": "Image size multiplier for high-resolution retina displays. Must be between 1 and 3.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": "1"
+                },
+                {
+                  "name": "preferredContentType",
+                  "description": "Best effort conversion of image into content type (SVG -> PNG, Anything -> JGP, Anything -> WEBP are supported).",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "ImageContentType",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "URL",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "CropRegion",
+          "description": "The part of the image that should remain after cropping.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "CENTER",
+              "description": "Keep the center of the image",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TOP",
+              "description": "Keep the top of the image",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BOTTOM",
+              "description": "Keep the bottom of the image",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LEFT",
+              "description": "Keep the left of the image",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RIGHT",
+              "description": "Keep the right of the image",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "ImageContentType",
+          "description": "List of supported image content types.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "PNG",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "JPG",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "WEBP",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "ProductConnection",
           "description": null,
           "fields": [
@@ -7294,6 +7089,217 @@
               "deprecationReason": null
             }
           ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "WeightUnit",
+          "description": "Units of measurement for weight.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "KILOGRAMS",
+              "description": "1 kilogram equals 1000 grams.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GRAMS",
+              "description": "Metric system unit of mass.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "POUNDS",
+              "description": "1 pound equals 16 ounces.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OUNCES",
+              "description": "Imperial system unit of mass.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProductVariantPricePairConnection",
+          "description": null,
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ProductVariantPricePairEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProductVariantPricePairEdge",
+          "description": null,
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of ProductVariantPricePairEdge.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProductVariantPricePair",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProductVariantPricePair",
+          "description": "The compare-at price and price of a variant sharing a currency.\n",
+          "fields": [
+            {
+              "name": "compareAtPrice",
+              "description": "The compare-at price of the variant with associated currency.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "MoneyV2",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "price",
+              "description": "The price of the variant with associated currency.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MoneyV2",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SelectedOption",
+          "description": "Custom properties that a shop owner can use to define product variants.\nMultiple options can exist. Options are represented as: option1, option2, option3, etc.\n",
+          "fields": [
+            {
+              "name": "name",
+              "description": "The product option’s name.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "value",
+              "description": "The product option’s value.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
           "possibleTypes": null
         },
         {
@@ -9423,6 +9429,30 @@
               "deprecationReason": null
             },
             {
+              "name": "enabledPresentmentCurrencies",
+              "description": "A list of enabled currencies (ISO 4217 format) that the shop accepts. Merchants can enable currencies from their Shopify Payments settings in the Shopify admin.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "CurrencyCode",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "shopifyPaymentsAccountId",
               "description": "The shop’s Shopify Payments account id.",
               "args": [],
@@ -10311,6 +10341,18 @@
               "deprecationReason": null
             },
             {
+              "name": "seo",
+              "description": "The article’s SEO information.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SEO",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "tags",
               "description": "A categorization that a article can be tagged with.",
               "args": [],
@@ -10455,6 +10497,41 @@
                   "name": "String",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SEO",
+          "description": "SEO information.",
+          "fields": [
+            {
+              "name": "description",
+              "description": "The meta description.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "The SEO title.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -13887,7 +13964,7 @@
             },
             {
               "name": "status",
-              "description": "The status of the transaction",
+              "description": "The status of the transaction.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -13898,12 +13975,24 @@
                   "ofType": null
                 }
               },
+              "isDeprecated": true,
+              "deprecationReason": "Use `statusV2` instead"
+            },
+            {
+              "name": "statusV2",
+              "description": "The status of the transaction.",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "TransactionStatus",
+                "ofType": null
+              },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "test",
-              "description": "Whether the transaction was done in test mode or not",
+              "description": "Whether the transaction was done in test mode or not.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",

--- a/schema.json
+++ b/schema.json
@@ -4247,6 +4247,12 @@
               "deprecationReason": null
             },
             {
+              "name": "PAB",
+              "description": "Panamian Balboa (PAB).",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "PKR",
               "description": "Pakistani Rupee (PKR).",
               "isDeprecated": false,
@@ -8044,6 +8050,22 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "CheckoutLineItemConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lineItemsSubtotalPrice",
+              "description": "The sum of all the prices of all the items in the checkout. Taxes, shipping and discounts excluded.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MoneyV2",
                   "ofType": null
                 }
               },
@@ -19269,8 +19291,8 @@
                   "ofType": null
                 }
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "Use `title` instead"
             },
             {
               "name": "targetSelection",
@@ -19298,6 +19320,22 @@
                 "ofType": {
                   "kind": "ENUM",
                   "name": "DiscountApplicationTargetType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "The title of the application as defined by the Script.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },

--- a/src/graphql/CheckoutFragment.graphql
+++ b/src/graphql/CheckoutFragment.graphql
@@ -30,6 +30,10 @@ fragment CheckoutFragment on Checkout {
   taxesIncluded
   currencyCode
   totalTax
+  lineItemsSubtotalPrice {
+    amount
+    currencyCode
+  }
   subtotalPrice
   totalPrice
   completedAt


### PR DESCRIPTION
PR to bump schema. Schema changes include:
- Adds currency support for Bermudian Dollar
- Adds `seo` field to `article` which exposes SEO title and description information
- Deprecates `status` field on `transaction` and replaces it with `statusV2`, which supports a null status. 
- Add line items subtotal price as a field returned on checkout.