### PR TITLE
Queries go to /api/2019-07/graphql

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -39,7 +39,7 @@ class Client {
    * @param {Config} config An instance of {@link Config} used to configure the Client.
    */
   constructor(config, GraphQLClientClass = GraphQLJSClient, fetchFunction) {
-    const url = `https://${config.domain}/api/graphql`;
+    const url = `https://${config.domain}/api/${config.apiVersion}/graphql`;
 
     const headers = {
       'X-SDK-Variant': 'javascript',

--- a/src/config.js
+++ b/src/config.js
@@ -53,6 +53,12 @@ class Config {
         throw new Error(`new Config() requires the option '${key}'`);
       }
     });
+
+    if (attrs.hasOwnProperty('apiVersion')) {
+      this.apiVersion = attrs.apiVersion;
+    } else {
+      this.apiVersion = '2019-07';
+    }
   }
 }
 

--- a/test/client-checkout-integration-test.js
+++ b/test/client-checkout-integration-test.js
@@ -30,7 +30,8 @@ import checkoutShippingAdddressUpdateV2WithUserErrorsFixture from '../fixtures/c
 
 suite('client-checkout-integration-test', () => {
   const domain = 'client-integration-tests.myshopify.io';
-  const apiUrl = `https://${domain}/api/graphql`;
+  const apiVersion = '2019-07';
+  const apiUrl = `https://${domain}/api/${apiVersion}/graphql`;
   const config = {
     storefrontAccessToken: 'abc123',
     domain

--- a/test/client-integration-test.js
+++ b/test/client-integration-test.js
@@ -23,7 +23,8 @@ import shopPoliciesFixture from '../fixtures/shop-policies-fixture';
 
 suite('client-integration-test', () => {
   const domain = 'client-integration-tests.myshopify.io';
-  const apiUrl = `https://${domain}/api/graphql`;
+  const apiVersion = '2019-07';
+  const apiUrl = `https://${domain}/api/${apiVersion}/graphql`;
   const config = {
     storefrontAccessToken: 'abc123',
     domain

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -27,7 +27,7 @@ suite('client-test', () => {
     new Client(new Config(config), FakeGraphQLJSClient); // eslint-disable-line no-new
 
     assert.deepEqual(passedTypeBundle, types);
-    assert.equal(passedUrl, 'https://sendmecats.myshopify.com/api/graphql');
+    assert.equal(passedUrl, 'https://sendmecats.myshopify.com/api/2019-07/graphql');
     assert.deepEqual(passedFetcherOptions, {
       headers: {
         'X-SDK-Variant': 'javascript',
@@ -64,7 +64,7 @@ suite('client-test', () => {
     new Client(new Config(config), FakeGraphQLJSClient, fetchFunction); // eslint-disable-line no-new
 
     return passedFetcher({data: 'body'}).then(() => {
-      assert.equal(passedUrl, 'https://sendmecats.myshopify.com/api/graphql');
+      assert.equal(passedUrl, 'https://sendmecats.myshopify.com/api/2019-07/graphql');
       assert.equal(passedBody, JSON.stringify({data: 'body'}));
       assert.equal(passedMethod, 'POST');
       assert.equal(passedMode, 'cors');

--- a/test/product-helpers-test.js
+++ b/test/product-helpers-test.js
@@ -6,7 +6,7 @@ import singleProductFixture from '../fixtures/product-fixture';
 import types from '../schema.json';
 
 suite('product-helpers-test', () => {
-  const graphQLClient = new GraphQLJSClient(types, {url: 'https://sendmecats.myshopify.com/api/graphql'});
+  const graphQLClient = new GraphQLJSClient(types, {url: 'https://sendmecats.myshopify.com/api/2019-07/graphql'});
   const query = productNodeQuery(graphQLClient)
     .definitions
     .find((definition) => definition.operationType === 'query');


### PR DESCRIPTION
Good find by @jmignac! All requests should be made to `/api/2019-07/graphql`. 
