### PR TITLE
Gift Cards addition and removal

### DIFF
--- a/fixtures/checkout-gift-card-remove-fixture.js
+++ b/fixtures/checkout-gift-card-remove-fixture.js
@@ -1,0 +1,91 @@
+export default {
+  "data": {
+    "checkoutGiftCardRemoveV2": {
+      "checkoutUserErrors": [],
+      "userErrors": [],
+      "checkout": {
+        "id": "Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",
+        "appliedGiftCards": [],
+        "createdAt": "2017-03-17T16:00:40Z",
+        "updatedAt": "2017-03-17T16:00:40Z",
+        "requiresShipping": true,
+        "shippingLine": null,
+        "order": null,
+        "orderStatusUrl": null,
+        "taxExempt": false,
+        "taxesIncluded": false,
+        "currencyCode": "CAD",
+        "totalPrice": "80.28",
+        "lineItemsSubtotalPrice": {
+          "amount": "74.99",
+          "currencyCode": "CAD"
+        },
+        "subtotalPrice": "67.50",
+        "totalTax": "8.78",
+        "paymentDue": "80.28",
+        "taxExempt": false,
+        "taxesIncluded": false,
+        "completedAt": null,
+        "shippingAddress": {
+          "address1": "123 Cat Road",
+          "address2": null,
+          "city": "Cat Land",
+          "company": "Catmart",
+          "country": "Canada",
+          "firstName": "Meow",
+          "formatted": [
+            "Catmart",
+            "123 Cat Road",
+            "Cat Land ON M3O 0W1",
+            "Canada"
+          ],
+          "lastName": "Meowington",
+          "latitude": null,
+          "longitude": null,
+          "phone": "4161234566",
+          "province": "Ontario",
+          "zip": "M3O 0W1",
+          "name": "Meow Meowington",
+          "countryCode": "CA",
+          "provinceCode": "ON",
+          "id": "291dC9lM2JkNzHJnnf8a89njNJNKAhu1gn7lMzM5MzFlZj9rZXk9NDcwOTJ=="
+        },
+        "lineItems": {
+          "pageInfo": {
+            "hasNextPage": false,
+            "hasPreviousPage": false
+          },
+          "edges": [
+            {
+              "cursor": "eyJsYXN0X2lkIjoiZDUyZWU5ZTEwYmQxMWE0NDlkNmQzMWNkMzBhMGFjNzMifQ==",
+              "node": {
+                "title": "Intelligent Granite Table",
+                "variant": {
+                  "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
+                  "price": "74.99"
+                },
+                "quantity": 5,
+                "customAttributes": [],
+                "discountAllocations": [
+                  {
+                    "allocatedAmount": {
+                      "amount": "7.49",
+                      "currencyCode": "CAD"
+                    },
+                    "discountApplication": {
+                      "targetSelection": "ALL",
+                      "allocationMethod": "ACROSS",
+                      "targetType": "LINE_ITEM",
+                      "code": "TENPERCENTOFF",
+                      "applicable": true
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+};

--- a/fixtures/checkout-gift-cards-apply-fixture.js
+++ b/fixtures/checkout-gift-cards-apply-fixture.js
@@ -1,0 +1,116 @@
+export default {
+  "data": {
+    "checkoutGiftCardsAppend": {
+      "checkoutUserErrors": [],
+      "userErrors": [],
+      "checkout": {
+        "id": "Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",
+        "appliedGiftCards": [
+          {
+            "amountUsedV2": {
+              "amount": "45.0",
+              "currencyCode": "USD"
+            },
+            "balanceV2": {
+              "amount": "45.0",
+              "currencyCode": "USD"
+            },
+            "id": "Z2lkOi8vc2hvcGlmeS9BcHBsaWVkR2lmdENhcmQvNDI4NTQ1ODAzMTI=",
+            "lastCharacters": "949f"
+          },
+          {
+            "amountUsedV2": {
+              "amount": "96.18",
+              "currencyCode": "USD"
+            },
+            "balanceV2": {
+              "amount": "6000.12",
+              "currencyCode": "USD"
+            },
+            "id": "Z2lkOi8vc2hvcGlmeS9BcHBsaWVkR2lmdENhcmQvNDI4NTQ2MTMwODc=",
+            "lastCharacters": "hb6a"
+          }
+        ],
+        "createdAt": "2017-03-17T16:00:40Z",
+        "updatedAt": "2017-03-17T16:00:40Z",
+        "requiresShipping": true,
+        "shippingLine": null,
+        "order": null,
+        "orderStatusUrl": null,
+        "taxExempt": false,
+        "taxesIncluded": false,
+        "currencyCode": "CAD",
+        "totalPrice": "80.28",
+        "lineItemsSubtotalPrice": {
+          "amount": "74.99",
+          "currencyCode": "CAD"
+        },
+        "subtotalPrice": "67.50",
+        "totalTax": "8.78",
+        "paymentDue": "80.28",
+        "taxExempt": false,
+        "taxesIncluded": false,
+        "completedAt": null,
+        "shippingAddress": {
+          "address1": "123 Cat Road",
+          "address2": null,
+          "city": "Cat Land",
+          "company": "Catmart",
+          "country": "Canada",
+          "firstName": "Meow",
+          "formatted": [
+            "Catmart",
+            "123 Cat Road",
+            "Cat Land ON M3O 0W1",
+            "Canada"
+          ],
+          "lastName": "Meowington",
+          "latitude": null,
+          "longitude": null,
+          "phone": "4161234566",
+          "province": "Ontario",
+          "zip": "M3O 0W1",
+          "name": "Meow Meowington",
+          "countryCode": "CA",
+          "provinceCode": "ON",
+          "id": "291dC9lM2JkNzHJnnf8a89njNJNKAhu1gn7lMzM5MzFlZj9rZXk9NDcwOTJ=="
+        },
+        "lineItems": {
+          "pageInfo": {
+            "hasNextPage": false,
+            "hasPreviousPage": false
+          },
+          "edges": [
+            {
+              "cursor": "eyJsYXN0X2lkIjoiZDUyZWU5ZTEwYmQxMWE0NDlkNmQzMWNkMzBhMGFjNzMifQ==",
+              "node": {
+                "title": "Intelligent Granite Table",
+                "variant": {
+                  "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
+                  "price": "74.99"
+                },
+                "quantity": 5,
+                "customAttributes": [],
+                "discountAllocations": [
+                  {
+                    "allocatedAmount": {
+                      "amount": "7.49",
+                      "currencyCode": "CAD"
+                    },
+                    "discountApplication": {
+                      "targetSelection": "ALL",
+                      "allocationMethod": "ACROSS",
+                      "targetType": "LINE_ITEM",
+                      "code": "TENPERCENTOFF",
+                      "applicable": true
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+};

--- a/src/checkout-resource.js
+++ b/src/checkout-resource.js
@@ -12,6 +12,7 @@ import checkoutLineItemsUpdateMutation from './graphql/checkoutLineItemsUpdateMu
 import checkoutAttributesUpdateV2Mutation from './graphql/checkoutAttributesUpdateV2Mutation.graphql';
 import checkoutDiscountCodeApplyV2Mutation from './graphql/checkoutDiscountCodeApplyV2Mutation.graphql';
 import checkoutDiscountCodeRemoveMutation from './graphql/checkoutDiscountCodeRemoveMutation.graphql';
+import checkoutGiftCardsAppendMutation from './graphql/checkoutGiftCardsAppendMutation.graphql';
 import checkoutEmailUpdateV2Mutation from './graphql/checkoutEmailUpdateV2Mutation.graphql';
 import checkoutShippingAddressUpdateV2Mutation from './graphql/checkoutShippingAddressUpdateV2Mutation.graphql';
 
@@ -179,6 +180,27 @@ class CheckoutResource extends Resource {
     return this.graphQLClient
       .send(checkoutDiscountCodeRemoveMutation, {checkoutId})
       .then(handleCheckoutMutation('checkoutDiscountCodeRemove', this.graphQLClient));
+  }
+
+  /**
+   * Applies gift cards to an existing checkout using a list of gift card codes
+   *
+   * @example
+   * const checkoutId = 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9kMTZmM2EzMDM4Yjc4N=';
+   * const giftCardCodes = ['6FD8853DAGAA949F'];
+   *
+   * client.checkout.addGiftCards(checkoutId, giftCardCodes).then((checkout) => {
+   *   // Do something with the updated checkout
+   * });
+   *
+   * @param {String} checkoutId The ID of the checkout to add gift cards to.
+   * @param {String[]} giftCardCodes The gift card codes to apply to the checkout.
+   * @return {Promise|GraphModel} A promise resolving with the updated checkout.
+   */
+  addGiftCards(checkoutId, giftCardCodes) {
+    return this.graphQLClient
+      .send(checkoutGiftCardsAppendMutation, {checkoutId, giftCardCodes})
+      .then(handleCheckoutMutation('checkoutGiftCardsAppend', this.graphQLClient));
   }
 
   /**

--- a/src/checkout-resource.js
+++ b/src/checkout-resource.js
@@ -13,6 +13,7 @@ import checkoutAttributesUpdateV2Mutation from './graphql/checkoutAttributesUpda
 import checkoutDiscountCodeApplyV2Mutation from './graphql/checkoutDiscountCodeApplyV2Mutation.graphql';
 import checkoutDiscountCodeRemoveMutation from './graphql/checkoutDiscountCodeRemoveMutation.graphql';
 import checkoutGiftCardsAppendMutation from './graphql/checkoutGiftCardsAppendMutation.graphql';
+import checkoutGiftCardRemoveV2Mutation from './graphql/checkoutGiftCardRemoveV2Mutation.graphql';
 import checkoutEmailUpdateV2Mutation from './graphql/checkoutEmailUpdateV2Mutation.graphql';
 import checkoutShippingAddressUpdateV2Mutation from './graphql/checkoutShippingAddressUpdateV2Mutation.graphql';
 
@@ -201,6 +202,27 @@ class CheckoutResource extends Resource {
     return this.graphQLClient
       .send(checkoutGiftCardsAppendMutation, {checkoutId, giftCardCodes})
       .then(handleCheckoutMutation('checkoutGiftCardsAppend', this.graphQLClient));
+  }
+
+  /**
+   * Remove a gift card from an existing checkout
+   *
+   * @example
+   * const checkoutId = 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9kMTZmM2EzMDM4Yjc4N=';
+   * const giftCardId = 'Z2lkOi8vc2hvcGlmeS9BcHBsaWVkR2lmdENhcmQvNDI4NTQ1ODAzMTI=';
+   *
+   * client.checkout.removeGiftCard(checkoutId, appliedGiftCardId).then((checkout) => {
+   *   // Do something with the updated checkout
+   * });
+   *
+   * @param {String} checkoutId The ID of the checkout to add gift cards to.
+   * @param {String} giftCardId The gift card id to remove from the checkout.
+   * @return {Promise|GraphModel} A promise resolving with the updated checkout.
+   */
+  removeGiftCard(checkoutId, appliedGiftCardId) {
+    return this.graphQLClient
+      .send(checkoutGiftCardRemoveV2Mutation, {checkoutId, appliedGiftCardId})
+      .then(handleCheckoutMutation('checkoutGiftCardRemoveV2', this.graphQLClient));
   }
 
   /**

--- a/src/graphql/AppliedGiftCardFragment.graphql
+++ b/src/graphql/AppliedGiftCardFragment.graphql
@@ -1,0 +1,12 @@
+fragment AppliedGiftCardFragment on AppliedGiftCard {
+  amountUsedV2 {
+    amount
+    currencyCode
+  }
+  balanceV2 {
+    amount
+    currencyCode
+  }
+  id
+  lastCharacters
+}

--- a/src/graphql/CheckoutFragment.graphql
+++ b/src/graphql/CheckoutFragment.graphql
@@ -51,6 +51,9 @@ fragment CheckoutFragment on Checkout {
       }
     }
   }
+  appliedGiftCards {
+    ...AppliedGiftCardFragment
+  }
   shippingAddress {
     ...MailingAddressFragment
   }

--- a/src/graphql/checkoutGiftCardRemoveV2Mutation.graphql
+++ b/src/graphql/checkoutGiftCardRemoveV2Mutation.graphql
@@ -1,0 +1,13 @@
+mutation checkoutGiftCardRemoveV2($appliedGiftCardId: ID!, $checkoutId: ID!) {
+  checkoutGiftCardRemoveV2(appliedGiftCardId: $appliedGiftCardId, checkoutId: $checkoutId) {
+    userErrors {
+      ...UserErrorFragment
+    }
+    checkoutUserErrors {
+      ...CheckoutUserErrorFragment
+    }
+    checkout {
+      ...CheckoutFragment
+    }
+  }
+}

--- a/src/graphql/checkoutGiftCardsAppendMutation.graphql
+++ b/src/graphql/checkoutGiftCardsAppendMutation.graphql
@@ -1,0 +1,13 @@
+mutation checkoutGiftCardsAppend($giftCardCodes: [String!]!, $checkoutId: ID!) {
+  checkoutGiftCardsAppend(giftCardCodes: $giftCardCodes, checkoutId: $checkoutId) {
+    userErrors {
+      ...UserErrorFragment
+    }
+    checkoutUserErrors {
+      ...CheckoutUserErrorFragment
+    }
+    checkout {
+      ...CheckoutFragment
+    }
+  }
+}

--- a/test/client-checkout-integration-test.js
+++ b/test/client-checkout-integration-test.js
@@ -24,6 +24,7 @@ import checkoutUpdateEmailV2WithUserErrorsFixture from '../fixtures/checkout-upd
 import checkoutDiscountCodeApplyV2Fixture from '../fixtures/checkout-discount-code-apply-fixture';
 import checkoutDiscountCodeRemoveFixture from '../fixtures/checkout-discount-code-remove-fixture';
 import checkoutGiftCardsAppendFixture from '../fixtures/checkout-gift-cards-apply-fixture';
+import checkoutGiftCardRemoveV2Fixture from '../fixtures/checkout-gift-card-remove-fixture';
 import checkoutShippingAddressUpdateV2Fixture from '../fixtures/checkout-shipping-address-update-v2-fixture';
 import checkoutShippingAdddressUpdateV2WithUserErrorsFixture from '../fixtures/checkout-shipping-address-update-v2-with-user-errors-fixture';
 
@@ -382,6 +383,52 @@ suite('client-checkout-integration-test', () => {
       assert.ok(false, 'Promise should not resolve');
     }).catch((error) => {
       assert.equal(error.message, '[{"message":"Code is invalid","field":["giftCardCodes","0"],"code":"GIFT_CARD_CODE_INVALID"}]');
+    });
+  });
+
+  test('it resolves with a checkout on Client.checkout#removeGiftCard', () => {
+    const checkoutId = checkoutGiftCardRemoveV2Fixture.data.checkoutGiftCardRemoveV2.checkout.id;
+    const appliedGiftCardId = 'Z2lkOi8vc2hvcGlmeS9BcHBsaWVkR2lmdENhcmQvNDI4NTQ1ODAzMTI=';
+
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutGiftCardRemoveV2Fixture);
+
+    return client.checkout.removeGiftCard(checkoutId, appliedGiftCardId).then((checkout) => {
+      assert.equal(checkout.id, checkoutId);
+      assert.ok(fetchMock.done());
+    });
+  });
+
+  test('it resolves with checkoutUserErrors on Client.checkout#removeGiftCard with a code not present', () => {
+    const checkoutGiftCardsRemoveV2WithCheckoutUserErrorsFixture = {
+      data: {
+        checkoutGiftCardRemoveV2: {
+          checkoutUserErrors: [
+            {
+              message: 'Applied Gift Card not found',
+              field: null,
+              code: 'GIFT_CARD_NOT_FOUND'
+            }
+          ],
+          userErrors: [
+            {
+              message: 'Applied Gift Card not found',
+              field: null
+            }
+          ],
+          checkout: null
+        }
+      }
+    };
+
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutGiftCardsRemoveV2WithCheckoutUserErrorsFixture);
+
+    const checkoutId = checkoutGiftCardRemoveV2Fixture.data.checkoutGiftCardRemoveV2.checkout.id;
+    const appliedGiftCardId = 'Z2lkOi8vc2hvcGlmeS9BcHBsaWVkR2lmdENhcmQvNDI4NTQ1ODAzMTI=';
+
+    return client.checkout.removeGiftCard(checkoutId, appliedGiftCardId).then(() => {
+      assert.ok(false, 'Promise should not resolve');
+    }).catch((error) => {
+      assert.equal(error.message, '[{"message":"Applied Gift Card not found","field":null,"code":"GIFT_CARD_NOT_FOUND"}]');
     });
   });
 

--- a/test/client-checkout-integration-test.js
+++ b/test/client-checkout-integration-test.js
@@ -23,6 +23,7 @@ import checkoutUpdateEmailV2Fixture from '../fixtures/checkout-update-email-fixt
 import checkoutUpdateEmailV2WithUserErrorsFixture from '../fixtures/checkout-update-email-with-user-errors-fixture';
 import checkoutDiscountCodeApplyV2Fixture from '../fixtures/checkout-discount-code-apply-fixture';
 import checkoutDiscountCodeRemoveFixture from '../fixtures/checkout-discount-code-remove-fixture';
+import checkoutGiftCardsAppendFixture from '../fixtures/checkout-gift-cards-apply-fixture';
 import checkoutShippingAddressUpdateV2Fixture from '../fixtures/checkout-shipping-address-update-v2-fixture';
 import checkoutShippingAdddressUpdateV2WithUserErrorsFixture from '../fixtures/checkout-shipping-address-update-v2-with-user-errors-fixture';
 
@@ -335,6 +336,52 @@ suite('client-checkout-integration-test', () => {
     return client.checkout.removeDiscount(checkoutId).then((checkout) => {
       assert.equal(checkout.id, checkoutId);
       assert.ok(fetchMock.done());
+    });
+  });
+
+  test('it resolves with a checkout on Client.checkout#addGiftCards', () => {
+    const checkoutId = checkoutGiftCardsAppendFixture.data.checkoutGiftCardsAppend.checkout.id;
+    const giftCardCodes = ['H8HA 6H9F HBA8 F2FC', '6FD8 835D AAGA 949F'];
+
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutGiftCardsAppendFixture);
+
+    return client.checkout.addGiftCards(checkoutId, giftCardCodes).then((checkout) => {
+      assert.equal(checkout.id, checkoutId);
+      assert.ok(fetchMock.done());
+    });
+  });
+
+  test('it resolves with checkoutUserErrors on Client.checkout#addGiftCards with an invalid code', () => {
+    const checkoutGiftCardsApppendWithCheckoutUserErrorsFixture = {
+      data: {
+        checkoutGiftCardsAppend: {
+          checkoutUserErrors: [
+            {
+              message: 'Code is invalid',
+              field: ['giftCardCodes', '0'],
+              code: 'GIFT_CARD_CODE_INVALID'
+            }
+          ],
+          userErrors: [
+            {
+              message: 'Code is invalid',
+              field: ['giftCardCodes', '0']
+            }
+          ],
+          checkout: null
+        }
+      }
+    };
+
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutGiftCardsApppendWithCheckoutUserErrorsFixture);
+
+    const checkoutId = checkoutGiftCardsAppendFixture.data.checkoutGiftCardsAppend.checkout.id;
+    const giftCardCode = 'INVALIDCODE';
+
+    return client.checkout.addGiftCards(checkoutId, [giftCardCode]).then(() => {
+      assert.ok(false, 'Promise should not resolve');
+    }).catch((error) => {
+      assert.equal(error.message, '[{"message":"Code is invalid","field":["giftCardCodes","0"],"code":"GIFT_CARD_CODE_INVALID"}]');
     });
   });
 


### PR DESCRIPTION
Greetings,

this PR adds support for `Client.checkout#addGiftCards`, which allows clients to add gift cards to a checkout using their codes, and `Client.checkout#removeGiftCard`, which allows clients to remove a previously added gift card from a checkout using the addition id. This also adds the applied gift cards to `checkoutFragment`. This is meant as a natural companion to the apply/remove discount code methods.

Basic success / failure integration tests and their fixtures are also included.

I've left three separated commits: one for `addGiftCards`, one for the added field on the checkout fragment, one for `removeGiftCard`. This is to make it easy to separate them in case you prefer different pull request, but can obviously be squashed if it's not needed.
