### PR TITLE
Update SFAPI version to 2020-01 and add language header

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,22 @@ import Client from 'shopify-buy/index.unoptimized.umd';
 ## Examples
 
 ### Initializing the Client
+If your store supports multiple languages, Storefront API can return translated resource types and fields. Learn more about [translating content](https://help.shopify.com/en/api/guides/multi-language/translating-content-api).
+
 ```javascript
 import Client from 'shopify-buy';
 
+// Initializing a client
 const client = Client.buildClient({
   domain: 'your-shop-name.myshopify.com',
   storefrontAccessToken: 'your-storefront-access-token'
+});
+
+// Initializing a client to return translated content
+const clientWithTranslatedContent = Client.buildClient({
+  domain: 'your-shop-name.myshopify.com',
+  storefrontAccessToken: 'your-storefront-access-token',
+  language: 'ja-JP'
 });
 ```
 

--- a/docs/config.js.html
+++ b/docs/config.js.html
@@ -85,7 +85,7 @@ class Config {
     if (attrs.hasOwnProperty('apiVersion')) {
       this.apiVersion = attrs.apiVersion;
     } else {
-      this.apiVersion = '2019-10';
+      this.apiVersion = '2020-01';
     }
 
     if (attrs.hasOwnProperty('source')) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint --max-warnings 0 -c .eslintrc.json $(yarn run lint:reporter-args 2>&1 >/dev/null) src/ test/",
     "lint:reporter-args": "test -n \"${CI}\" && >&2 echo -o $CIRCLE_TEST_REPORTS/junit/eslint.xml -f junit",
     "print-start-message": "wait-on file:.tmp/test/index.html file:.tmp/test/tests.js tcp:35729 tcp:4200 && echo \"\n\n⚡️⚡️⚡️  Good to go at http://localhost:4200 ⚡️⚡️⚡️\"",
-    "schema:fetch": "graphql-js-schema-fetch --url 'https://graphql.myshopify.com/api/2019-10/graphql' --header 'Authorization: Basic MzUxYzEyMjAxN2QwZjJhOTU3ZDMyYWU3MjhhZDc0OWM=' | jq '.' > schema.json",
+    "schema:fetch": "graphql-js-schema-fetch --url 'https://graphql.myshopify.com/api/2020-01/graphql' --header 'Authorization: Basic MzUxYzEyMjAxN2QwZjJhOTU3ZDMyYWU3MjhhZDc0OWM=' | jq '.' > schema.json",
     "minify-umd:optimized": "echo \"/*\n$(cat LICENSE.txt)\n*/\" > index.umd.min.js && babel-minify index.umd.js >> index.umd.min.js",
     "minify-umd:unoptimized": "echo \"/*\n$(cat LICENSE.txt)\n*/\" > index.unoptimized.umd.min.js && babel-minify index.unoptimized.umd.js >> index.unoptimized.umd.min.js"
   },

--- a/src/client.js
+++ b/src/client.js
@@ -51,6 +51,10 @@ class Client {
       headers['X-SDK-Variant-Source'] = config.source;
     }
 
+    if (config.language) {
+      headers['Accept-Language'] = config.language;
+    }
+
     if (fetchFunction) {
       headers['Content-Type'] = 'application/json';
       headers.Accept = 'application/json';

--- a/src/config.js
+++ b/src/config.js
@@ -57,11 +57,15 @@ class Config {
     if (attrs.hasOwnProperty('apiVersion')) {
       this.apiVersion = attrs.apiVersion;
     } else {
-      this.apiVersion = '2019-10';
+      this.apiVersion = '2020-01';
     }
 
     if (attrs.hasOwnProperty('source')) {
       this.source = attrs.source;
+    }
+
+    if (attrs.hasOwnProperty('language')) {
+      this.language = attrs.language;
     }
   }
 }

--- a/test/config-test.js
+++ b/test/config-test.js
@@ -70,4 +70,20 @@ suite('config-test', () => {
     assert.equal(config.storefrontAccessToken, storefrontAccessToken, 'storefrontAccessToken should match');
     assert.equal(config.source, source, 'source should match');
   });
+
+  test('it sets language property when a language is provided', () => {
+    const domain = 'website.com';
+    const storefrontAccessToken = 123;
+    const language = 'ja-JP';
+
+    const config = new Config({
+      domain,
+      storefrontAccessToken,
+      language
+    });
+
+    assert.equal(config.domain, domain, 'domain should match');
+    assert.equal(config.storefrontAccessToken, storefrontAccessToken, 'storefrontAccessToken should match');
+    assert.equal(config.language, language, 'language should match');
+  });
 });

--- a/test/product-helpers-test.js
+++ b/test/product-helpers-test.js
@@ -6,7 +6,7 @@ import singleProductFixture from '../fixtures/product-fixture';
 import types from '../schema.json';
 
 suite('product-helpers-test', () => {
-  const graphQLClient = new GraphQLJSClient(types, {url: 'https://sendmecats.myshopify.com/api/2019-10/graphql'});
+  const graphQLClient = new GraphQLJSClient(types, {url: 'https://sendmecats.myshopify.com/api/2020-01/graphql'});
   const query = productNodeQuery(graphQLClient)
     .definitions
     .find((definition) => definition.operationType === 'query');


### PR DESCRIPTION
Update Storefront API version to `2020-01` and add new `language` header to retrieve translated content for [supported resource types and fields](https://help.shopify.com/en/api/guides/multi-language/translating-content-api). 