### PR TITLE
Add multicurrency fields to queries

### DIFF
--- a/src/graphql/AppliedGiftCardFragment.graphql
+++ b/src/graphql/AppliedGiftCardFragment.graphql
@@ -7,6 +7,10 @@ fragment AppliedGiftCardFragment on AppliedGiftCard {
     amount
     currencyCode
   }
+  presentmentAmountUsed {
+    amount
+    currencyCode
+  }
   id
   lastCharacters
 }

--- a/src/graphql/CheckoutFragment.graphql
+++ b/src/graphql/CheckoutFragment.graphql
@@ -24,18 +24,34 @@ fragment CheckoutFragment on Checkout {
   requiresShipping
   note
   paymentDue
+  paymentDueV2 {
+    amount
+    currencyCode
+  }
   webUrl
   orderStatusUrl
   taxExempt
   taxesIncluded
   currencyCode
   totalTax
+  totalTaxV2 {
+    amount
+    currencyCode
+  }
   lineItemsSubtotalPrice {
     amount
     currencyCode
   }
   subtotalPrice
+  subtotalPriceV2 {
+    amount
+    currencyCode
+  }
   totalPrice
+  totalPriceV2 {
+    amount
+    currencyCode
+  }
   completedAt
   createdAt
   updatedAt
@@ -71,11 +87,31 @@ fragment CheckoutFragment on Checkout {
     processedAt
     orderNumber
     subtotalPrice
+    subtotalPriceV2 {
+      amount
+      currencyCode
+    }
     totalShippingPrice
+    totalShippingPriceV2 {
+      amount
+      currencyCode
+    }
     totalTax
+    totalTaxV2 {
+      amount
+      currencyCode
+    }
     totalPrice
+    totalPriceV2 {
+      amount
+      currencyCode
+    }
     currencyCode
     totalRefunded
+    totalRefundedV2 {
+      amount
+      currencyCode
+    }
     customerUrl
     shippingAddress {
       ...MailingAddressFragment

--- a/src/graphql/VariantFragment.graphql
+++ b/src/graphql/VariantFragment.graphql
@@ -2,6 +2,20 @@ fragment VariantFragment on ProductVariant {
   id
   title
   price
+  presentmentPrices(first: 20) {
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+    }
+    edges {
+      node {
+        price {
+          amount
+          currencyCode
+        }
+      }
+    }
+  }
   weight
   available: availableForSale
   sku

--- a/src/graphql/shopQuery.graphql
+++ b/src/graphql/shopQuery.graphql
@@ -1,6 +1,9 @@
 query {
   shop {
     currencyCode
+    paymentSettings {
+      enabledPresentmentCurrencies
+    }
     description
     moneyFormat
     name


### PR DESCRIPTION
Add multicurrency fields and connections to queries:

AppliedGiftCard: `presentmentAmountUsed`.
Checkout: `paymentDueV2`, `totalTaxV2`, `subtotalPriceV2`, `totalPriceV2`.
Order: `subtotalPriceV2`, `totalShippingPriceV2`, `totalTaxV2`, `totalPriceV2`, `totalRefundedV2`.
Variant: `presentmentPrices`.
Shop: `paymentSettings` (that includes `enabledPresentmentCurrencies`)