### PR TITLE
Upgrade to Storefront API version 2019-10

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint --max-warnings 0 -c .eslintrc.json $(yarn run lint:reporter-args 2>&1 >/dev/null) src/ test/",
     "lint:reporter-args": "test -n \"${CI}\" && >&2 echo -o $CIRCLE_TEST_REPORTS/junit/eslint.xml -f junit",
     "print-start-message": "wait-on file:.tmp/test/index.html file:.tmp/test/tests.js tcp:35729 tcp:4200 && echo \"\n\n⚡️⚡️⚡️  Good to go at http://localhost:4200 ⚡️⚡️⚡️\"",
-    "schema:fetch": "graphql-js-schema-fetch --url 'https://graphql.myshopify.com/api/2019-07/graphql' --header 'Authorization: Basic MzUxYzEyMjAxN2QwZjJhOTU3ZDMyYWU3MjhhZDc0OWM=' | jq '.' > schema.json",
+    "schema:fetch": "graphql-js-schema-fetch --url 'https://graphql.myshopify.com/api/2019-10/graphql' --header 'Authorization: Basic MzUxYzEyMjAxN2QwZjJhOTU3ZDMyYWU3MjhhZDc0OWM=' | jq '.' > schema.json",
     "minify-umd:optimized": "echo \"/*\n$(cat LICENSE.txt)\n*/\" > index.umd.min.js && babel-minify index.umd.js >> index.umd.min.js",
     "minify-umd:unoptimized": "echo \"/*\n$(cat LICENSE.txt)\n*/\" > index.unoptimized.umd.min.js && babel-minify index.unoptimized.umd.js >> index.unoptimized.umd.min.js"
   },

--- a/schema.json
+++ b/schema.json
@@ -928,7 +928,7 @@
         {
           "kind": "SCALAR",
           "name": "ID",
-          "description": "Represents a unique identifier. It is often used to refetch an object or as key for a cache.",
+          "description": "Represents a unique identifier, often used to refetch an object or as key for a cache.\nThe ID type appears in a JSON response as a String, but it is not intended to be human-readable.\nWhen expected as an input type, any string (such as \"4\") or integer (such as 4) input value will be accepted as an ID.\n\nAdmin API example value: `\"gid://shopify/Product/10079785100\"`.\n\nStorefront API example value: `\"Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzEwMDc5Nzg1MTAw\"`.\n",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -1338,7 +1338,7 @@
         {
           "kind": "SCALAR",
           "name": "DateTime",
-          "description": "An ISO-8601 encoded UTC date time string.",
+          "description": "An ISO-8601 encoded UTC date time string. Example value: `\"2019-07-03T20:47:55Z\"`.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -3850,7 +3850,7 @@
         {
           "kind": "SCALAR",
           "name": "Money",
-          "description": "A monetary value string.",
+          "description": "A monetary value string. Example value: `\"100.57\"`.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -3903,7 +3903,7 @@
         {
           "kind": "SCALAR",
           "name": "Decimal",
-          "description": "A signed decimal number, which supports arbitrary precision and is serialized as a string.",
+          "description": "A signed decimal number, which supports arbitrary precision and is serialized as a string. Example value: `\"29.99\"`.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -4171,6 +4171,12 @@
               "deprecationReason": null
             },
             {
+              "name": "DJF",
+              "description": "Djiboutian Franc (DJF).",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "DOP",
               "description": "Dominican Peso (DOP).",
               "isDeprecated": false,
@@ -4237,6 +4243,12 @@
               "deprecationReason": null
             },
             {
+              "name": "GNF",
+              "description": "Guinean Franc (GNF).",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "HTG",
               "description": "Haitian Gourde (HTG).",
               "isDeprecated": false,
@@ -4281,6 +4293,12 @@
             {
               "name": "ILS",
               "description": "Israeli New Shekel (NIS).",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "IRR",
+              "description": "Iranian Rial (IRR).",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -4365,6 +4383,12 @@
             {
               "name": "LRD",
               "description": "Liberian Dollar (LRD).",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LYD",
+              "description": "Libyan Dinar (LYD).",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -4591,6 +4615,12 @@
               "deprecationReason": null
             },
             {
+              "name": "SLL",
+              "description": "Sierra Leonean Leone (SLL).",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "SGD",
               "description": "Singapore Dollars (SGD).",
               "isDeprecated": false,
@@ -4675,8 +4705,20 @@
               "deprecationReason": null
             },
             {
+              "name": "TJS",
+              "description": "Tajikistani Somoni (TJS).",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "TZS",
               "description": "Tanzanian Shilling (TZS).",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TOP",
+              "description": "Tongan Pa'anga (TOP).",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -4776,7 +4818,7 @@
         {
           "kind": "SCALAR",
           "name": "URL",
-          "description": "An RFC 3986 and RFC 3987 compliant URI string.",
+          "description": "An RFC 3986 and RFC 3987 compliant URI string.\n\nExample value: `\"https://johns-apparel.myshopify.com\"`.\n",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -6060,7 +6102,7 @@
           "fields": [
             {
               "name": "availableForSale",
-              "description": "Whether the product is available on the Online Store channel and in stock.",
+              "description": "Indicates if at least one product variant is available for sale.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -7293,7 +7335,7 @@
         {
           "kind": "SCALAR",
           "name": "HTML",
-          "description": "A string containing HTML code.",
+          "description": "A string containing HTML code. Example value: `\"<p>Grey cotton knit sweater.</p>\"`.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -12733,7 +12775,7 @@
             },
             {
               "name": "checkoutCompleteFree",
-              "description": null,
+              "description": "Completes a checkout without providing payment information. You can use this mutation for free items or items whose purchase price is covered by a gift card.",
               "args": [
                 {
                   "name": "checkoutId",
@@ -12801,7 +12843,7 @@
             },
             {
               "name": "checkoutCompleteWithCreditCardV2",
-              "description": "Completes a checkout using a credit card token from Shopify's Vault.",
+              "description": "Completes a checkout using a credit card token from Shopify's card vault. Before you can complete checkouts using CheckoutCompleteWithCreditCardV2, you need to  [_request payment processing_](https://help.shopify.com/api/guides/sales-channel-sdk/getting-started#request-payment-processing).",
               "args": [
                 {
                   "name": "checkoutId",
@@ -14987,7 +15029,7 @@
             },
             {
               "name": "errorMessage",
-              "description": "An message describing a processing error during asynchronous processing.",
+              "description": "A message describing a processing error during asynchronous processing.",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -15020,6 +15062,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nextActionUrl",
+              "description": "The URL where the customer needs to be redirected so they can complete the 3D Secure payment flow.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "URL",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -19517,6 +19571,34 @@
           "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
           "fields": [
             {
+              "name": "accessRestricted",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "accessRestrictedReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "description",
               "description": null,
               "args": [],
@@ -19714,6 +19796,22 @@
           "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
           "fields": [
             {
+              "name": "accessRestricted",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "accessRestrictedReason",
               "description": null,
               "args": [],
@@ -19769,22 +19867,6 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "isAccessRestricted",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/src/config.js
+++ b/src/config.js
@@ -57,7 +57,7 @@ class Config {
     if (attrs.hasOwnProperty('apiVersion')) {
       this.apiVersion = attrs.apiVersion;
     } else {
-      this.apiVersion = '2019-07';
+      this.apiVersion = '2019-10';
     }
 
     if (attrs.hasOwnProperty('source')) {

--- a/test/client-checkout-integration-test.js
+++ b/test/client-checkout-integration-test.js
@@ -30,8 +30,6 @@ import checkoutShippingAdddressUpdateV2WithUserErrorsFixture from '../fixtures/c
 
 suite('client-checkout-integration-test', () => {
   const domain = 'client-integration-tests.myshopify.io';
-  const apiVersion = '2019-07';
-  const apiUrl = `https://${domain}/api/${apiVersion}/graphql`;
   const config = {
     storefrontAccessToken: 'abc123',
     domain
@@ -49,9 +47,11 @@ suite('client-checkout-integration-test', () => {
     zip: '40202'
   };
   let client;
+  let apiUrl;
 
   setup(() => {
     client = Client.buildClient(config);
+    apiUrl = `https://${domain}/api/${client.config.apiVersion}/graphql`;
     fetchMock.reset();
   });
 

--- a/test/client-integration-test.js
+++ b/test/client-integration-test.js
@@ -23,16 +23,16 @@ import shopPoliciesFixture from '../fixtures/shop-policies-fixture';
 
 suite('client-integration-test', () => {
   const domain = 'client-integration-tests.myshopify.io';
-  const apiVersion = '2019-07';
-  const apiUrl = `https://${domain}/api/${apiVersion}/graphql`;
   const config = {
     storefrontAccessToken: 'abc123',
     domain
   };
   let client;
+  let apiUrl;
 
   setup(() => {
     client = Client.buildClient(config);
+    apiUrl = `https://${domain}/api/${client.config.apiVersion}/graphql`;
     fetchMock.reset();
   });
 

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -8,7 +8,8 @@ import {version} from '../package.json';
 suite('client-test', () => {
   const config = {
     domain: 'sendmecats.myshopify.com',
-    storefrontAccessToken: 'abc123'
+    storefrontAccessToken: 'abc123',
+    apiVersion: '2019-10'
   };
 
   test('it instantiates a GraphQL client with the given config and without custom source header when no source config is provided', () => {
@@ -27,7 +28,7 @@ suite('client-test', () => {
     new Client(new Config(config), FakeGraphQLJSClient); // eslint-disable-line no-new
 
     assert.deepEqual(passedTypeBundle, types);
-    assert.equal(passedUrl, 'https://sendmecats.myshopify.com/api/2019-07/graphql');
+    assert.equal(passedUrl, `https://sendmecats.myshopify.com/api/${config.apiVersion}/graphql`);
     assert.deepEqual(passedFetcherOptions, {
       headers: {
         'X-SDK-Variant': 'javascript',
@@ -59,7 +60,7 @@ suite('client-test', () => {
     new Client(new Config(withSourceConfig), FakeGraphQLJSClient); // eslint-disable-line no-new
 
     assert.deepEqual(passedTypeBundle, types);
-    assert.equal(passedUrl, 'https://sendmecats.myshopify.com/api/2019-07/graphql');
+    assert.equal(passedUrl, `https://sendmecats.myshopify.com/api/${config.apiVersion}/graphql`);
     assert.deepEqual(passedFetcherOptions, {
       headers: {
         'X-SDK-Variant': 'javascript',
@@ -97,7 +98,7 @@ suite('client-test', () => {
     new Client(new Config(config), FakeGraphQLJSClient, fetchFunction); // eslint-disable-line no-new
 
     return passedFetcher({data: 'body'}).then(() => {
-      assert.equal(passedUrl, 'https://sendmecats.myshopify.com/api/2019-07/graphql');
+      assert.equal(passedUrl, `https://sendmecats.myshopify.com/api/${config.apiVersion}/graphql`);
       assert.equal(passedBody, JSON.stringify({data: 'body'}));
       assert.equal(passedMethod, 'POST');
       assert.equal(passedMode, 'cors');

--- a/test/product-helpers-test.js
+++ b/test/product-helpers-test.js
@@ -6,7 +6,7 @@ import singleProductFixture from '../fixtures/product-fixture';
 import types from '../schema.json';
 
 suite('product-helpers-test', () => {
-  const graphQLClient = new GraphQLJSClient(types, {url: 'https://sendmecats.myshopify.com/api/2019-07/graphql'});
+  const graphQLClient = new GraphQLJSClient(types, {url: 'https://sendmecats.myshopify.com/api/2019-10/graphql'});
   const query = productNodeQuery(graphQLClient)
     .definitions
     .find((definition) => definition.operationType === 'query');


### PR DESCRIPTION
- Bumps the schema to include the following changes: https://help.shopify.com/en/api/versioning/release-notes/2019-10#storefront-api-changes
- Removes some references to the hardcoded api version
