### PR TITLE
Add help center 'Getting started' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,8 @@ There are JS Buy SDK specific example apps in Node, Ember, and React. You can us
 
 ## Documentation
 
-For full API documentation go check out the [API docs](https://shopify.github.io/js-buy-sdk).
+- [Getting started guide](https://help.shopify.com/en/api/storefront-api/tools/js-buy-sdk/getting-started)
+- [API documentation](https://shopify.github.io/js-buy-sdk).
 
 ## Contributing
 For help on setting up the repo locally, building, testing, and contributing


### PR DESCRIPTION
Adds a link to the Help Center's JS Buy SDK "Getting started" guide to the `readme`.
Issue: https://github.com/Shopify/help/issues/7359