### PR TITLE
Schema-level errors do not contain data or model properties

### DIFF
--- a/fixtures/checkout-create-invalid-variant-id-error-fixture.js
+++ b/fixtures/checkout-create-invalid-variant-id-error-fixture.js
@@ -1,0 +1,7 @@
+export default {
+  "errors": [
+    {
+      "message": "Variable input of type CheckoutCreateInput! was provided invalid value"
+    }
+  ]
+}

--- a/src/handle-checkout-mutation.js
+++ b/src/handle-checkout-mutation.js
@@ -1,5 +1,5 @@
 export default function handleCheckoutMutation(mutationRootKey, client) {
-  return function({data, errors, model}) {
+  return function({data = {}, errors, model = {}}) {
     const rootData = data[mutationRootKey];
     const rootModel = model[mutationRootKey];
 

--- a/test/client-checkout-integration-test.js
+++ b/test/client-checkout-integration-test.js
@@ -7,6 +7,7 @@ import fetchMockPostOnce from './fetch-mock-helper';
 import checkoutFixture from '../fixtures/checkout-fixture';
 import checkoutNullFixture from '../fixtures/node-null-fixture';
 import checkoutCreateFixture from '../fixtures/checkout-create-fixture';
+import checkoutCreateInvalidVariantIdErrorFixture from '../fixtures/checkout-create-invalid-variant-id-error-fixture';
 import checkoutCreateWithPaginatedLineItemsFixture from '../fixtures/checkout-create-with-paginated-line-items-fixture';
 import {secondPageLineItemsFixture, thirdPageLineItemsFixture} from '../fixtures/paginated-line-items-fixture';
 import checkoutLineItemsAddFixture from '../fixtures/checkout-line-items-add-fixture';
@@ -98,6 +99,25 @@ suite('client-checkout-integration-test', () => {
     return client.checkout.create(input).then((checkout) => {
       assert.equal(checkout.id, checkoutCreateFixture.data.checkoutCreate.checkout.id);
       assert.ok(fetchMock.done());
+    });
+  });
+
+  test('it resolve with user errors on Client.checkout#create when variantId is invalid', () => {
+    const input = {
+      lineItems: [
+        {
+          variantId: 'a-bad-id',
+          quantity: 5
+        }
+      ]
+    };
+
+    fetchMockPostOnce(fetchMock, apiUrl, checkoutCreateInvalidVariantIdErrorFixture);
+
+    return client.checkout.create(input).then(() => {
+      assert.ok(false, 'Promise should not resolve');
+    }).catch((error) => {
+      assert.equal(error.message, '[{"message":"Variable input of type CheckoutCreateInput! was provided invalid value"}]');
     });
   });
 


### PR DESCRIPTION
This results in a `TypeError`: 

```
TypeError: Cannot read property 'checkoutCreate' of undefined
at index.umd.min.js:25
```

There are similar errors that take place elsewhere (should I open a separate PR or address here?). 

The fixture I've added is a shortened version of the real response:
```json
{
  "errors": [
    {
      "message": "Variable input of type CheckoutCreateInput! was provided invalid value",
      "locations": [
        {
          "line": 1,
          "column": 3030
        }
      ],
      "extensions": {
        "value": {
          "lineItems": {
            "quantity": 1,
            "variantId": "XXlkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8XXDEzNjY3OTg3Ng=="
          }
        },
        "problems": [
          {
            "path": [],
            "explanation": "Invalid global id `XXlkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8XXDEzNjY3OTg3Ng==`"
          }
        ]
      }
    }
  ]
}
```

Let me know if you prefer this. 
