### PR TITLE
Add ShippingLine priceV2

### DIFF
--- a/src/graphql/CheckoutFragment.graphql
+++ b/src/graphql/CheckoutFragment.graphql
@@ -76,6 +76,10 @@ fragment CheckoutFragment on Checkout {
   shippingLine {
     handle
     price
+    priceV2 {
+      amount
+      currencyCode
+    }
     title
   }
   customAttributes {


### PR DESCRIPTION
https://help.shopify.com/en/api/storefront-api/reference/object/shippingrate?api[version]=2019-10

Shopify also returns MoneyV2 for ShippingRate field in Checkout object. This is uselful for multicurrency apps, along with other MoneyV2 fields.

Tested locally:
![shippingline](https://user-images.githubusercontent.com/4291189/67683726-2999d680-f992-11e9-999d-5a63ba72f22e.png)

