### PR TITLE
Add value field to discount application fragment

### DIFF
--- a/fixtures/checkout-discount-code-apply-fixture.js
+++ b/fixtures/checkout-discount-code-apply-fixture.js
@@ -76,10 +76,33 @@ export default {
                       "allocationMethod": "ACROSS",
                       "targetType": "LINE_ITEM",
                       "code": "TENPERCENTOFF",
-                      "applicable": true
+                      "applicable": true,
+                      "value": {
+                        "percentage": "10"
+                      }
                     }
                   }
                 ]
+              }
+            }
+          ]
+        },
+        "discountApplications": {
+          "pageInfo": {
+            "hasNextPage": false,
+            "hasPreviousPage": false
+          },
+          "edges": [
+            {
+              "node": {
+                "targetSelection": "ALL",
+                "allocationMethod": "ACROSS",
+                "targetType": "LINE_ITEM",
+                "code": "TENPERCENTOFF",
+                "applicable": true,
+                "value": {
+                  "percentage": "10"
+                }
               }
             }
           ]

--- a/fixtures/checkout-gift-card-remove-fixture.js
+++ b/fixtures/checkout-gift-card-remove-fixture.js
@@ -77,10 +77,33 @@ export default {
                       "allocationMethod": "ACROSS",
                       "targetType": "LINE_ITEM",
                       "code": "TENPERCENTOFF",
-                      "applicable": true
+                      "applicable": true,
+                      "value": {
+                        "percentage": "10"
+                      }
                     }
                   }
                 ]
+              }
+            }
+          ]
+        },
+        "discountApplications": {
+          "pageInfo": {
+            "hasNextPage": false,
+            "hasPreviousPage": false
+          },
+          "edges": [
+            {
+              "node": {
+                "targetSelection": "ALL",
+                "allocationMethod": "ACROSS",
+                "targetType": "LINE_ITEM",
+                "code": "TENPERCENTOFF",
+                "applicable": true,
+                "value": {
+                  "percentage": "10"
+                }
               }
             }
           ]

--- a/fixtures/checkout-gift-cards-apply-fixture.js
+++ b/fixtures/checkout-gift-cards-apply-fixture.js
@@ -102,10 +102,33 @@ export default {
                       "allocationMethod": "ACROSS",
                       "targetType": "LINE_ITEM",
                       "code": "TENPERCENTOFF",
-                      "applicable": true
+                      "applicable": true,
+                      "value": {
+                        "percentage": "10"
+                      }
                     }
                   }
                 ]
+              }
+            }
+          ]
+        },
+        "discountApplications": {
+          "pageInfo": {
+            "hasNextPage": false,
+            "hasPreviousPage": false
+          },
+          "edges": [
+            {
+              "node": {
+                "targetSelection": "ALL",
+                "allocationMethod": "ACROSS",
+                "targetType": "LINE_ITEM",
+                "code": "TENPERCENTOFF",
+                "applicable": true,
+                "value": {
+                  "percentage": "10"
+                }
               }
             }
           ]

--- a/src/graphql/DiscountApplicationFragment.graphql
+++ b/src/graphql/DiscountApplicationFragment.graphql
@@ -2,6 +2,15 @@ fragment DiscountApplicationFragment on DiscountApplication {
   targetSelection
   allocationMethod
   targetType
+  value {
+    ... on MoneyV2 {
+      amount
+      currencyCode
+    }
+    ... on PricingPercentageValue {
+      percentage
+    }
+  }
   ... on ManualDiscountApplication {
     title
     description


### PR DESCRIPTION
* In order to easily get cart/checkout level discounts, I've exposed the value field on the discount application fragment
  * This prevents the need to loop through all the checkout's line item discounts, and aggregate them into totals grouped by a discount
* Since the fragment is shared between checkout discountApplications field and the line item discountAllocation's discountApplication field, this value will be exposed in both places