### PR TITLE
Return null when no product is found

### DIFF
--- a/src/fetch-resources-for-products.js
+++ b/src/fetch-resources-for-products.js
@@ -2,6 +2,14 @@ export default function fetchResourcesForProducts(productOrProduct, client) {
   const products = [].concat(productOrProduct);
 
   return Promise.all(products.reduce((promiseAcc, product) => {
+
+    // If the graphql query doesn't find a match, returns null.
+    if (product === null) {
+      promiseAcc.push(null);
+
+      return promiseAcc;
+    }
+
     // Fetch the rest of the images and variants for this product
     promiseAcc.push(client.fetchAllPages(product.images, {pageSize: 250}).then((images) => {
       product.attrs.images = images;

--- a/src/fetch-resources-for-products.js
+++ b/src/fetch-resources-for-products.js
@@ -4,11 +4,7 @@ export default function fetchResourcesForProducts(productOrProduct, client) {
   return Promise.all(products.reduce((promiseAcc, product) => {
 
     // If the graphql query doesn't find a match, returns null.
-    if (product === null) {
-      promiseAcc.push(null);
-
-      return promiseAcc;
-    }
+    if (product === null) return promiseAcc;
 
     // Fetch the rest of the images and variants for this product
     promiseAcc.push(client.fetchAllPages(product.images, {pageSize: 250}).then((images) => {

--- a/src/fetch-resources-for-products.js
+++ b/src/fetch-resources-for-products.js
@@ -3,7 +3,7 @@ export default function fetchResourcesForProducts(productOrProduct, client) {
 
   return Promise.all(products.reduce((promiseAcc, product) => {
 
-    // If the graphql query doesn't find a match, returns null.
+    // If the graphql query doesn't find a match, skip fetching variants and images.
     if (product === null) {
       return promiseAcc;
     }

--- a/src/fetch-resources-for-products.js
+++ b/src/fetch-resources-for-products.js
@@ -4,7 +4,9 @@ export default function fetchResourcesForProducts(productOrProduct, client) {
   return Promise.all(products.reduce((promiseAcc, product) => {
 
     // If the graphql query doesn't find a match, returns null.
-    if (product === null) return promiseAcc;
+    if (product === null) {
+      return promiseAcc;
+    }
 
     // Fetch the rest of the images and variants for this product
     promiseAcc.push(client.fetchAllPages(product.images, {pageSize: 250}).then((images) => {

--- a/test/fetch-resources-for-products-test.js
+++ b/test/fetch-resources-for-products-test.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 import fetchResourcesForProducts from '../src/fetch-resources-for-products';
 
 suite('fetch-resources-for-product-test', () => {
-  test('it returns null when no product is found', () => {
+  test('it returns an empty array when no product is found', () => {
     return fetchResourcesForProducts(null).then((result) => {
 
       assert.deepStrictEqual(result, []);

--- a/test/fetch-resources-for-products-test.js
+++ b/test/fetch-resources-for-products-test.js
@@ -3,9 +3,7 @@ import fetchResourcesForProducts from '../src/fetch-resources-for-products';
 
 suite('fetch-resources-for-product-test', () => {
   test('it returns null when no product is found', () => {
-    const fixture = null;
-
-    return fetchResourcesForProducts(fixture).then((result) => {
+    return fetchResourcesForProducts(null).then((result) => {
 
       assert.deepStrictEqual(result, [null]);
     });

--- a/test/fetch-resources-for-products-test.js
+++ b/test/fetch-resources-for-products-test.js
@@ -5,7 +5,7 @@ suite('fetch-resources-for-product-test', () => {
   test('it returns null when no product is found', () => {
     return fetchResourcesForProducts(null).then((result) => {
 
-      assert.deepStrictEqual(result, [null]);
+      assert.deepStrictEqual(result, []);
     });
   });
 

--- a/test/fetch-resources-for-products-test.js
+++ b/test/fetch-resources-for-products-test.js
@@ -2,6 +2,15 @@ import assert from 'assert';
 import fetchResourcesForProducts from '../src/fetch-resources-for-products';
 
 suite('fetch-resources-for-product-test', () => {
+  test('it returns null when no product is found', () => {
+    const fixture = null;
+
+    return fetchResourcesForProducts(fixture).then((result) => {
+
+      assert.deepStrictEqual(result, [null]);
+    });
+  });
+
   test('it fetches all pages of images and for a single product', () => {
     const imagesArray = ['images'];
     const variantsArray = ['variants'];


### PR DESCRIPTION
Adresses #690 

Returns null when a product query doesn't find a matching product.