### PR TITLE
Add priceV2 and compareAtPriceV2 to variant fragment

### DIFF
--- a/fixtures/collection-with-products-fixture.js
+++ b/fixtures/collection-with-products-fixture.js
@@ -100,6 +100,14 @@ export default {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNTk3Ng==",
                       "title": "Fluffy / Medium",
                       "price": "0.00",
+                      "priceV2": {
+                        "amount": "0.00",
+                        "currencyCode": "CAD"
+                      },
+                      "compareAtPriceV2": {
+                        "amount": "5.00",
+                        "currencyCode": "CAD"
+                      },
                       "weight": 18,
                       "image": {
                         "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
@@ -124,6 +132,14 @@ export default {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNjA0MA==",
                       "title": "Extra Fluffy / Small",
                       "price": "0.00",
+                      "priceV2": {
+                        "amount": "0.00",
+                        "currencyCode": "CAD"
+                      },
+                      "compareAtPriceV2": {
+                        "amount": "5.00",
+                        "currencyCode": "CAD"
+                      },
                       "weight": 18,
                       "image": {
                         "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
@@ -148,6 +164,14 @@ export default {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNjEwNA==",
                       "title": "Mega Fluff / Large",
                       "price": "0.00",
+                      "priceV2": {
+                        "amount": "0.00",
+                        "currencyCode": "CAD"
+                      },
+                      "compareAtPriceV2": {
+                        "amount": "5.00",
+                        "currencyCode": "CAD"
+                      },
                       "weight": 0,
                       "image": {
                         "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
@@ -220,6 +244,14 @@ export default {
                       "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTkzNzExMjEzNg==",
                       "title": "Default Title",
                       "price": "0.00",
+                      "priceV2": {
+                        "amount": "0.00",
+                        "currencyCode": "CAD"
+                      },
+                      "compareAtPriceV2": {
+                        "amount": "5.00",
+                        "currencyCode": "CAD"
+                      },
                       "weight": 0,
                       "image": null,
                       "selectedOptions": [

--- a/fixtures/dynamic-product-fixture.js
+++ b/fixtures/dynamic-product-fixture.js
@@ -52,6 +52,14 @@ export default {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NTk3MjA=",
               "price": "0.00",
+              "priceV2": {
+                "amount": "0.00",
+                "currencyCode": "CAD"
+              },
+              "compareAtPriceV2": {
+                "amount": "5.00",
+                "currencyCode": "CAD"
+              },
               "weight": 18
             }
           },
@@ -60,6 +68,14 @@ export default {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
               "price": "0.00",
+              "priceV2": {
+                "amount": "0.00",
+                "currencyCode": "CAD"
+              },
+              "compareAtPriceV2": {
+                "amount": "5.00",
+                "currencyCode": "CAD"
+              },
               "weight": 18
             }
           },
@@ -68,6 +84,14 @@ export default {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI4MjkzODQ=",
               "price": "0.00",
+              "priceV2": {
+                "amount": "0.00",
+                "currencyCode": "CAD"
+              },
+              "compareAtPriceV2": {
+                "amount": "5.00",
+                "currencyCode": "CAD"
+              },
               "weight": 0
             }
           }

--- a/fixtures/paginated-variants-fixtures.js
+++ b/fixtures/paginated-variants-fixtures.js
@@ -15,6 +15,14 @@ export const secondPageVariantsFixture = {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
               "title": "Extra Fluffy",
               "price": "0.00",
+              "priceV2": {
+                "amount": "0.00",
+                "currencyCode": "CAD"
+              },
+              "compareAtPriceV2": {
+                "amount": "5.00",
+                "currencyCode": "CAD"
+              },
               "weight": 18,
               "image": null,
               "selectedOptions": [
@@ -48,6 +56,14 @@ export const thirdPageVariantsFixture = {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NTk3MjA=",
               "title": "Mega Fluff",
               "price": "0.00",
+              "priceV2": {
+                "amount": "0.00",
+                "currencyCode": "CAD"
+              },
+              "compareAtPriceV2": {
+                "amount": "5.00",
+                "currencyCode": "CAD"
+              },
               "weight": 0,
               "image": null,
               "selectedOptions": [

--- a/fixtures/product-by-handle-fixture.js
+++ b/fixtures/product-by-handle-fixture.js
@@ -107,6 +107,14 @@ export default {
               "available": true,
               "weight": 0,
               "price": "788.00",
+              "priceV2": {
+                "amount": "788.00",
+                "currencyCode": "CAD"
+              },
+              "compareAtPriceV2": {
+                "amount": "888.00",
+                "currencyCode": "CAD"
+              },
               "title": "Black / X-Small",
               "image": null,
               "selectedOptions": [
@@ -127,6 +135,14 @@ export default {
               "available": true,
               "weight": 0,
               "price": "788.00",
+              "priceV2": {
+                "amount": "788.00",
+                "currencyCode": "CAD"
+              },
+              "compareAtPriceV2": {
+                "amount": "888.00",
+                "currencyCode": "CAD"
+              },
               "title": "Black / Small",
               "image": null,
               "selectedOptions": [
@@ -147,6 +163,14 @@ export default {
               "available": false,
               "weight": 0,
               "price": "788.00",
+              "priceV2": {
+                "amount": "788.00",
+                "currencyCode": "CAD"
+              },
+              "compareAtPriceV2": {
+                "amount": "888.00",
+                "currencyCode": "CAD"
+              },
               "title": "Black / Medium",
               "image": null,
               "selectedOptions": [
@@ -167,6 +191,14 @@ export default {
               "available": true,
               "weight": 0,
               "price": "750.00",
+              "priceV2": {
+                "amount": "750.00",
+                "currencyCode": "CAD"
+              },
+              "compareAtPriceV2": {
+                "amount": "850.00",
+                "currencyCode": "CAD"
+              },
               "title": "Dark Green / X-Small",
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg0MjI=",
@@ -190,6 +222,14 @@ export default {
               "available": false,
               "weight": 0,
               "price": "750.00",
+              "priceV2": {
+                "amount": "750.00",
+                "currencyCode": "CAD"
+              },
+              "compareAtPriceV2": {
+                "amount": "850.00",
+                "currencyCode": "CAD"
+              },
               "title": "Dark Green / Small",
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg2MTQ=",
@@ -213,6 +253,14 @@ export default {
               "available": true,
               "weight": 0,
               "price": "788.00",
+              "priceV2": {
+                "amount": "788.00",
+                "currencyCode": "CAD"
+              },
+              "compareAtPriceV2": {
+                "amount": "888.00",
+                "currencyCode": "CAD"
+              },
               "title": "Dark Green / Medium",
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg1NTA=",
@@ -236,6 +284,14 @@ export default {
               "available": true,
               "weight": 0,
               "price": "788.00",
+              "priceV2": {
+                "amount": "788.00",
+                "currencyCode": "CAD"
+              },
+              "compareAtPriceV2": {
+                "amount": "888.00",
+                "currencyCode": "CAD"
+              },
               "title": "Dark Green / Large",
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMjI5MzI5MDg0ODY=",

--- a/fixtures/product-fixture.js
+++ b/fixtures/product-fixture.js
@@ -85,6 +85,14 @@ export default {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
               "title": "Fluffy / Medium",
               "price": "0.00",
+              "priceV2": {
+                "amount": "0.00",
+                "currencyCode": "CAD"
+              },
+              "compareAtPriceV2": {
+                "amount": "5.00",
+                "currencyCode": "CAD"
+              },
               "weight": 18,
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
@@ -109,6 +117,14 @@ export default {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
               "title": "Extra Fluffy / Small",
               "price": "0.00",
+              "priceV2": {
+                "amount": "0.00",
+                "currencyCode": "CAD"
+              },
+              "compareAtPriceV2": {
+                "amount": "5.00",
+                "currencyCode": "CAD"
+              },
               "weight": 18,
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
@@ -133,6 +149,14 @@ export default {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
               "title": "Mega Fluff / Large",
               "price": "0.00",
+              "priceV2": {
+                "amount": "0.00",
+                "currencyCode": "CAD"
+              },
+              "compareAtPriceV2": {
+                "amount": "5.00",
+                "currencyCode": "CAD"
+              },
               "weight": 0,
               "image": {
                 "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",

--- a/fixtures/product-with-paginated-images-fixture.js
+++ b/fixtures/product-with-paginated-images-fixture.js
@@ -58,6 +58,14 @@ export default {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
                     "title": "Fluffy",
                     "price": "0.00",
+                    "priceV2": {
+                      "amount": "0.00",
+                      "currencyCode": "CAD"
+                    },
+                    "compareAtPriceV2": {
+                      "amount": "5.00",
+                      "currencyCode": "CAD"
+                    },
                     "weight": 18,
                     "selectedOptions": [
                       {

--- a/fixtures/product-with-paginated-variants-fixture.js
+++ b/fixtures/product-with-paginated-variants-fixture.js
@@ -38,6 +38,14 @@ export default {
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4MTk0MDA=",
               "price": "0.00",
+              "priceV2": {
+                "amount": "0.00",
+                "currencyCode": "CAD"
+              },
+              "compareAtPriceV2": {
+                "amount": "5.00",
+                "currencyCode": "CAD"
+              },
               "weight": 18
             }
           }

--- a/fixtures/query-collections-with-pagination-fixture.js
+++ b/fixtures/query-collections-with-pagination-fixture.js
@@ -83,6 +83,14 @@ export default {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNTk3Ng==",
                             "title": "Fluffy / Medium",
                             "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.00",
+                              "currencyCode": "CAD"
+                            },
+                            "compareAtPriceV2": {
+                              "amount": "5.00",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 18,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
@@ -107,6 +115,14 @@ export default {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNjA0MA==",
                             "title": "Extra Fluffy / Small",
                             "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.00",
+                              "currencyCode": "CAD"
+                            },
+                            "compareAtPriceV2": {
+                              "amount": "5.00",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 18,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
@@ -131,6 +147,14 @@ export default {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNjEwNA==",
                             "title": "Mega Fluff / Large",
                             "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.00",
+                              "currencyCode": "CAD"
+                            },
+                            "compareAtPriceV2": {
+                              "amount": "5.00",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
@@ -203,6 +227,14 @@ export default {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTkzNzExMjEzNg==",
                             "title": "Default Title",
                             "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.00",
+                              "currencyCode": "CAD"
+                            },
+                            "compareAtPriceV2": {
+                              "amount": "5.00",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 0,
                             "image": null,
                             "selectedOptions": [
@@ -289,6 +321,14 @@ export default {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjAyMjc5Mg==",
                             "title": "small",
                             "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.00",
+                              "currencyCode": "CAD"
+                            },
+                            "compareAtPriceV2": {
+                              "amount": "5.00",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
@@ -309,6 +349,14 @@ export default {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
                             "title": "large",
                             "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.00",
+                              "currencyCode": "CAD"
+                            },
+                            "compareAtPriceV2": {
+                              "amount": "5.00",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NTk3MjA=",
@@ -329,6 +377,14 @@ export default {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDY0OA==",
                             "title": "very large",
                             "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.00",
+                              "currencyCode": "CAD"
+                            },
+                            "compareAtPriceV2": {
+                              "amount": "5.00",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI4MjkzODQ=",

--- a/fixtures/query-collections-with-products-fixture.js
+++ b/fixtures/query-collections-with-products-fixture.js
@@ -107,6 +107,14 @@ export default {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNTk3Ng==",
                             "title": "Fluffy / Medium",
                             "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.00",
+                              "currencyCode": "CAD"
+                            },
+                            "compareAtPriceV2": {
+                              "amount": "5.00",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 18,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk2MTY3MzY4NDA=",
@@ -131,6 +139,14 @@ export default {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNjA0MA==",
                             "title": "Extra Fluffy / Small",
                             "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.00",
+                              "currencyCode": "CAD"
+                            },
+                            "compareAtPriceV2": {
+                              "amount": "5.00",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 18,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3ODc1OTI=",
@@ -155,6 +171,14 @@ export default {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yNTYwMjIzNjEwNA==",
                             "title": "Mega Fluff / Large",
                             "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.00",
+                              "currencyCode": "CAD"
+                            },
+                            "compareAtPriceV2": {
+                              "amount": "5.00",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
@@ -227,6 +251,14 @@ export default {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTkzNzExMjEzNg==",
                             "title": "Default Title",
                             "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.00",
+                              "currencyCode": "CAD"
+                            },
+                            "compareAtPriceV2": {
+                              "amount": "5.00",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 0,
                             "image": null,
                             "selectedOptions": [
@@ -345,6 +377,14 @@ export default {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjAyMjc5Mg==",
                             "title": "small",
                             "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.00",
+                              "currencyCode": "CAD"
+                            },
+                            "compareAtPriceV2": {
+                              "amount": "5.00",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI3ODM1NjA=",
@@ -365,6 +405,14 @@ export default {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
                             "title": "large",
                             "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.00",
+                              "currencyCode": "CAD"
+                            },
+                            "compareAtPriceV2": {
+                              "amount": "5.00",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NTk3MjA=",
@@ -385,6 +433,14 @@ export default {
                             "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDY0OA==",
                             "title": "very large",
                             "price": "0.00",
+                            "priceV2": {
+                              "amount": "0.00",
+                              "currencyCode": "CAD"
+                            },
+                            "compareAtPriceV2": {
+                              "amount": "5.00",
+                              "currencyCode": "CAD"
+                            },
                             "weight": 0,
                             "image": {
                               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTk4OTI4MjkzODQ=",

--- a/fixtures/query-products-fixture.js
+++ b/fixtures/query-products-fixture.js
@@ -74,6 +74,14 @@ export default {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                     "title": "Fluffy",
                     "price": "0.00",
+                    "priceV2": {
+                      "amount": "0.00",
+                      "currencyCode": "CAD"
+                    },
+                    "compareAtPriceV2": {
+                      "amount": "5.00",
+                      "currencyCode": "CAD"
+                    },
                     "weight": 18,
                     "image": null,
                     "selectedOptions": [
@@ -90,6 +98,14 @@ export default {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                     "title": "Extra Fluffy",
                     "price": "0.00",
+                    "priceV2": {
+                      "amount": "0.00",
+                      "currencyCode": "CAD"
+                    },
+                    "compareAtPriceV2": {
+                      "amount": "5.00",
+                      "currencyCode": "CAD"
+                    },
                     "weight": 18,
                     "image": null,
                     "selectedOptions": [
@@ -106,6 +122,14 @@ export default {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                     "title": "Mega Fluff",
                     "price": "0.00",
+                    "priceV2": {
+                      "amount": "0.00",
+                      "currencyCode": "CAD"
+                    },
+                    "compareAtPriceV2": {
+                      "amount": "5.00",
+                      "currencyCode": "CAD"
+                    },
                     "weight": 0,
                     "image": null,
                     "selectedOptions": [
@@ -196,6 +220,14 @@ export default {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                     "title": "small",
                     "price": "0.00",
+                    "priceV2": {
+                      "amount": "0.00",
+                      "currencyCode": "CAD"
+                    },
+                    "compareAtPriceV2": {
+                      "amount": "5.00",
+                      "currencyCode": "CAD"
+                    },
                     "weight": 0,
                     "selectedOptions": [
                       {
@@ -211,6 +243,14 @@ export default {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                     "title": "large",
                     "price": "0.00",
+                    "priceV2": {
+                      "amount": "0.00",
+                      "currencyCode": "CAD"
+                    },
+                    "compareAtPriceV2": {
+                      "amount": "5.00",
+                      "currencyCode": "CAD"
+                    },
                     "weight": 0,
                     "selectedOptions": [
                       {
@@ -226,6 +266,14 @@ export default {
                     "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzc4NTc5ODkzODQ=",
                     "title": "very large",
                     "price": "0.00",
+                    "priceV2": {
+                      "amount": "0.00",
+                      "currencyCode": "CAD"
+                    },
+                    "compareAtPriceV2": {
+                      "amount": "5.00",
+                      "currencyCode": "CAD"
+                    },
                     "weight": 0,
                     "selectedOptions": [
                       {

--- a/src/graphql/VariantFragment.graphql
+++ b/src/graphql/VariantFragment.graphql
@@ -2,6 +2,10 @@ fragment VariantFragment on ProductVariant {
   id
   title
   price
+  priceV2 {
+    amount
+    currencyCode
+  }
   presentmentPrices(first: 20) {
     pageInfo {
       hasNextPage
@@ -20,6 +24,10 @@ fragment VariantFragment on ProductVariant {
   available: availableForSale
   sku
   compareAtPrice
+  compareAtPriceV2 {
+    amount
+    currencyCode
+  }
   image {
     id
     src: originalSrc


### PR DESCRIPTION
Add the variant's `MoneyV2` fields (`priceV2` & `compareAtPriceV2`) to the variant fragment so users can move away from using the deprecated `price` and `compareAtPrice` fields