### PR TITLE
Remove deprecated fields and add new multi-currency fields

### DIFF
--- a/fixtures/checkout-create-fixture.js
+++ b/fixtures/checkout-create-fixture.js
@@ -2,7 +2,6 @@ export default {
   "data": {
     "checkoutCreate": {
       "checkoutUserErrors": [],
-      "userErrors": [],
       "checkout": {
         "id": "Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",
         "ready": true,

--- a/fixtures/checkout-create-fixture.js
+++ b/fixtures/checkout-create-fixture.js
@@ -55,7 +55,7 @@ export default {
           "province": "Ontario",
           "zip": "M3O 0W1",
           "name": "Meow Meowington",
-          "countryCode": "CA",
+          "countryCodeV2": "CA",
           "provinceCode": "ON",
           "id": "Z2lkOi8vc2hvcGlmeS9QcmdfnAU8nakdWMnAbh890hyOTEwNjA2NDU4NA=="
         },

--- a/fixtures/checkout-create-fixture.js
+++ b/fixtures/checkout-create-fixture.js
@@ -19,7 +19,10 @@ export default {
                 "variant": {
                   "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
                   "title": "Awesome Copper Bench",
-                  "price": "64.99",
+                  "priceV2": {
+                    "amount": "64.99",
+                    "currencyCode": "CAD"
+                  },
                   "weight": 4.5,
                   "image": null,
                   "selectedOptions": [
@@ -63,19 +66,31 @@ export default {
         "requiresShipping": true,
         "customAttributes": [],
         "note": null,
-        "paymentDue": "367.19",
+        "paymentDueV2": {
+          "amount": "367.19",
+          "currencyCode": "CAD"
+        },
         "webUrl": "https://checkout.myshopify.io/1/checkouts/c4abf4bf036239ab5e3d0bf93c642c96",
         "orderStatusUrl": null,
         "taxExempt": false,
         "taxesIncluded": false,
         "currencyCode": "CAD",
-        "totalTax": "42.24",
+        "totalTaxV2": {
+          "amount": "42.24",
+          "currencyCode": "CAD"
+        },
         "lineItemsSubtotalPrice": {
           "amount": "324.95",
           "currencyCode": "CAD"
         },
-        "subtotalPrice": "324.95",
-        "totalPrice": "367.19",
+        "subtotalPriceV2": {
+          "amount": "324.95",
+          "currencyCode": "CAD"
+        },
+        "totalPriceV2": {
+          "amount": "367.19",
+          "currencyCode": "CAD"
+        },
         "completedAt": null,
         "createdAt": "2017-03-28T16:58:31Z",
         "updatedAt": "2017-03-28T16:58:31Z"

--- a/fixtures/checkout-create-with-paginated-line-items-fixture.js
+++ b/fixtures/checkout-create-with-paginated-line-items-fixture.js
@@ -19,7 +19,10 @@ export default {
                 "variant": {
                   "id": "gid://shopify/ProductVariant/1",
                   "title": "Awesome Copper Bench",
-                  "price": "64.99",
+                  "priceV2": {
+                    "amount": "64.99",
+                    "currencyCode": "CAD"
+                  },
                   "weight": 4.5,
                   "image": null,
                   "selectedOptions": [
@@ -40,20 +43,32 @@ export default {
         "requiresShipping": true,
         "customAttributes": [],
         "note": null,
-        "paymentDue": "367.19",
+        "paymentDueV2": {
+          "amount": "367.19",
+          "currencyCode": "CAD"
+        },
         "webUrl": "https://checkout.myshopify.io/1/checkouts/c4abf4bf036239ab5e3d0bf93c642c96",
         "order": null,
         "orderStatusUrl": null,
         "taxExempt": false,
         "taxesIncluded": false,
         "currencyCode": "CAD",
-        "totalTax": "42.24",
+        "totalTaxV2": {
+          "amount": "42.24",
+          "currencyCode": "CAD"
+        },
         "lineItemsSubtotalPrice": {
           "amount": "324.95",
           "currencyCode": "CAD"
         },
-        "subtotalPrice": "324.95",
-        "totalPrice": "367.19",
+        "subtotalPriceV2": {
+          "amount": "324.95",
+          "currencyCode": "CAD"
+        },
+        "totalPriceV2": {
+          "amount": "367.19",
+          "currencyCode": "CAD"
+        },
         "completedAt": null,
         "createdAt": "2017-03-28T16:58:31Z",
         "updatedAt": "2017-03-28T16:58:31Z"

--- a/fixtures/checkout-create-with-paginated-line-items-fixture.js
+++ b/fixtures/checkout-create-with-paginated-line-items-fixture.js
@@ -2,7 +2,6 @@ export default {
   "data": {
     "checkoutCreate": {
       "checkoutUserErrors": [],
-      "userErrors": [],
       "checkout": {
         "id": "Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",
         "ready": true,

--- a/fixtures/checkout-discount-code-apply-fixture.js
+++ b/fixtures/checkout-discount-code-apply-fixture.js
@@ -2,7 +2,6 @@ export default {
   "data": {
     "checkoutDiscountCodeApplyV2": {
       "checkoutUserErrors": [],
-      "userErrors": [],
       "checkout": {
         "id": "Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",
         "createdAt": "2017-03-17T16:00:40Z",

--- a/fixtures/checkout-discount-code-apply-fixture.js
+++ b/fixtures/checkout-discount-code-apply-fixture.js
@@ -45,7 +45,7 @@ export default {
           "province": "Ontario",
           "zip": "M3O 0W1",
           "name": "Meow Meowington",
-          "countryCode": "CA",
+          "countryCodeV2": "CA",
           "provinceCode": "ON",
           "id": "291dC9lM2JkNzHJnnf8a89njNJNKAhu1gn7lMzM5MzFlZj9rZXk9NDcwOTJ=="
         },

--- a/fixtures/checkout-discount-code-apply-fixture.js
+++ b/fixtures/checkout-discount-code-apply-fixture.js
@@ -14,14 +14,26 @@ export default {
         "taxExempt": false,
         "taxesIncluded": false,
         "currencyCode": "CAD",
-        "totalPrice": "80.28",
+        "totalPriceV2": {
+          "amount": "80.28",
+          "currencyCode": "CAD",
+        },
         "lineItemsSubtotalPrice": {
           "amount": "74.99",
           "currencyCode": "CAD"
         },
-        "subtotalPrice": "67.50",
-        "totalTax": "8.78",
-        "paymentDue": "80.28",
+        "subtotalPriceV2": {
+          "amount": "67.50",
+          "currencyCode": "CAD"
+        },
+        "totalTaxV2": {
+          "amount": "8.78",
+          "currencyCode": "CAD"
+        },
+        "paymentDueV2": {
+          "amount": "80.28",
+          "currencyCode": "CAD"
+        },
         "taxExempt": false,
         "taxesIncluded": false,
         "completedAt": null,
@@ -61,7 +73,10 @@ export default {
                 "title": "Intelligent Granite Table",
                 "variant": {
                   "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
-                  "price": "74.99"
+                  "priceV2": {
+                    "amount": "74.99",
+                    "currencyCode": "CAD"
+                  }
                 },
                 "quantity": 5,
                 "customAttributes": [],

--- a/fixtures/checkout-discount-code-remove-fixture.js
+++ b/fixtures/checkout-discount-code-remove-fixture.js
@@ -14,14 +14,26 @@ export default {
         "taxExempt": false,
         "taxesIncluded": false,
         "currencyCode": "CAD",
-        "totalPrice": "88.74",
+        "totalPriceV2": {
+          "amount": "88.74",
+          "currencyCode": "CAD",
+        },
         "lineItemsSubtotalPrice": {
           "amount": "74.99",
           "currencyCode": "CAD"
         },
-        "subtotalPrice": "74.99",
-        "totalTax": "9.75",
-        "paymentDue": "88.74",
+        "subtotalPriceV2": {
+          "amount": "74.99",
+          "currencyCode": "CAD"
+        },
+        "totalTaxV2": {
+          "amount": "9.75",
+          "currencyCode": "CAD"
+        },
+        "paymentDueV2": {
+          "amount": "88.74",
+          "currencyCode": "CAD"
+        },
         "taxExempt": false,
         "taxesIncluded": false,
         "completedAt": null,
@@ -61,7 +73,10 @@ export default {
                 "title": "Intelligent Granite Table",
                 "variant": {
                   "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
-                  "price": "74.99"
+                  "priceV2": {
+                    "amount": "74.99",
+                    "currencyCode": "CAD"
+                  }
                 },
                 "quantity": 5,
                 "customAttributes": [],

--- a/fixtures/checkout-discount-code-remove-fixture.js
+++ b/fixtures/checkout-discount-code-remove-fixture.js
@@ -45,7 +45,7 @@ export default {
           "province": "Ontario",
           "zip": "M3O 0W1",
           "name": "Meow Meowington",
-          "countryCode": "CA",
+          "countryCodeV2": "CA",
           "provinceCode": "ON",
           "id": "291dC9lM2JkNzHJnnf8a89njNJNKAhu1gn7lMzM5MzFlZj9rZXk9NDcwOTJ=="
         },

--- a/fixtures/checkout-discount-code-remove-fixture.js
+++ b/fixtures/checkout-discount-code-remove-fixture.js
@@ -2,7 +2,6 @@ export default {
   "data": {
     "checkoutDiscountCodeRemove": {
       "checkoutUserErrors": [],
-      "userErrors": [],
       "checkout": {
         "id": "Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",
         "createdAt": "2017-03-17T16:00:40Z",

--- a/fixtures/checkout-fixture.js
+++ b/fixtures/checkout-fixture.js
@@ -16,20 +16,32 @@ export default {
       "requiresShipping": false,
       "customAttributes": [],
       "note": null,
-      "paymentDue": "0.00",
+      "paymentDueV2": {
+        "amount": "0.0",
+        "currencyCode": "CAD"
+      },
       "webUrl": "https://checkout.shopify.com/15107238/checkouts/df400853e4dcf6732995195d50f999b1?key=da88309409dfc67d5957752a4c313dba",
       "order": null,
       "orderStatusUrl": null,
       "taxExempt": false,
       "taxesIncluded": false,
       "currencyCode": "CAD",
-      "totalTax": "0.00",
-      "lineItemsSubtotalPrice": {
-        "amount": "0.00",
+      "totalTaxV2": {
+        "amount": "0.0",
         "currencyCode": "CAD"
       },
-      "subtotalPrice": "0.00",
-      "totalPrice": "0.00",
+      "lineItemsSubtotalPrice": {
+        "amount": "0.0",
+        "currencyCode": "CAD"
+      },
+      "subtotalPriceV2": {
+        "amount": "0.0",
+        "currencyCode": "CAD"
+      },
+      "totalPriceV2": {
+        "amount": "0.0",
+        "currencyCode": "CAD"
+      },
       "completedAt": null,
       "createdAt": "2017-04-10T17:50:11Z",
       "updatedAt": "2017-04-10T17:50:11Z"

--- a/fixtures/checkout-line-items-add-fixture.js
+++ b/fixtures/checkout-line-items-add-fixture.js
@@ -29,7 +29,7 @@ export default {
           "province": "Ontario",
           "zip": "M3O 0W1",
           "name": "Meow Meowington",
-          "countryCode": "CA",
+          "countryCodeV2": "CA",
           "provinceCode": "ON",
           "id": "291dC9lM2JkNzHJnnf8a89njNJNKAhu1gn7lMzM5MzFlZj9rZXk9NDcwOTJ=="
         },

--- a/fixtures/checkout-line-items-add-fixture.js
+++ b/fixtures/checkout-line-items-add-fixture.js
@@ -1,7 +1,6 @@
 export default {
   "data": {
     "checkoutLineItemsAdd": {
-      "userErrors": [],
       "checkoutUserErrors" : [],
       "checkout": {
         "id": "Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",

--- a/fixtures/checkout-line-items-add-with-user-errors-fixture.js
+++ b/fixtures/checkout-line-items-add-with-user-errors-fixture.js
@@ -1,12 +1,6 @@
 export default {
   "data": {
     "checkoutLineItemsAdd": {
-      "userErrors": [
-        {
-          "message": "Variant is invalid",
-          "field": ["lineItems", "0", "variantId"]
-        }
-      ],
       "checkoutUserErrors": [
         {
           "message": "Variant is invalid",

--- a/fixtures/checkout-line-items-remove-fixture.js
+++ b/fixtures/checkout-line-items-remove-fixture.js
@@ -41,19 +41,31 @@ export default {
         "requiresShipping": true,
         "customAttributes": [],
         "note": null,
-        "paymentDue": "367.19",
+        "paymentDueV2": {
+          "amount": "367.19",
+          "currencyCode": "CAD"
+        },
         "webUrl": "https://checkout.myshopify.io/1/checkouts/c4abf4bf036239ab5e3d0bf93c642c96",
         "orderStatusUrl": null,
         "taxExempt": false,
         "taxesIncluded": false,
         "currencyCode": "CAD",
-        "totalTax": "42.24",
+        "totalTaxV2": {
+          "amount": "42.42",
+          "currencyCode": "CAD"
+        },
         "lineItemsSubtotalPrice": {
           "amount": "0.00",
           "currencyCode": "CAD"
         },
-        "subtotalPrice": "324.95",
-        "totalPrice": "367.19",
+        "subtotalPriceV2": {
+          "amount": "324.95",
+          "currencyCode": "CAD"
+        },
+        "totalPriceV2": {
+          "amount": "367.19",
+          "currencyCode": "CAD"
+        },
         "completedAt": null,
         "createdAt": "2017-03-28T16:58:31Z",
         "updatedAt": "2017-03-28T16:58:31Z"

--- a/fixtures/checkout-line-items-remove-fixture.js
+++ b/fixtures/checkout-line-items-remove-fixture.js
@@ -33,7 +33,7 @@ export default {
           "province": "Ontario",
           "zip": "M3O 0W1",
           "name": "Meow Meowington",
-          "countryCode": "CA",
+          "countryCodeV2": "CA",
           "provinceCode": "ON",
           "id": "Z2lkOi8vc2hvcGlmeSsiujh8aQJbnkl9Qcm9kdWN0VmaJKN8flqAnq8TEwNjA2NDU4NA=="
         },

--- a/fixtures/checkout-line-items-remove-fixture.js
+++ b/fixtures/checkout-line-items-remove-fixture.js
@@ -1,7 +1,6 @@
 export default {
   "data": {
     "checkoutLineItemsRemove": {
-      "userErrors": [],
       "checkoutUserErrors": [],
       "checkout": {
         "id": "Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",

--- a/fixtures/checkout-line-items-remove-with-user-errors-fixture.js
+++ b/fixtures/checkout-line-items-remove-with-user-errors-fixture.js
@@ -1,12 +1,6 @@
 export default {
   "data": {
     "checkoutLineItemsRemove": {
-      "userErrors": [
-        {
-          "message": "Line item with id abcdefgh not found",
-          "field": null,
-        }
-      ],
       "checkoutUserErrors": [
         {
           "message": "Line item with id abcdefgh not found",

--- a/fixtures/checkout-line-items-replace-fixture.js
+++ b/fixtures/checkout-line-items-replace-fixture.js
@@ -28,7 +28,7 @@ export default {
           "province": "Ontario",
           "zip": "M3O 0W1",
           "name": "Meow Meowington",
-          "countryCode": "CA",
+          "countryCodeV2": "CA",
           "provinceCode": "ON",
           "id": "291dC9lM2JkNzHJnnf8a89njNJNKAhu1gn7lMzM5MzFlZj9rZXk9NDcwOTJ=="
         },

--- a/fixtures/checkout-line-items-update-fixture.js
+++ b/fixtures/checkout-line-items-update-fixture.js
@@ -1,7 +1,6 @@
 export default {
    "data":{
       "checkoutLineItemsUpdate":{
-         "userErrors":[],
          "checkoutUserErrors": [],
          "checkout":{
             "id":"Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",

--- a/fixtures/checkout-line-items-update-fixture.js
+++ b/fixtures/checkout-line-items-update-fixture.js
@@ -20,7 +20,10 @@ export default {
                         "variant":{
                            "id":"Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
                            "title":"Black / 8",
-                           "price":"188.00",
+                           "priceV2": {
+                             "amount": "188.0",
+                             "currencyCode": "CAD"
+                           },
                            "weight":0,
                            "image": {
                               "id":"Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
@@ -53,20 +56,32 @@ export default {
 
             ],
             "note":null,
-            "paymentDue":"376.00",
+            "paymentDueV2": {
+              "amount": "376.00",
+              "currencyCode": "CAD"
+            },
             "webUrl":"https://checkout.shopify.com/13120893/checkouts/e28b55a3205f8d129a9b7223287ec95a?key=191add76e8eba90b93cfe4d5d261c4cb",
             "order":null,
             "orderStatusUrl":null,
             "taxExempt":false,
             "taxesIncluded":false,
             "currencyCode":"CAD",
-            "totalTax":"0.00",
+            "totalTaxV2": {
+              "amount": "0.0",
+              "currencyCode": "CAD"
+            },
             "lineItemsSubtotalPrice": {
               "amount": "376.00",
               "currencyCode": "CAD"
             },
-            "subtotalPrice":"376.00",
-            "totalPrice":"376.00",
+            "subtotalPriceV2": {
+              "amount": "376.00",
+              "currencyCode": "CAD"
+            },
+            "totalPriceV2": {
+              "amount": "376.00",
+              "currencyCode": "CAD"
+            },
             "completedAt":null,
             "createdAt":"2017-04-13T21:54:16Z",
             "updatedAt":"2017-04-13T21:54:17Z"

--- a/fixtures/checkout-line-items-update-fixture.js
+++ b/fixtures/checkout-line-items-update-fixture.js
@@ -24,7 +24,7 @@ export default {
                            "weight":0,
                            "image": {
                               "id":"Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
-                              "src":"https://cdn.shopify.com/s/files/1/1312/0893/products/003_3e206539-20d3-49c0-8bff-006e449906ca.jpg?v=1491850970",
+                              "originalSrc":"https://cdn.shopify.com/s/files/1/1312/0893/products/003_3e206539-20d3-49c0-8bff-006e449906ca.jpg?v=1491850970",
                               "altText":null
                            },
                            "selectedOptions":[

--- a/fixtures/checkout-line-items-update-with-user-errors-fixture.js
+++ b/fixtures/checkout-line-items-update-with-user-errors-fixture.js
@@ -1,12 +1,6 @@
 export default {
    "data":{
       "checkoutLineItemsUpdate":{
-        "userErrors": [
-          {
-            "message": "Variant is invalid",
-            "field": ['lineItems', '0', 'variantId']
-          }
-        ],
         "checkoutUserErrors": [
           {
             "message": "Variant is invalid",

--- a/fixtures/checkout-shipping-address-update-v2-fixture.js
+++ b/fixtures/checkout-shipping-address-update-v2-fixture.js
@@ -1,7 +1,6 @@
 export default {
   "data": {
     "checkoutShippingAddressUpdateV2": {
-      "userErrors": [],
       "checkoutUserErrors": [],
       "checkout": {
         "id": "Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",

--- a/fixtures/checkout-shipping-address-update-v2-fixture.js
+++ b/fixtures/checkout-shipping-address-update-v2-fixture.js
@@ -18,10 +18,22 @@ export default {
           "amount": "374.95",
           "currencyCode": "CAD"
         },
-        "totalPrice": "80.28",
-        "subtotalPrice": "67.50",
-        "totalTax": "8.78",
-        "paymentDue": "80.28",
+        "totalPriceV2": {
+          "amount": "80.28",
+          "currencyCode": "CAD"
+        },
+        "subtotalPriceV2": {
+          "amount": "67.50",
+          "currencyCode": "CAD"
+        },
+        "totalTaxV2": {
+          "amount": "8.78",
+          "currencyCode": "CAD"
+        },
+        "paymentDueV2": {
+          "amount": "80.28",
+          "currencyCode": "CAD"
+        },
         "taxExempt": false,
         "taxesIncluded": false,
         "completedAt": null,
@@ -46,7 +58,7 @@ export default {
           "province": "Kentucky",
           "zip": "40202",
           "name": "Bob Norman",
-          "countryCode": "US",
+          "countryCodeV2": "US",
           "provinceCode": "KY"
         },
         "lineItems": {
@@ -61,7 +73,10 @@ export default {
                 "title": "Intelligent Granite Table",
                 "variant": {
                   "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
-                  "price": "74.99"
+                  "priceV2": {
+                    "amount": "74.99",
+                    "currencyCode": "CAD"
+                  }
                 },
                 "quantity": 5,
                 "customAttributes": [],

--- a/fixtures/checkout-shipping-address-update-v2-with-user-errors-fixture.js
+++ b/fixtures/checkout-shipping-address-update-v2-with-user-errors-fixture.js
@@ -1,12 +1,6 @@
 export default {
   "data": {
     "checkoutShippingAddressUpdateV2": {
-      "userErrors": [
-        {
-          "message": 'Country is not supported',
-          "field": ['shippingAddress', 'country'],
-        },
-      ],
       "checkoutUserErrors" : [
         {
           "message": 'Country is not supported',

--- a/fixtures/checkout-update-custom-attrs-fixture.js
+++ b/fixtures/checkout-update-custom-attrs-fixture.js
@@ -19,7 +19,10 @@ export default {
                 "variant": {
                   "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
                   "title": "Awesome Copper Bench",
-                  "price": "64.99",
+                  "priceV2": {
+                    "amount": "64.99",
+                    "currencyCode": "CAD"
+                  },
                   "weight": 4.5,
                   "image": null,
                   "selectedOptions": [
@@ -63,19 +66,31 @@ export default {
         "requiresShipping": true,
         "customAttributes": [{key: "MyKey", value: "MyValue"}],
         "note": null,
-        "paymentDue": "367.19",
+        "paymentDueV2": {
+          "amount": "367.19",
+          "currencyCode": "CAD"
+        },
         "webUrl": "https://checkout.myshopify.io/1/checkouts/c4abf4bf036239ab5e3d0bf93c642c96",
         "orderStatusUrl": null,
         "taxExempt": false,
         "taxesIncluded": false,
         "currencyCode": "CAD",
-        "totalTax": "42.24",
+        "totalTaxV2": {
+          "amount": "42.42",
+          "currencyCode": "CAD"
+        },
         "lineItemsSubtotalPrice": {
           "amount": "324.95",
           "currencyCode": "CAD"
         },
-        "subtotalPrice": "324.95",
-        "totalPrice": "367.19",
+        "subtotalPriceV2": {
+          "amount": "324.95",
+          "currencyCode": "CAD"
+        },
+        "totalPriceV2": {
+          "amount": "367.19",
+          "currencyCode": "CAD"
+        },
         "completedAt": null,
         "createdAt": "2017-03-28T16:58:31Z",
         "updatedAt": "2017-03-28T16:58:31Z"

--- a/fixtures/checkout-update-custom-attrs-fixture.js
+++ b/fixtures/checkout-update-custom-attrs-fixture.js
@@ -55,7 +55,7 @@ export default {
           "province": "Ontario",
           "zip": "M3O 0W1",
           "name": "Meow Meowington",
-          "countryCode": "CA",
+          "countryCodeV2": "CA",
           "provinceCode": "ON",
           "id": "Z2lkOi8vc2hvcGlmeS9QcmdfnAU8nakdWMnAbh890hyOTEwNjA2NDU4NA=="
         },

--- a/fixtures/checkout-update-custom-attrs-fixture.js
+++ b/fixtures/checkout-update-custom-attrs-fixture.js
@@ -2,7 +2,6 @@ export default {
   "data": {
     "checkoutAttributesUpdateV2": {
       "checkoutUserErrors": [],
-      "userErrors": [],
       "checkout": {
         "id": "Z2lkOi8vU2hvcGlmeS9FeGFtcGxlLzE=",
         "ready": true,

--- a/fixtures/checkout-update-custom-attrs-with-user-errors-fixture.js
+++ b/fixtures/checkout-update-custom-attrs-with-user-errors-fixture.js
@@ -8,12 +8,6 @@ export default {
           "code": "TOO_LONG"
         }
       ],
-      "userErrors": [
-        {
-          "message": "Note is too long (maximum is 5000 characters)",
-          "field": ['input', 'note']
-        }
-      ],
       "checkout": null
     }
   }

--- a/fixtures/checkout-update-email-fixture.js
+++ b/fixtures/checkout-update-email-fixture.js
@@ -55,7 +55,7 @@ export default {
           "province": "Ontario",
           "zip": "M3O 0W1",
           "name": "Meow Meowington",
-          "countryCode": "CA",
+          "countryCodeV2": "CA",
           "provinceCode": "ON",
           "id": "Z2lkOi8vc2hvcGlmeS9QcmdfnAU8nakdWMnAbh890hyOTEwNjA2NDU4NA=="
         },

--- a/fixtures/checkout-update-email-fixture.js
+++ b/fixtures/checkout-update-email-fixture.js
@@ -19,7 +19,10 @@ export default {
                 "variant": {
                   "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
                   "title": "Awesome Copper Bench",
-                  "price": "64.99",
+                  "priceV2": {
+                    "amount": "64.99",
+                    "currencyCode": "CAD"
+                  },
                   "weight": 4.5,
                   "image": null,
                   "selectedOptions": [
@@ -64,19 +67,31 @@ export default {
         "email": "user@example.com",
         "customAttributes": [{key: "MyKey", value: "MyValue"}],
         "note": null,
-        "paymentDue": "367.19",
+        "paymentDueV2": {
+          "amount": "367.19",
+          "currencyCode": "CAD"
+        },
         "webUrl": "https://checkout.myshopify.io/1/checkouts/c4abf4bf036239ab5e3d0bf93c642c96",
         "orderStatusUrl": null,
         "taxExempt": false,
         "taxesIncluded": false,
         "currencyCode": "CAD",
-        "totalTax": "42.24",
+        "totalTaxV2": {
+          "amount": "42.42",
+          "currencyCode": "CAD"
+        },
         "lineItemsSubtotalPrice": {
           "amount": "324.95",
           "currencyCode": "CAD"
         },
-        "subtotalPrice": "324.95",
-        "totalPrice": "367.19",
+        "subtotalPriceV2": {
+          "amount": "324.95",
+          "currencyCode": "CAD"
+        },
+        "totalPriceV2": {
+          "amount": "367.19",
+          "currencyCode": "CAD"
+        },
         "completedAt": null,
         "createdAt": "2017-03-28T16:58:31Z",
         "updatedAt": "2017-03-28T16:58:31Z"

--- a/fixtures/checkout-update-email-fixture.js
+++ b/fixtures/checkout-update-email-fixture.js
@@ -2,7 +2,6 @@ export default {
   "data": {
     "checkoutEmailUpdateV2": {
       "checkoutUserErrors": [],
-      "userErrors": [],
       "checkout": {
         "id": "Z2lkOi8vU2hvcGlmeS9FeGFtcGxlLzE=",
         "ready": true,

--- a/fixtures/checkout-update-email-with-user-errors-fixture.js
+++ b/fixtures/checkout-update-email-with-user-errors-fixture.js
@@ -8,12 +8,6 @@ export default {
           "code": "INVALID"
         }
       ],
-      "userErrors": [
-        {
-          "message": "Email is invalid",
-          "field": ['email'],
-        }
-      ],
       "checkout": null
     }
   }

--- a/fixtures/checkout-with-paginated-line-items-fixture.js
+++ b/fixtures/checkout-with-paginated-line-items-fixture.js
@@ -16,7 +16,10 @@ export default {
               "variant": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                 "title": "Awesome Copper Bench",
-                "price": "64.99",
+                "priceV2": {
+                  "amount": "64.99",
+                  "currencyCode": "CAD"
+                },
                 "weight": 4.5,
                 "image": null,
                 "selectedOptions": [
@@ -37,20 +40,32 @@ export default {
       "requiresShipping": true,
       "customAttributes": [],
       "note": null,
-      "paymentDue": "367.19",
+      "paymentDueV2": {
+        "amount": "367.19",
+        "currencyCode": "CAD"
+      },
       "webUrl": "https://checkout.myshopify.io/1/checkouts/c4abf4bf036239ab5e3d0bf93c642c96",
       "order": null,
       "orderStatusUrl": null,
       "taxExempt": false,
       "taxesIncluded": false,
       "currencyCode": "CAD",
-      "totalTax": "42.24",
+      "totalTaxV2": {
+        "amount": "42.42",
+        "currencyCode": "CAD"
+      },
       "lineItemsSubtotalPrice": {
         "amount": "324.95",
         "currencyCode": "CAD"
       },
-      "subtotalPrice": "324.95",
-      "totalPrice": "367.19",
+      "subtotalPriceV2": {
+        "amount": "324.95",
+        "currencyCode": "CAD"
+      },
+      "totalPriceV2": {
+        "amount": "367.19",
+        "currencyCode": "CAD"
+      },
       "completedAt": null,
       "createdAt": "2017-03-28T16:58:31Z",
       "updatedAt": "2017-03-28T16:58:31Z"

--- a/fixtures/collection-with-products-fixture.js
+++ b/fixtures/collection-with-products-fixture.js
@@ -99,7 +99,10 @@ export default {
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNTk3Ng==",
                       "title": "Fluffy / Medium",
-                      "price": "0.00",
+                      "priceV2": {
+                        "amount": "0.0",
+                        "currencyCode": "CAD"
+                      },
                       "weight": 18,
                       "image": {
                         "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
@@ -123,7 +126,10 @@ export default {
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNjA0MA==",
                       "title": "Extra Fluffy / Small",
-                      "price": "0.00",
+                      "priceV2": {
+                        "amount": "0.0",
+                        "currencyCode": "CAD"
+                      },
                       "weight": 18,
                       "image": {
                         "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
@@ -147,7 +153,10 @@ export default {
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNjEwNA==",
                       "title": "Mega Fluff / Large",
-                      "price": "0.00",
+                      "priceV2": {
+                        "amount": "0.0",
+                        "currencyCode": "CAD"
+                      },
                       "weight": 0,
                       "image": {
                         "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
@@ -219,7 +228,10 @@ export default {
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTkzNzExMjEzNg==",
                       "title": "Default Title",
-                      "price": "0.00",
+                      "priceV2": {
+                        "amount": "0.0",
+                        "currencyCode": "CAD"
+                      },
                       "weight": 0,
                       "image": null,
                       "selectedOptions": [

--- a/fixtures/collection-with-products-fixture.js
+++ b/fixtures/collection-with-products-fixture.js
@@ -58,7 +58,7 @@ export default {
                     "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTYzMDY4MTI2ODA=",
-                      "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
+                      "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
                       "altText": "fettucine"
                     }
                   },
@@ -66,7 +66,7 @@ export default {
                     "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
-                      "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
+                      "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
                       "altText": null
                     }
                   },
@@ -74,7 +74,7 @@ export default {
                     "cursor": "eyJsYXN0X2lkIjoxODIxNzc5MDY2NH0=",
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
-                      "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
+                      "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
                       "altText": null
                     }
                   },
@@ -82,7 +82,7 @@ export default {
                     "cursor": "eyJsYXN0X2lkIjoxOTYxNjczNjg0MH0=",
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
-                      "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
+                      "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
                       "altText": null
                     }
                   }
@@ -103,7 +103,7 @@ export default {
                       "weight": 18,
                       "image": {
                         "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
-                        "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
+                        "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
                         "altText": null
                       },
                       "selectedOptions": [
@@ -127,7 +127,7 @@ export default {
                       "weight": 18,
                       "image": {
                         "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
-                        "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
+                        "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
                         "altText": null
                       },
                       "selectedOptions": [
@@ -151,7 +151,7 @@ export default {
                       "weight": 0,
                       "image": {
                         "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
-                        "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
+                        "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
                         "altText": null
                       },
                       "selectedOptions": [
@@ -202,7 +202,7 @@ export default {
                     "cursor": "eyJsYXN0X2lkIjoyMDE0MzA0MTg2NH0=",
                     "node": {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjAxNDMwNDE4NjQ=",
-                      "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/image.dots.morethings.jpg?v=1490898420",
+                      "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/image.dots.morethings.jpg?v=1490898420",
                       "altText": null
                     }
                   }

--- a/fixtures/dynamic-product-fixture.js
+++ b/fixtures/dynamic-product-fixture.js
@@ -16,21 +16,21 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTYzMDY4MTI2ODA=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096"
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096"
             }
           },
           {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581332"
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581332"
             }
           },
           {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc5MDY2NH0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1484581340"
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1484581340"
             }
           }
         ]

--- a/fixtures/dynamic-product-fixture.js
+++ b/fixtures/dynamic-product-fixture.js
@@ -51,7 +51,10 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNTk3Nn0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NTk3MjA=",
-              "price": "0.00",
+              "priceV2": {
+                "amount": "0.0",
+                "currencyCode": "CAD"
+              },
               "weight": 18
             }
           },
@@ -59,7 +62,10 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNjA0MH0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
-              "price": "0.00",
+              "priceV2": {
+                "amount": "0.0",
+                "currencyCode": "CAD"
+              },
               "weight": 18
             }
           },
@@ -67,7 +73,10 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNjEwNH0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI4MjkzODQ=",
-              "price": "0.00",
+              "priceV2": {
+                "amount": "0.0",
+                "currencyCode": "CAD"
+              },
               "weight": 0
             }
           }

--- a/fixtures/paginated-images-fixtures.js
+++ b/fixtures/paginated-images-fixtures.js
@@ -13,7 +13,7 @@ export const secondPageImagesFixture = {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTYzMDY4MTI2ODA=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581332",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581332",
               "altText": null
             }
           }
@@ -38,7 +38,7 @@ export const thirdPageImagesFixture = {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc5MDY2NH0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4MTk0MDA=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1484581340",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1484581340",
               "altText": null
             }
           }
@@ -63,7 +63,7 @@ export const fourthPageImagesFixture = {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI4MjkzODQ=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581340",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581340",
               "altText": null
             }
           }
@@ -88,7 +88,7 @@ export const fifthPageImagesFixture = {
             "cursor": "eyJsYXN0X2lkIjoxOTYxNjczNjg0MH0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
               "altText": null
             }
           }

--- a/fixtures/paginated-variants-fixtures.js
+++ b/fixtures/paginated-variants-fixtures.js
@@ -14,7 +14,10 @@ export const secondPageVariantsFixture = {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
               "title": "Extra Fluffy",
-              "price": "0.00",
+              "priceV2": {
+                "amount": "0.0",
+                "currencyCode": "CAD"
+              },
               "weight": 18,
               "image": null,
               "selectedOptions": [
@@ -47,7 +50,10 @@ export const thirdPageVariantsFixture = {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NTk3MjA=",
               "title": "Mega Fluff",
-              "price": "0.00",
+              "priceV2": {
+                "amount": "0.0",
+                "currencyCode": "CAD"
+              },
               "weight": 0,
               "image": null,
               "selectedOptions": [

--- a/fixtures/product-by-handle-fixture.js
+++ b/fixtures/product-by-handle-fixture.js
@@ -40,56 +40,56 @@ export default {
           {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDgxNjY=",
-              "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/babyandco5.jpg?v=1487171332",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/babyandco5.jpg?v=1487171332",
               "altText": null
             }
           },
           {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDgyMzA=",
-              "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24008.jpg?v=1487171332",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24008.jpg?v=1487171332",
               "altText": null
             }
           },
           {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDgyOTQ=",
-              "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24015.jpg?v=1487171332",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24015.jpg?v=1487171332",
               "altText": null
             }
           },
           {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDgzNTg=",
-              "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24020.jpg?v=1487171332",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24020.jpg?v=1487171332",
               "altText": null
             }
           },
           {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg0MjI=",
-              "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_34_51031_24037.jpg?v=1487171332",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_34_51031_24037.jpg?v=1487171332",
               "altText": null
             }
           },
           {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg0ODY=",
-              "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24024.jpg?v=1487171332",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24024.jpg?v=1487171332",
               "altText": null
             }
           },
           {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg1NTA=",
-              "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24034.jpg?v=1487171332",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24034.jpg?v=1487171332",
               "altText": null
             }
           },
           {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg2MTQ=",
-              "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_34_51031_24040.jpg?v=1487171332",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_34_51031_24040.jpg?v=1487171332",
               "altText": null
             }
           }
@@ -104,7 +104,7 @@ export default {
           {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zNTgzMTE3NDIxNA==",
-              "available": true,
+              "availableForSale": true,
               "weight": 0,
               "price": "788.00",
               "title": "Black / X-Small",
@@ -124,7 +124,7 @@ export default {
           {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zNTgzMTE3NDQwNg==",
-              "available": true,
+              "availableForSale": true,
               "weight": 0,
               "price": "788.00",
               "title": "Black / Small",
@@ -144,7 +144,7 @@ export default {
           {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zNTgzMTE3NDUzNA==",
-              "available": false,
+              "availableForSale": false,
               "weight": 0,
               "price": "788.00",
               "title": "Black / Medium",
@@ -164,13 +164,13 @@ export default {
           {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zNTgzMTE3NDcyNg==",
-              "available": true,
+              "availableForSale": true,
               "weight": 0,
               "price": "750.00",
               "title": "Dark Green / X-Small",
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg0MjI=",
-                "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_34_51031_24037.jpg?v=1487171332"
+                "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_34_51031_24037.jpg?v=1487171332"
               },
               "selectedOptions": [
                 {
@@ -187,13 +187,13 @@ export default {
           {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zNTgzMTE3NDkxOA==",
-              "available": false,
+              "availableForSale": false,
               "weight": 0,
               "price": "750.00",
               "title": "Dark Green / Small",
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg2MTQ=",
-                "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_34_51031_24040.jpg?v=1487171332"
+                "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_34_51031_24040.jpg?v=1487171332"
               },
               "selectedOptions": [
                 {
@@ -210,13 +210,13 @@ export default {
           {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zNTgzMTE3NTExMA==",
-              "available": true,
+              "availableForSale": true,
               "weight": 0,
               "price": "788.00",
               "title": "Dark Green / Medium",
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg1NTA=",
-                "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24034.jpg?v=1487171332"
+                "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24034.jpg?v=1487171332"
               },
               "selectedOptions": [
                 {
@@ -233,13 +233,13 @@ export default {
           {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC80MjgyNzA5NjcyNQ==",
-              "available": true,
+              "availableForSale": true,
               "weight": 0,
               "price": "788.00",
               "title": "Dark Green / Large",
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg0ODY=",
-                "src": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24024.jpg?v=1487171332"
+                "originalSrc": "https://cdn.shopify.com/s/files/1/1019/0495/products/2015-07-02_Ashley_33_51032_24024.jpg?v=1487171332"
               },
               "selectedOptions": [
                 {

--- a/fixtures/product-by-handle-fixture.js
+++ b/fixtures/product-by-handle-fixture.js
@@ -106,7 +106,10 @@ export default {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zNTgzMTE3NDIxNA==",
               "availableForSale": true,
               "weight": 0,
-              "price": "788.00",
+              "priceV2": {
+                "amount": "788.0",
+                "currencyCode": "CAD"
+              },
               "title": "Black / X-Small",
               "image": null,
               "selectedOptions": [
@@ -126,7 +129,10 @@ export default {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zNTgzMTE3NDQwNg==",
               "availableForSale": true,
               "weight": 0,
-              "price": "788.00",
+              "priceV2": {
+                "amount": "788.0",
+                "currencyCode": "CAD"
+              },
               "title": "Black / Small",
               "image": null,
               "selectedOptions": [
@@ -146,7 +152,10 @@ export default {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zNTgzMTE3NDUzNA==",
               "availableForSale": false,
               "weight": 0,
-              "price": "788.00",
+              "priceV2": {
+                "amount": "788.0",
+                "currencyCode": "CAD"
+              },
               "title": "Black / Medium",
               "image": null,
               "selectedOptions": [
@@ -166,7 +175,10 @@ export default {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zNTgzMTE3NDcyNg==",
               "availableForSale": true,
               "weight": 0,
-              "price": "750.00",
+              "priceV2": {
+                "amount": "750.00",
+                "currencyCode": "CAD"
+              },
               "title": "Dark Green / X-Small",
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg0MjI=",
@@ -189,7 +201,10 @@ export default {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zNTgzMTE3NDkxOA==",
               "availableForSale": false,
               "weight": 0,
-              "price": "750.00",
+              "priceV2": {
+                "amount": "750.00",
+                "currencyCode": "CAD"
+              },
               "title": "Dark Green / Small",
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg2MTQ=",
@@ -212,7 +227,10 @@ export default {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8zNTgzMTE3NTExMA==",
               "availableForSale": true,
               "weight": 0,
-              "price": "788.00",
+              "priceV2": {
+                "amount": "788.0",
+                "currencyCode": "CAD"
+              },
               "title": "Dark Green / Medium",
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg1NTA=",
@@ -235,7 +253,10 @@ export default {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC80MjgyNzA5NjcyNQ==",
               "availableForSale": true,
               "weight": 0,
-              "price": "788.00",
+              "priceV2": {
+                "amount": "788.0",
+                "currencyCode": "CAD"
+              },
               "title": "Dark Green / Large",
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg0ODY=",

--- a/fixtures/product-fixture.js
+++ b/fixtures/product-fixture.js
@@ -84,7 +84,10 @@ export default {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
               "title": "Fluffy / Medium",
-              "price": "0.00",
+              "priceV2": {
+                "amount": "0.0",
+                "currencyCode": "CAD"
+              },
               "weight": 18,
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
@@ -108,7 +111,10 @@ export default {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
               "title": "Extra Fluffy / Small",
-              "price": "0.00",
+              "priceV2": {
+                "amount": "0.0",
+                "currencyCode": "CAD"
+              },
               "weight": 18,
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
@@ -132,7 +138,10 @@ export default {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
               "title": "Mega Fluff / Large",
-              "price": "0.00",
+              "priceV2": {
+                "amount": "0.0",
+                "currencyCode": "CAD"
+              },
               "weight": 0,
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",

--- a/fixtures/product-fixture.js
+++ b/fixtures/product-fixture.js
@@ -43,7 +43,7 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
               "altText": "fettucine"
             }
           },
@@ -51,7 +51,7 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
               "altText": null
             }
           },
@@ -59,7 +59,7 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoxODIxNzc5MDY2NH0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
               "altText": null
             }
           },
@@ -67,7 +67,7 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoxOTYxNjczNjg0MH0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
               "altText": null
             }
           }
@@ -88,7 +88,7 @@ export default {
               "weight": 18,
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
+                "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
                 "altText": null
               },
               "selectedOptions": [
@@ -112,7 +112,7 @@ export default {
               "weight": 18,
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
+                "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
                 "altText": null
               },
               "selectedOptions": [
@@ -136,7 +136,7 @@ export default {
               "weight": 0,
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-                "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
+                "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
                 "altText": null
               },
               "selectedOptions": [

--- a/fixtures/product-with-paginated-images-fixture.js
+++ b/fixtures/product-with-paginated-images-fixture.js
@@ -40,7 +40,7 @@ export default {
                   "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
                   "node": {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
-                    "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096",
+                    "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096",
                     "altText": null
                   }
                 }

--- a/fixtures/product-with-paginated-images-fixture.js
+++ b/fixtures/product-with-paginated-images-fixture.js
@@ -57,7 +57,10 @@ export default {
                   "node": {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
                     "title": "Fluffy",
-                    "price": "0.00",
+                    "priceV2": {
+                      "amount": "0.0",
+                      "currencyCode": "CAD"
+                    },
                     "weight": 18,
                     "selectedOptions": [
                       {

--- a/fixtures/product-with-paginated-variants-fixture.js
+++ b/fixtures/product-with-paginated-variants-fixture.js
@@ -37,7 +37,10 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNTk3Nn0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4MTk0MDA=",
-              "price": "0.00",
+              "priceV2": {
+                "amount": "0.0",
+                "currencyCode": "CAD"
+              },
               "weight": 18
             }
           }

--- a/fixtures/product-with-paginated-variants-fixture.js
+++ b/fixtures/product-with-paginated-variants-fixture.js
@@ -16,7 +16,7 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTYzMDY4MTI2ODA=",
-              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096"
+              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096"
             }
           }
         ]

--- a/fixtures/query-collections-with-pagination-fixture.js
+++ b/fixtures/query-collections-with-pagination-fixture.js
@@ -82,7 +82,10 @@ export default {
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNTk3Ng==",
                             "title": "Fluffy / Medium",
-                            "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.0",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 18,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
@@ -106,7 +109,10 @@ export default {
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNjA0MA==",
                             "title": "Extra Fluffy / Small",
-                            "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.0",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 18,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
@@ -130,7 +136,10 @@ export default {
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNjEwNA==",
                             "title": "Mega Fluff / Large",
-                            "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.0",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
@@ -202,7 +211,10 @@ export default {
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTkzNzExMjEzNg==",
                             "title": "Default Title",
-                            "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.0",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 0,
                             "image": null,
                             "selectedOptions": [
@@ -288,7 +300,10 @@ export default {
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjAyMjc5Mg==",
                             "title": "small",
-                            "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.0",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
@@ -308,7 +323,10 @@ export default {
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
                             "title": "large",
-                            "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.0",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NTk3MjA=",
@@ -328,7 +346,10 @@ export default {
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDY0OA==",
                             "title": "very large",
-                            "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.0",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI4MjkzODQ=",

--- a/fixtures/query-collections-with-pagination-fixture.js
+++ b/fixtures/query-collections-with-pagination-fixture.js
@@ -65,7 +65,7 @@ export default {
                           "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTYzMDY4MTI2ODA=",
-                            "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
+                            "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
                             "altText": "fettucine"
                           }
                         }
@@ -86,7 +86,7 @@ export default {
                             "weight": 18,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
                               "altText": null
                             },
                             "selectedOptions": [
@@ -110,7 +110,7 @@ export default {
                             "weight": 18,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
                               "altText": null
                             },
                             "selectedOptions": [
@@ -134,7 +134,7 @@ export default {
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
                               "altText": null
                             },
                             "selectedOptions": [
@@ -185,7 +185,7 @@ export default {
                           "cursor": "eyJsYXN0X2lkIjoyMDE0MzA0MTg2NH0=",
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjAxNDMwNDE4NjQ=",
-                            "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/image.dots.morethings.jpg?v=1490898420",
+                            "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/image.dots.morethings.jpg?v=1490898420",
                             "altText": null
                           }
                         }
@@ -271,7 +271,7 @@ export default {
                           "cursor": "eyJsYXN0X2lkIjoxODIxNzgxOTQwMH0=",
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4MTk0MDA=",
-                            "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/notcat.jpeg?v=1490363658",
+                            "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/notcat.jpeg?v=1490363658",
                             "altText": null
                           }
                         }
@@ -292,7 +292,7 @@ export default {
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/054cca77f1be90654f4f70db263a3822.jpg?v=1490363658",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/054cca77f1be90654f4f70db263a3822.jpg?v=1490363658",
                               "altText": null
                             },
                             "selectedOptions": [
@@ -312,7 +312,7 @@ export default {
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NTk3MjA=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/23695_pets_vertical_store_dogs_small_tile_8._CB312176604.jpg?v=1490363658",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/23695_pets_vertical_store_dogs_small_tile_8._CB312176604.jpg?v=1490363658",
                               "altText": null
                             },
                             "selectedOptions": [
@@ -332,7 +332,7 @@ export default {
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI4MjkzODQ=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/original.jpg?v=1490363713",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/original.jpg?v=1490363713",
                               "altText": null
                             },
                             "selectedOptions": [

--- a/fixtures/query-collections-with-products-fixture.js
+++ b/fixtures/query-collections-with-products-fixture.js
@@ -106,7 +106,10 @@ export default {
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNTk3Ng==",
                             "title": "Fluffy / Medium",
-                            "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.0",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 18,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
@@ -130,7 +133,10 @@ export default {
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNjA0MA==",
                             "title": "Extra Fluffy / Small",
-                            "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.0",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 18,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
@@ -154,7 +160,10 @@ export default {
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNjEwNA==",
                             "title": "Mega Fluff / Large",
-                            "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.0",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
@@ -226,7 +235,10 @@ export default {
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTkzNzExMjEzNg==",
                             "title": "Default Title",
-                            "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.0",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 0,
                             "image": null,
                             "selectedOptions": [
@@ -344,7 +356,10 @@ export default {
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjAyMjc5Mg==",
                             "title": "small",
-                            "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.0",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
@@ -364,7 +379,10 @@ export default {
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
                             "title": "large",
-                            "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.0",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NTk3MjA=",
@@ -384,7 +402,10 @@ export default {
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDY0OA==",
                             "title": "very large",
-                            "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.0",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI4MjkzODQ=",

--- a/fixtures/query-collections-with-products-fixture.js
+++ b/fixtures/query-collections-with-products-fixture.js
@@ -65,7 +65,7 @@ export default {
                           "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTYzMDY4MTI2ODA=",
-                            "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
+                            "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1489515038",
                             "altText": "fettucine"
                           }
                         },
@@ -73,7 +73,7 @@ export default {
                           "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
-                            "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
+                            "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
                             "altText": null
                           }
                         },
@@ -81,7 +81,7 @@ export default {
                           "cursor": "eyJsYXN0X2lkIjoxODIxNzc5MDY2NH0=",
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
-                            "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
+                            "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
                             "altText": null
                           }
                         },
@@ -89,7 +89,7 @@ export default {
                           "cursor": "eyJsYXN0X2lkIjoxOTYxNjczNjg0MH0=",
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
-                            "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
+                            "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
                             "altText": null
                           }
                         }
@@ -110,7 +110,7 @@ export default {
                             "weight": 18,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/maxresdefault.jpg?v=1489515047",
                               "altText": null
                             },
                             "selectedOptions": [
@@ -134,7 +134,7 @@ export default {
                             "weight": 18,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1489515038",
                               "altText": null
                             },
                             "selectedOptions": [
@@ -158,7 +158,7 @@ export default {
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1489515038",
                               "altText": null
                             },
                             "selectedOptions": [
@@ -209,7 +209,7 @@ export default {
                           "cursor": "eyJsYXN0X2lkIjoyMDE0MzA0MTg2NH0=",
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjAxNDMwNDE4NjQ=",
-                            "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/image.dots.morethings.jpg?v=1490898420",
+                            "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/image.dots.morethings.jpg?v=1490898420",
                             "altText": null
                           }
                         }
@@ -295,7 +295,7 @@ export default {
                           "cursor": "eyJsYXN0X2lkIjoxODIxNzgxOTQwMH0=",
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4MTk0MDA=",
-                            "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/notcat.jpeg?v=1490363658",
+                            "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/notcat.jpeg?v=1490363658",
                             "altText": null
                           }
                         },
@@ -303,7 +303,7 @@ export default {
                           "cursor": "eyJsYXN0X2lkIjoxODIxNzg0NzYyNH0=",
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NDc2MjQ=",
-                            "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/hqdefault.jpg?v=1490363658",
+                            "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/hqdefault.jpg?v=1490363658",
                             "altText": null
                           }
                         },
@@ -311,7 +311,7 @@ export default {
                           "cursor": "eyJsYXN0X2lkIjoxODIxNzg1OTcyMH0=",
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NTk3MjA=",
-                            "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/23695_pets_vertical_store_dogs_small_tile_8._CB312176604.jpg?v=1490363658",
+                            "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/23695_pets_vertical_store_dogs_small_tile_8._CB312176604.jpg?v=1490363658",
                             "altText": null
                           }
                         },
@@ -319,7 +319,7 @@ export default {
                           "cursor": "eyJsYXN0X2lkIjoxOTg5Mjc4MzU2MH0=",
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
-                            "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/054cca77f1be90654f4f70db263a3822.jpg?v=1490363658",
+                            "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/054cca77f1be90654f4f70db263a3822.jpg?v=1490363658",
                             "altText": null
                           }
                         },
@@ -327,7 +327,7 @@ export default {
                           "cursor": "eyJsYXN0X2lkIjoxOTg5MjgyOTM4NH0=",
                           "node": {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI4MjkzODQ=",
-                            "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/original.jpg?v=1490363713",
+                            "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/original.jpg?v=1490363713",
                             "altText": null
                           }
                         }
@@ -348,7 +348,7 @@ export default {
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/054cca77f1be90654f4f70db263a3822.jpg?v=1490363658",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/054cca77f1be90654f4f70db263a3822.jpg?v=1490363658",
                               "altText": null
                             },
                             "selectedOptions": [
@@ -368,7 +368,7 @@ export default {
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NTk3MjA=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/23695_pets_vertical_store_dogs_small_tile_8._CB312176604.jpg?v=1490363658",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/23695_pets_vertical_store_dogs_small_tile_8._CB312176604.jpg?v=1490363658",
                               "altText": null
                             },
                             "selectedOptions": [
@@ -388,7 +388,7 @@ export default {
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI4MjkzODQ=",
-                              "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/original.jpg?v=1490363713",
+                              "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/original.jpg?v=1490363713",
                               "altText": null
                             },
                             "selectedOptions": [

--- a/fixtures/query-products-fixture.js
+++ b/fixtures/query-products-fixture.js
@@ -40,7 +40,7 @@ export default {
                   "cursor": "eyJsYXN0X2lkIjoxNjMwNjgxMjY4MH0=",
                   "node": {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-                    "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096",
+                    "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat.jpg?v=1474839096",
                     "altText": null
                   }
                 },
@@ -48,7 +48,7 @@ export default {
                   "cursor": "eyJsYXN0X2lkIjoxODIxNzc4NzU5Mn0=",
                   "node": {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-                    "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581332",
+                    "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat2.jpeg?v=1484581332",
                     "altText": null
                   }
                 },
@@ -56,7 +56,7 @@ export default {
                   "cursor": "eyJsYXN0X2lkIjoxODIxNzc5MDY2NH0=",
                   "node": {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-                    "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1484581340",
+                    "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/cat3.jpeg?v=1484581340",
                     "altText": null
                   }
                 }
@@ -154,7 +154,7 @@ export default {
                   "cursor": "eyJsYXN0X2lkIjoxODIxNzgxOTQwMH0=",
                   "node": {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-                    "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/notcat.jpeg?v=1484581419",
+                    "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/notcat.jpeg?v=1484581419",
                     "altText": null
                   }
                 },
@@ -162,7 +162,7 @@ export default {
                   "cursor": "eyJsYXN0X2lkIjoxODIxNzg0NzYyNH0=",
                   "node": {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-                    "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/hqdefault.jpg?v=1484581502",
+                    "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/hqdefault.jpg?v=1484581502",
                     "altText": null
                   }
                 },
@@ -170,7 +170,7 @@ export default {
                   "cursor": "eyJsYXN0X2lkIjoxODIxNzg1OTcyMH0=",
                   "node": {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-                    "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/23695_pets_vertical_store_dogs_small_tile_8._CB312176604.jpg?v=1484581539",
+                    "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/23695_pets_vertical_store_dogs_small_tile_8._CB312176604.jpg?v=1484581539",
                     "altText": null
                   }
                 },
@@ -178,7 +178,7 @@ export default {
                   "cursor": "eyJsYXN0X2lkIjoxODIxNzg2ODQ4OH0=",
                   "node": {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
-                    "src": "https://cdn.shopify.com/s/files/1/1510/7238/products/images.jpg?v=1484581568",
+                    "originalSrc": "https://cdn.shopify.com/s/files/1/1510/7238/products/images.jpg?v=1484581568",
                     "altText": null
                   }
                 }

--- a/fixtures/query-products-fixture.js
+++ b/fixtures/query-products-fixture.js
@@ -73,7 +73,10 @@ export default {
                   "node": {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                     "title": "Fluffy",
-                    "price": "0.00",
+                    "priceV2": {
+                      "amount": "0.0",
+                      "currencyCode": "CAD"
+                    },
                     "weight": 18,
                     "image": null,
                     "selectedOptions": [
@@ -89,7 +92,10 @@ export default {
                   "node": {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                     "title": "Extra Fluffy",
-                    "price": "0.00",
+                    "priceV2": {
+                      "amount": "0.0",
+                      "currencyCode": "CAD"
+                    },
                     "weight": 18,
                     "image": null,
                     "selectedOptions": [
@@ -105,7 +111,10 @@ export default {
                   "node": {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                     "title": "Mega Fluff",
-                    "price": "0.00",
+                    "priceV2": {
+                      "amount": "0.0",
+                      "currencyCode": "CAD"
+                    },
                     "weight": 0,
                     "image": null,
                     "selectedOptions": [
@@ -195,7 +204,10 @@ export default {
                   "node": {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                     "title": "small",
-                    "price": "0.00",
+                    "priceV2": {
+                      "amount": "0.0",
+                      "currencyCode": "CAD"
+                    },
                     "weight": 0,
                     "selectedOptions": [
                       {
@@ -210,7 +222,10 @@ export default {
                   "node": {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                     "title": "large",
-                    "price": "0.00",
+                    "priceV2": {
+                      "amount": "0.0",
+                      "currencyCode": "CAD"
+                    },
                     "weight": 0,
                     "selectedOptions": [
                       {
@@ -225,7 +240,10 @@ export default {
                   "node": {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                     "title": "very large",
-                    "price": "0.00",
+                    "priceV2": {
+                      "amount": "0.0",
+                      "currencyCode": "CAD"
+                    },
                     "weight": 0,
                     "selectedOptions": [
                       {

--- a/fixtures/shop-info-fixture.js
+++ b/fixtures/shop-info-fixture.js
@@ -2,7 +2,12 @@ export default {
   "data": {
     "shop": {
       "paymentSettings": {
-        "currencyCode": "CAD"
+        "currencyCode": "CAD",
+        "enabledPresentmentCurrencies": [
+          "CAD",
+          "EUR",
+          "JPY"
+        ]
       },
       "description": "pls send me cats",
       "moneyFormat": "${{amount}}",

--- a/fixtures/shop-info-fixture.js
+++ b/fixtures/shop-info-fixture.js
@@ -1,7 +1,9 @@
 export default {
   "data": {
     "shop": {
-      "currencyCode": "CAD",
+      "paymentSettings": {
+        "currencyCode": "CAD"
+      },
       "description": "pls send me cats",
       "moneyFormat": "${{amount}}",
       "name": "sendmecats",

--- a/schema.json
+++ b/schema.json
@@ -3546,6 +3546,18 @@
                 "name": "Money",
                 "ofType": null
               },
+              "isDeprecated": true,
+              "deprecationReason": "Use `subtotalPriceV2` instead"
+            },
+            {
+              "name": "subtotalPriceV2",
+              "description": "Price of the order before shipping and taxes.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "MoneyV2",
+                "ofType": null
+              },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -3593,6 +3605,22 @@
                   "ofType": null
                 }
               },
+              "isDeprecated": true,
+              "deprecationReason": "Use `totalPriceV2` instead"
+            },
+            {
+              "name": "totalPriceV2",
+              "description": "The sum of all the prices of all the items in the order, taxes and discounts included (must be positive).",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MoneyV2",
+                  "ofType": null
+                }
+              },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -3606,6 +3634,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Money",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `totalRefundedV2` instead"
+            },
+            {
+              "name": "totalRefundedV2",
+              "description": "The total amount that has been refunded.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MoneyV2",
                   "ofType": null
                 }
               },
@@ -3625,6 +3669,22 @@
                   "ofType": null
                 }
               },
+              "isDeprecated": true,
+              "deprecationReason": "Use `totalShippingPriceV2` instead"
+            },
+            {
+              "name": "totalShippingPriceV2",
+              "description": "The total cost of shipping.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MoneyV2",
+                  "ofType": null
+                }
+              },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -3635,6 +3695,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Money",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `totalTaxV2` instead"
+            },
+            {
+              "name": "totalTaxV2",
+              "description": "The total cost of taxes.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "MoneyV2",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -3656,6 +3728,59 @@
           "kind": "SCALAR",
           "name": "Money",
           "description": "A monetary value string.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "MoneyV2",
+          "description": "A monetary value with currency.\n\nTo format currencies, combine this type's amount and currencyCode fields with your client's locale.\n\nFor example, in JavaScript you could use Intl.NumberFormat:\n\n```js\nnew Intl.NumberFormat(locale, {\n  style: 'currency',\n  currency: currencyCode\n}).format(amount);\n```\n\nOther formatting libraries include:\n\n* iOS - [NumberFormatter](https://developer.apple.com/documentation/foundation/numberformatter)\n* Android - [NumberFormat](https://developer.android.com/reference/java/text/NumberFormat.html)\n* PHP - [NumberFormatter](http://php.net/manual/en/class.numberformatter.php)\n\nFor a more general solution, the [Unicode CLDR number formatting database] is available with many implementations\n(such as [TwitterCldr](https://github.com/twitter/twitter-cldr-rb)).\n",
+          "fields": [
+            {
+              "name": "amount",
+              "description": "Decimal money amount.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Decimal",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currencyCode",
+              "description": "Currency of the money.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyCode",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Decimal",
+          "description": "A signed decimal number, which supports arbitrary precision and is serialized as a string.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -4579,59 +4704,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "MoneyV2",
-          "description": "A monetary value with currency.\n\nTo format currencies, combine this type's amount and currencyCode fields with your client's locale.\n\nFor example, in JavaScript you could use Intl.NumberFormat:\n\n```js\nnew Intl.NumberFormat(locale, {\n  style: 'currency',\n  currency: currencyCode\n}).format(amount);\n```\n\nOther formatting libraries include:\n\n* iOS - [NumberFormatter](https://developer.apple.com/documentation/foundation/numberformatter)\n* Android - [NumberFormat](https://developer.android.com/reference/java/text/NumberFormat.html)\n* PHP - [NumberFormatter](http://php.net/manual/en/class.numberformatter.php)\n\nFor a more general solution, the [Unicode CLDR number formatting database] is available with many implementations\n(such as [TwitterCldr](https://github.com/twitter/twitter-cldr-rb)).\n",
-          "fields": [
-            {
-              "name": "amount",
-              "description": "Decimal money amount.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Decimal",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "currencyCode",
-              "description": "Currency of the money.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "CurrencyCode",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Decimal",
-          "description": "A signed decimal number, which supports arbitrary precision and is serialized as a string.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "INTERFACE",
           "name": "DiscountApplication",
           "description": "Discount applications capture the intentions of a discount source at\nthe time of application.\n",
@@ -4811,7 +4883,7 @@
         {
           "kind": "UNION",
           "name": "PricingValue",
-          "description": "The value of the pricing object.",
+          "description": "The price value (fixed or percentage) for a discount application.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -5095,6 +5167,18 @@
                 "name": "Money",
                 "ofType": null
               },
+              "isDeprecated": true,
+              "deprecationReason": "Use `compareAtPriceV2` instead"
+            },
+            {
+              "name": "compareAtPriceV2",
+              "description": "The compare at price of the variant. This can be used to mark a variant as on sale, when `compareAtPriceV2` is higher than `priceV2`.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "MoneyV2",
+                "ofType": null
+              },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -5262,6 +5346,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Money",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `priceV2` instead"
+            },
+            {
+              "name": "priceV2",
+              "description": "The product variant’s price.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MoneyV2",
                   "ofType": null
                 }
               },
@@ -8121,6 +8221,22 @@
                   "ofType": null
                 }
               },
+              "isDeprecated": true,
+              "deprecationReason": "Use `paymentDueV2` instead"
+            },
+            {
+              "name": "paymentDueV2",
+              "description": "The amount left to be paid. This is equal to the cost of the line items, taxes and shipping minus discounts and gift cards.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MoneyV2",
+                  "ofType": null
+                }
+              },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -8217,6 +8333,22 @@
                   "ofType": null
                 }
               },
+              "isDeprecated": true,
+              "deprecationReason": "Use `subtotalPriceV2` instead"
+            },
+            {
+              "name": "subtotalPriceV2",
+              "description": "Price of the checkout before shipping and taxes.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MoneyV2",
+                  "ofType": null
+                }
+              },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -8265,6 +8397,22 @@
                   "ofType": null
                 }
               },
+              "isDeprecated": true,
+              "deprecationReason": "Use `totalPriceV2` instead"
+            },
+            {
+              "name": "totalPriceV2",
+              "description": "The sum of all the prices of all the items in the checkout, taxes and discounts included.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MoneyV2",
+                  "ofType": null
+                }
+              },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -8278,6 +8426,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Money",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `totalTaxV2` instead"
+            },
+            {
+              "name": "totalTaxV2",
+              "description": "The sum of all the taxes applied to the line items and shipping lines in the checkout.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MoneyV2",
                   "ofType": null
                 }
               },
@@ -8581,6 +8745,22 @@
                   "ofType": null
                 }
               },
+              "isDeprecated": true,
+              "deprecationReason": "Use `priceV2` instead"
+            },
+            {
+              "name": "priceV2",
+              "description": "Price of this shipping rate.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MoneyV2",
+                  "ofType": null
+                }
+              },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -8671,6 +8851,22 @@
                   "ofType": null
                 }
               },
+              "isDeprecated": true,
+              "deprecationReason": "Use `amountUsedV2` instead"
+            },
+            {
+              "name": "amountUsedV2",
+              "description": "The amount that was used taken from the Gift Card by applying it.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MoneyV2",
+                  "ofType": null
+                }
+              },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -8684,6 +8880,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Money",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `balanceV2` instead"
+            },
+            {
+              "name": "balanceV2",
+              "description": "The amount left on the Gift Card.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MoneyV2",
                   "ofType": null
                 }
               },
@@ -15947,6 +16159,16 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "presentmentCurrencyCode",
+              "description": "The currency code of one of the shop's enabled presentment currencies. If the shop uses Shopify Payments, then the checkout is set to this currency.",
+              "type": {
+                "kind": "ENUM",
+                "name": "CurrencyCode",
                 "ofType": null
               },
               "defaultValue": null

--- a/src/checkout-resource.js
+++ b/src/checkout-resource.js
@@ -67,7 +67,7 @@ class CheckoutResource extends Resource {
    *   @param {Object} [input.shippingAddress] A shipping address. See the {@link https://help.shopify.com/api/storefront-api/reference/input_object/mailingaddressinput|Storefront API reference} for valid input fields.
    *   @param {String} [input.note] A note for the checkout.
    *   @param {Object[]} [input.customAttributes] A list of custom attributes for the checkout. See the {@link https://help.shopify.com/api/storefront-api/reference/input_object/attributeinput|Storefront API reference} for valid input fields.
-   *   @param {String} [input.presentmentCurrencyCode] A presentment currency code for the checkout.
+   *   @param {String} [input.presentmentCurrencyCode] A presentment currency code for the checkout. All pricing values for the checkout will be returned in the specified currency if this presentment currency is enabled for the store.
    * @return {Promise|GraphModel} A promise resolving with the created checkout.
    */
   create(input = {}) {

--- a/src/checkout-resource.js
+++ b/src/checkout-resource.js
@@ -67,6 +67,7 @@ class CheckoutResource extends Resource {
    *   @param {Object} [input.shippingAddress] A shipping address. See the {@link https://help.shopify.com/api/storefront-api/reference/input_object/mailingaddressinput|Storefront API reference} for valid input fields.
    *   @param {String} [input.note] A note for the checkout.
    *   @param {Object[]} [input.customAttributes] A list of custom attributes for the checkout. See the {@link https://help.shopify.com/api/storefront-api/reference/input_object/attributeinput|Storefront API reference} for valid input fields.
+   *   @param {String} [input.presentmentCurrencyCode] A presentment currency code for the checkout.
    * @return {Promise|GraphModel} A promise resolving with the created checkout.
    */
   create(input = {}) {

--- a/src/graphql/CheckoutFragment.graphql
+++ b/src/graphql/CheckoutFragment.graphql
@@ -14,7 +14,7 @@ fragment MailingAddressFragment on MailingAddress {
   province
   zip
   name
-  countryCode: countryCodeV2
+  countryCodeV2
   provinceCode
 }
 

--- a/src/graphql/CheckoutFragment.graphql
+++ b/src/graphql/CheckoutFragment.graphql
@@ -23,19 +23,31 @@ fragment CheckoutFragment on Checkout {
   ready
   requiresShipping
   note
-  paymentDue
+  paymentDueV2 {
+    amount
+    currencyCode
+  }
   webUrl
   orderStatusUrl
   taxExempt
   taxesIncluded
   currencyCode
-  totalTax
+  totalTaxV2 {
+    amount
+    currencyCode
+  }
   lineItemsSubtotalPrice {
     amount
     currencyCode
   }
-  subtotalPrice
-  totalPrice
+  subtotalPriceV2 {
+    amount
+    currencyCode
+  }
+  totalPriceV2 {
+    amount
+    currencyCode
+  }
   completedAt
   createdAt
   updatedAt
@@ -56,7 +68,10 @@ fragment CheckoutFragment on Checkout {
   }
   shippingLine {
     handle
-    price
+    priceV2 {
+      amount
+      currencyCode
+    }
     title
   }
   customAttributes {
@@ -67,12 +82,27 @@ fragment CheckoutFragment on Checkout {
     id
     processedAt
     orderNumber
-    subtotalPrice
-    totalShippingPrice
-    totalTax
-    totalPrice
+    subtotalPriceV2 {
+      amount
+      currencyCode
+    }
+    totalShippingPriceV2 {
+      amount
+      currencyCode
+    }
+    totalTaxV2 {
+      amount
+      currencyCode
+    }
+    totalPriceV2 {
+      amount
+      currencyCode
+    }
     currencyCode
-    totalRefunded
+    totalRefundedV2 {
+      amount
+      currencyCode
+    }
     customerUrl
     shippingAddress {
       ...MailingAddressFragment

--- a/src/graphql/CollectionFragment.graphql
+++ b/src/graphql/CollectionFragment.graphql
@@ -7,7 +7,7 @@ fragment CollectionFragment on Collection {
   title
   image {
     id
-    src: originalSrc
+    originalSrc
     altText
   }
 }

--- a/src/graphql/DiscountApplicationFragment.graphql
+++ b/src/graphql/DiscountApplicationFragment.graphql
@@ -11,7 +11,7 @@ fragment DiscountApplicationFragment on DiscountApplication {
     applicable
   }
   ... on ScriptDiscountApplication {
-    description
+    title
   }
   ... on AutomaticDiscountApplication {
     title

--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -24,7 +24,7 @@ fragment ProductFragment on Product {
       cursor
       node {
         id
-        src: originalSrc
+        originalSrc
         altText
       }
     }

--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -24,7 +24,7 @@ fragment ProductFragment on Product {
       cursor
       node {
         id
-        src
+        src: originalSrc
         altText
       }
     }

--- a/src/graphql/VariantFragment.graphql
+++ b/src/graphql/VariantFragment.graphql
@@ -3,12 +3,12 @@ fragment VariantFragment on ProductVariant {
   title
   price
   weight
-  available: availableForSale
+  availableForSale
   sku
   compareAtPrice
   image {
     id
-    src: originalSrc
+    originalSrc
     altText
   }
   selectedOptions {

--- a/src/graphql/VariantFragment.graphql
+++ b/src/graphql/VariantFragment.graphql
@@ -1,11 +1,17 @@
 fragment VariantFragment on ProductVariant {
   id
   title
-  price
+  priceV2 {
+    amount
+    currencyCode
+  }
   weight
   availableForSale
   sku
-  compareAtPrice
+  compareAtPriceV2 {
+    amount
+    currencyCode
+  }
   image {
     id
     originalSrc

--- a/src/graphql/checkoutAttributesUpdateV2Mutation.graphql
+++ b/src/graphql/checkoutAttributesUpdateV2Mutation.graphql
@@ -1,8 +1,5 @@
 mutation checkoutAttributesUpdateV2($checkoutId: ID!, $input: CheckoutAttributesUpdateV2Input!) {
   checkoutAttributesUpdateV2(checkoutId: $checkoutId, input: $input) {
-    userErrors {
-      ...UserErrorFragment
-    }
     checkoutUserErrors {
       ...CheckoutUserErrorFragment
     }

--- a/src/graphql/checkoutCreateMutation.graphql
+++ b/src/graphql/checkoutCreateMutation.graphql
@@ -1,8 +1,5 @@
 mutation ($input: CheckoutCreateInput!) {
   checkoutCreate(input: $input) {
-    userErrors {
-      ...UserErrorFragment
-    }
     checkoutUserErrors {
       ...CheckoutUserErrorFragment
     }

--- a/src/graphql/checkoutDiscountCodeApplyV2Mutation.graphql
+++ b/src/graphql/checkoutDiscountCodeApplyV2Mutation.graphql
@@ -1,8 +1,5 @@
 mutation checkoutDiscountCodeApplyV2($discountCode: String!, $checkoutId: ID!) {
   checkoutDiscountCodeApplyV2(discountCode: $discountCode, checkoutId: $checkoutId) {
-    userErrors {
-      ...UserErrorFragment
-    }
     checkoutUserErrors {
       ...CheckoutUserErrorFragment
     }

--- a/src/graphql/checkoutDiscountCodeRemoveMutation.graphql
+++ b/src/graphql/checkoutDiscountCodeRemoveMutation.graphql
@@ -1,8 +1,5 @@
 mutation checkoutDiscountCodeRemove($checkoutId: ID!) {
   checkoutDiscountCodeRemove(checkoutId: $checkoutId) {
-    userErrors {
-      ...UserErrorFragment
-    }
     checkoutUserErrors {
       ...CheckoutUserErrorFragment
     }

--- a/src/graphql/checkoutEmailUpdateV2Mutation.graphql
+++ b/src/graphql/checkoutEmailUpdateV2Mutation.graphql
@@ -1,8 +1,5 @@
 mutation checkoutEmailUpdateV2($checkoutId: ID!, $email: String!) {
   checkoutEmailUpdateV2(checkoutId: $checkoutId, email: $email) {
-    userErrors {
-      ...UserErrorFragment
-    }
     checkoutUserErrors {
       ...CheckoutUserErrorFragment
     }

--- a/src/graphql/checkoutLineItemsAddMutation.graphql
+++ b/src/graphql/checkoutLineItemsAddMutation.graphql
@@ -1,8 +1,5 @@
 mutation ($checkoutId: ID!, $lineItems: [CheckoutLineItemInput!]!) {
   checkoutLineItemsAdd(checkoutId: $checkoutId, lineItems: $lineItems) {
-    userErrors {
-      ...UserErrorFragment
-    }
     checkoutUserErrors {
       ...CheckoutUserErrorFragment
     }

--- a/src/graphql/checkoutLineItemsRemoveMutation.graphql
+++ b/src/graphql/checkoutLineItemsRemoveMutation.graphql
@@ -1,8 +1,5 @@
 mutation ($checkoutId: ID!, $lineItemIds: [ID!]!) {
   checkoutLineItemsRemove(checkoutId: $checkoutId, lineItemIds: $lineItemIds) {
-    userErrors {
-      ...UserErrorFragment
-    }
     checkoutUserErrors {
       ...CheckoutUserErrorFragment
     }

--- a/src/graphql/checkoutLineItemsUpdateMutation.graphql
+++ b/src/graphql/checkoutLineItemsUpdateMutation.graphql
@@ -1,8 +1,5 @@
 mutation ($checkoutId: ID!, $lineItems: [CheckoutLineItemUpdateInput!]!) {
   checkoutLineItemsUpdate(checkoutId: $checkoutId, lineItems: $lineItems) {
-    userErrors {
-      ...UserErrorFragment
-    }
     checkoutUserErrors {
       ...CheckoutUserErrorFragment
     }

--- a/src/graphql/checkoutShippingAddressUpdateV2Mutation.graphql
+++ b/src/graphql/checkoutShippingAddressUpdateV2Mutation.graphql
@@ -1,8 +1,5 @@
 mutation checkoutShippingAddressUpdateV2($shippingAddress: MailingAddressInput!, $checkoutId: ID!) {
   checkoutShippingAddressUpdateV2(shippingAddress: $shippingAddress, checkoutId: $checkoutId) {
-    userErrors {
-      ...UserErrorFragment
-    }
     checkoutUserErrors {
       ...CheckoutUserErrorFragment
     }

--- a/src/graphql/shopQuery.graphql
+++ b/src/graphql/shopQuery.graphql
@@ -1,6 +1,8 @@
 query {
   shop {
-    currencyCode
+    paymentSettings {
+      currencyCode
+    }
     description
     moneyFormat
     name

--- a/src/graphql/shopQuery.graphql
+++ b/src/graphql/shopQuery.graphql
@@ -2,6 +2,7 @@ query {
   shop {
     paymentSettings {
       currencyCode
+      enabledPresentmentCurrencies
     }
     description
     moneyFormat

--- a/src/shop-resource.js
+++ b/src/shop-resource.js
@@ -12,7 +12,7 @@ import shopPolicyQuery from './graphql/shopPolicyQuery.graphql';
 class ShopResource extends Resource {
 
   /**
-   * Fetches shop information (`currencyCode`, `description`, `moneyFormat`, `name`, and `primaryDomain`).
+   * Fetches shop information (`paymentSettings` (`currencyCode`), `description`, `moneyFormat`, `name`, and `primaryDomain`).
    * See the {@link https://help.shopify.com/api/storefront-api/reference/object/shop|Storefront API reference} for more information.
    *
    * @example

--- a/test/client-checkout-integration-test.js
+++ b/test/client-checkout-integration-test.js
@@ -306,12 +306,6 @@ suite('client-checkout-integration-test', () => {
               code: 'DISCOUNT_NOT_FOUND'
             }
           ],
-          userErrors: [
-            {
-              message: 'Discount code Unable to find a valid discount matching the code entered',
-              field: ['discountCode']
-            }
-          ],
           checkout: null
         }
       }
@@ -393,14 +387,15 @@ suite('client-checkout-integration-test', () => {
     const checkoutCreateWithUserErrorsFixture = {
       data: {
         checkoutCreate: {
-          userErrors: [
+          checkoutUserErrors: [
             {
               message: 'Variant is invalid',
               field: [
                 'lineItems',
                 '0',
                 'variantId'
-              ]
+              ],
+              code: 'INVALID'
             }
           ],
           checkout: null
@@ -419,7 +414,9 @@ suite('client-checkout-integration-test', () => {
     return client.checkout.create(input).then(() => {
       assert.ok(false, 'Promise should not resolve');
     }).catch((error) => {
-      assert.equal(error.message, '[{"message":"Variant is invalid","field":["lineItems","0","variantId"]}]');
+      assert.equal(
+        error.message,
+        '[{"message":"Variant is invalid","field":["lineItems","0","variantId"],"code":"INVALID"}]');
     });
   });
 

--- a/test/client-checkout-integration-test.js
+++ b/test/client-checkout-integration-test.js
@@ -93,9 +93,16 @@ suite('client-checkout-integration-test', () => {
 
     fetchMockPostOnce(fetchMock, apiUrl, checkoutCreateFixture);
 
+    const {
+      amount,
+      currencyCode
+    } = checkoutCreateFixture.data.checkoutCreate.checkout.totalPriceV2;
+
     return client.checkout.create(input).then((checkout) => {
       assert.equal(checkout.id, checkoutCreateFixture.data.checkoutCreate.checkout.id);
       assert.equal(checkout.currencyCode, checkoutCreateFixture.data.checkoutCreate.checkout.currencyCode);
+      assert.equal(amount, checkoutCreateFixture.data.checkoutCreate.checkout.totalPriceV2.amount);
+      assert.equal(currencyCode, checkoutCreateFixture.data.checkoutCreate.checkout.totalPriceV2.currencyCode);
       assert.ok(fetchMock.done());
     });
   });

--- a/test/client-checkout-integration-test.js
+++ b/test/client-checkout-integration-test.js
@@ -87,13 +87,15 @@ suite('client-checkout-integration-test', () => {
           quantity: 5
         }
       ],
-      shippingAddress: {}
+      shippingAddress: {},
+      presentmentCurrencyCode: 'CAD'
     };
 
     fetchMockPostOnce(fetchMock, apiUrl, checkoutCreateFixture);
 
     return client.checkout.create(input).then((checkout) => {
       assert.equal(checkout.id, checkoutCreateFixture.data.checkoutCreate.checkout.id);
+      assert.equal(checkout.currencyCode, checkoutCreateFixture.data.checkoutCreate.checkout.currencyCode);
       assert.ok(fetchMock.done());
     });
   });

--- a/test/client-integration-test.js
+++ b/test/client-integration-test.js
@@ -254,6 +254,7 @@ suite('client-integration-test', () => {
     return client.shop.fetchInfo().then((shop) => {
       assert.equal(shop.name, shopInfoFixture.data.shop.name);
       assert.equal(shop.description, shopInfoFixture.data.shop.description);
+      assert.equal(shop.enabledPresentmentCurrencies, shopInfoFixture.data.shop.enabledPresentmentCurrencies);
       assert.ok(fetchMock.done());
     });
   });


### PR DESCRIPTION
- Removed existing field aliasing for `countryCodeV2`, `originalSrc`, and `availableForSale` fields. The names of these returned fields now match the names present in the [Storefront API reference](https://help.shopify.com/en/api/custom-storefronts/storefront-api/reference) and the Shopify GraphQL schema.
- Remove deprecated `currencyCode` on Shop in favour of `paymentSettings.currencyCode`
- Remove deprecated price and compareAtPrice on ProductVariant in favour of priceV2 (MoneyV2!) and compareAtPriceV2 (MoneyV2!)
- Remove deprecated pricing fields on Checkout in favour of MoneyV2-typed fields.
- Remove deprecated pricing fields on Order in favour of MoneyV2-type fields.
- Add support for `enabledPresentmentCurrencies` on paymentSettings.

This PR marks the removal of all Money-typed pricing fields in the SDK. After this PR ships, all existing pricing fields returned by the SDK will be of type MoneyV2.

A PR to package for release version 3.0.0 (update changelog and docs) will follow when this PR is merged.