### PR TITLE
ensure handleCheckoutMutation prioritizes error handling

### DIFF
--- a/src/handle-checkout-mutation.js
+++ b/src/handle-checkout-mutation.js
@@ -1,5 +1,9 @@
 export default function handleCheckoutMutation(mutationRootKey, client) {
   return function({data, errors, model}) {
+    if (!data && errors && errors.length) {
+      return Promise.reject(new Error(JSON.stringify(errors)));
+    }
+
     const rootData = data[mutationRootKey];
     const rootModel = model[mutationRootKey];
 
@@ -11,10 +15,6 @@ export default function handleCheckoutMutation(mutationRootKey, client) {
 
         return rootModel.checkout;
       });
-    }
-
-    if (errors && errors.length) {
-      return Promise.reject(new Error(JSON.stringify(errors)));
     }
 
     if (rootData && rootData.checkoutUserErrors && rootData.checkoutUserErrors.length) {

--- a/test/client-checkout-integration-test.js
+++ b/test/client-checkout-integration-test.js
@@ -518,7 +518,6 @@ suite('client-checkout-integration-test', () => {
 
   test('it rejects checkout mutations that return with a non-null `errors` without data field', () => {
     const checkoutCreateWithUserErrorsFixture = {
-      data: {},
       errors: [{message: 'Timeout'}]
     };
 


### PR DESCRIPTION
Without this change, if there is an error (and no data) handleCheckoutMutation throws a TypeError (eg, `Cannot read property 'checkoutCreate' of undefined`) rather than rejecting with the helpful errors information. This is because it tries to handle aspects of the data path (but is unable) before the error path. This change prioritizes the handling of errors.