### PR TITLE
Add unit pricing fields to variant

### DIFF
--- a/fixtures/collection-with-products-fixture.js
+++ b/fixtures/collection-with-products-fixture.js
@@ -123,7 +123,15 @@ export default {
                           "name": "Size",
                           "value": "Medium"
                         }
-                      ]
+                      ],
+                      "unitPrice": null,
+                      "unitPriceMeasurement": {
+                        "measuredType": null,
+                        "quantityUnit": null,
+                        "quantityValue": 0.0,
+                        "referenceUnit": null,
+                        "referenceValue": 0
+                      }
                     }
                   },
                   {
@@ -155,7 +163,18 @@ export default {
                           "name": "Size",
                           "value": "Small"
                         }
-                      ]
+                      ],
+                      "unitPrice": {
+                        "amount": "0.00",
+                        "currencyCode": "CAD"
+                      },
+                      "unitPriceMeasurement": {
+                        "measuredType": "VOLUME",
+                        "quantityUnit": "ML",
+                        "quantityValue": 5.0,
+                        "referenceUnit": "ML",
+                        "referenceValue": 1
+                      }
                     }
                   },
                   {
@@ -187,7 +206,18 @@ export default {
                           "name": "Size",
                           "value": "Large"
                         }
-                      ]
+                      ],
+                      "unitPrice": {
+                        "amount": "0.00",
+                        "currencyCode": "CAD"
+                      },
+                      "unitPriceMeasurement": {
+                        "measuredType": "VOLUME",
+                        "quantityUnit": "ML",
+                        "quantityValue": 5.0,
+                        "referenceUnit": "ML",
+                        "referenceValue": 1
+                      }
                     }
                   }
                 ]
@@ -259,7 +289,15 @@ export default {
                           "name": "Title",
                           "value": "Default Title"
                         }
-                      ]
+                      ],
+                      "unitPrice": null,
+                      "unitPriceMeasurement": {
+                        "measuredType": null,
+                        "quantityUnit": null,
+                        "quantityValue": 0.0,
+                        "referenceUnit": null,
+                        "referenceValue": 0
+                      }
                     }
                   }
                 ]

--- a/fixtures/dynamic-product-fixture.js
+++ b/fixtures/dynamic-product-fixture.js
@@ -60,7 +60,15 @@ export default {
                 "amount": "5.00",
                 "currencyCode": "CAD"
               },
-              "weight": 18
+              "weight": 18,
+              "unitPrice": null,
+              "unitPriceMeasurement": {
+                "measuredType": null,
+                "quantityUnit": null,
+                "quantityValue": 0.0,
+                "referenceUnit": null,
+                "referenceValue": 0
+              }
             }
           },
           {
@@ -76,7 +84,18 @@ export default {
                 "amount": "5.00",
                 "currencyCode": "CAD"
               },
-              "weight": 18
+              "weight": 18,
+              "unitPrice": {
+                "amount": "0.00",
+                "currencyCode": "CAD"
+              },
+              "unitPriceMeasurement": {
+                "measuredType": "VOLUME",
+                "quantityUnit": "ML",
+                "quantityValue": 5.0,
+                "referenceUnit": "ML",
+                "referenceValue": 1
+              }
             }
           },
           {
@@ -92,7 +111,15 @@ export default {
                 "amount": "5.00",
                 "currencyCode": "CAD"
               },
-              "weight": 0
+              "weight": 0,
+              "unitPrice": null,
+              "unitPriceMeasurement": {
+                "measuredType": null,
+                "quantityUnit": null,
+                "quantityValue": 0.0,
+                "referenceUnit": null,
+                "referenceValue": 0
+              }
             }
           }
         ]

--- a/fixtures/paginated-variants-fixtures.js
+++ b/fixtures/paginated-variants-fixtures.js
@@ -30,7 +30,15 @@ export const secondPageVariantsFixture = {
                   "name": "Fur",
                   "value": "Extra Fluffy"
                 }
-              ]
+              ],
+              "unitPrice": null,
+              "unitPriceMeasurement": {
+                "measuredType": null,
+                "quantityUnit": null,
+                "quantityValue": 0.0,
+                "referenceUnit": null,
+                "referenceValue": 0
+              }
             }
           }
         ]
@@ -71,7 +79,18 @@ export const thirdPageVariantsFixture = {
                   "name": "Fur",
                   "value": "Mega Fluff"
                 }
-              ]
+              ],
+              "unitPrice": {
+                "amount": "0.00",
+                "currencyCode": "CAD"
+              },
+              "unitPriceMeasurement": {
+                "measuredType": "VOLUME",
+                "quantityUnit": "ML",
+                "quantityValue": 5.0,
+                "referenceUnit": "ML",
+                "referenceValue": 1
+              }
             }
           }
         ]

--- a/fixtures/product-by-handle-fixture.js
+++ b/fixtures/product-by-handle-fixture.js
@@ -126,7 +126,15 @@ export default {
                   "name": "Size",
                   "value": "X-Small"
                 }
-              ]
+              ],
+              "unitPrice": null,
+              "unitPriceMeasurement": {
+                "measuredType": null,
+                "quantityUnit": null,
+                "quantityValue": 0.0,
+                "referenceUnit": null,
+                "referenceValue": 0
+              }
             }
           },
           {
@@ -154,7 +162,18 @@ export default {
                   "name": "Size",
                   "value": "Small"
                 }
-              ]
+              ],
+              "unitPrice": {
+                "amount": "1.00",
+                "currencyCode": "CAD"
+              },
+              "unitPriceMeasurement": {
+                "measuredType": "VOLUME",
+                "quantityUnit": "ML",
+                "quantityValue": 788.0,
+                "referenceUnit": "ML",
+                "referenceValue": 1
+              }
             }
           },
           {
@@ -182,7 +201,15 @@ export default {
                   "name": "Size",
                   "value": "Medium"
                 }
-              ]
+              ],
+              "unitPrice": null,
+              "unitPriceMeasurement": {
+                "measuredType": null,
+                "quantityUnit": null,
+                "quantityValue": 0.0,
+                "referenceUnit": null,
+                "referenceValue": 0
+              }
             }
           },
           {
@@ -213,7 +240,18 @@ export default {
                   "name": "Size",
                   "value": "X-Small"
                 }
-              ]
+              ],
+              "unitPrice": {
+                "amount": "1.00",
+                "currencyCode": "CAD"
+              },
+              "unitPriceMeasurement": {
+                "measuredType": "VOLUME",
+                "quantityUnit": "ML",
+                "quantityValue": 750.0,
+                "referenceUnit": "ML",
+                "referenceValue": 1
+              }
             }
           },
           {
@@ -244,7 +282,15 @@ export default {
                   "name": "Size",
                   "value": "Small"
                 }
-              ]
+              ],
+              "unitPrice": null,
+              "unitPriceMeasurement": {
+                "measuredType": null,
+                "quantityUnit": null,
+                "quantityValue": 0.0,
+                "referenceUnit": null,
+                "referenceValue": 0
+              }
             }
           },
           {
@@ -275,7 +321,15 @@ export default {
                   "name": "Size",
                   "value": "Medium"
                 }
-              ]
+              ],
+              "unitPrice": null,
+              "unitPriceMeasurement": {
+                "measuredType": null,
+                "quantityUnit": null,
+                "quantityValue": 0.0,
+                "referenceUnit": null,
+                "referenceValue": 0
+              }
             }
           },
           {
@@ -306,7 +360,18 @@ export default {
                   "name": "Size",
                   "value": "Large"
                 }
-              ]
+              ],
+              "unitPrice": {
+                "amount": "1.00",
+                "currencyCode": "CAD"
+              },
+              "unitPriceMeasurement": {
+                "measuredType": "VOLUME",
+                "quantityUnit": "ML",
+                "quantityValue": 788.0,
+                "referenceUnit": "ML",
+                "referenceValue": 1
+              }
             }
           }
         ]

--- a/fixtures/product-fixture.js
+++ b/fixtures/product-fixture.js
@@ -108,7 +108,18 @@ export default {
                   "name": "Size",
                   "value": "Medium"
                 }
-              ]
+              ],
+              "unitPrice": {
+                "amount": "0.00",
+                "currencyCode": "CAD"
+              },
+              "unitPriceMeasurement": {
+                "measuredType": "VOLUME",
+                "quantityUnit": "ML",
+                "quantityValue": 5.0,
+                "referenceUnit": "ML",
+                "referenceValue": 1
+              }
             }
           },
           {
@@ -140,7 +151,15 @@ export default {
                   "name": "Size",
                   "value": "Small"
                 }
-              ]
+              ],
+              "unitPrice": null,
+              "unitPriceMeasurement": {
+                "measuredType": null,
+                "quantityUnit": null,
+                "quantityValue": 0.0,
+                "referenceUnit": null,
+                "referenceValue": 0
+              }
             }
           },
           {
@@ -172,7 +191,15 @@ export default {
                   "name": "Size",
                   "value": "Large"
                 }
-              ]
+              ],
+              "unitPrice": null,
+              "unitPriceMeasurement": {
+                "measuredType": null,
+                "quantityUnit": null,
+                "quantityValue": 0.0,
+                "referenceUnit": null,
+                "referenceValue": 0
+              }
             }
           }
         ]

--- a/fixtures/product-with-paginated-images-fixture.js
+++ b/fixtures/product-with-paginated-images-fixture.js
@@ -72,7 +72,18 @@ export default {
                         "name": "Fur",
                         "value": "Fluffy"
                       }
-                    ]
+                    ],
+                    "unitPrice": {
+                      "amount": "0.00",
+                      "currencyCode": "CAD"
+                    },
+                    "unitPriceMeasurement": {
+                      "measuredType": "VOLUME",
+                      "quantityUnit": "ML",
+                      "quantityValue": 5.0,
+                      "referenceUnit": "ML",
+                      "referenceValue": 1
+                    }
                   }
                 }
               ]

--- a/fixtures/product-with-paginated-variants-fixture.js
+++ b/fixtures/product-with-paginated-variants-fixture.js
@@ -46,7 +46,15 @@ export default {
                 "amount": "5.00",
                 "currencyCode": "CAD"
               },
-              "weight": 18
+              "weight": 18,
+              "unitPrice": null,
+              "unitPriceMeasurement": {
+                "measuredType": null,
+                "quantityUnit": null,
+                "quantityValue": 0.0,
+                "referenceUnit": null,
+                "referenceValue": 0
+              }
             }
           }
         ]

--- a/fixtures/query-collections-with-pagination-fixture.js
+++ b/fixtures/query-collections-with-pagination-fixture.js
@@ -106,7 +106,18 @@ export default {
                                 "name": "Size",
                                 "value": "Medium"
                               }
-                            ]
+                            ],
+                            "unitPrice": {
+                              "amount": "0.00",
+                              "currencyCode": "CAD"
+                            },
+                            "unitPriceMeasurement": {
+                              "measuredType": "VOLUME",
+                              "quantityUnit": "ML",
+                              "quantityValue": 5.0,
+                              "referenceUnit": "ML",
+                              "referenceValue": 1
+                            }
                           }
                         },
                         {
@@ -138,7 +149,15 @@ export default {
                                 "name": "Size",
                                 "value": "Small"
                               }
-                            ]
+                            ],
+                            "unitPrice": null,
+                            "unitPriceMeasurement": {
+                              "measuredType": null,
+                              "quantityUnit": null,
+                              "quantityValue": 0.0,
+                              "referenceUnit": null,
+                              "referenceValue": 0
+                            }
                           }
                         },
                         {
@@ -170,7 +189,15 @@ export default {
                                 "name": "Size",
                                 "value": "Large"
                               }
-                            ]
+                            ],
+                            "unitPrice": null,
+                            "unitPriceMeasurement": {
+                              "measuredType": null,
+                              "quantityUnit": null,
+                              "quantityValue": 0.0,
+                              "referenceUnit": null,
+                              "referenceValue": 0
+                            }
                           }
                         }
                       ]
@@ -242,7 +269,18 @@ export default {
                                 "name": "Title",
                                 "value": "Default Title"
                               }
-                            ]
+                            ],
+                            "unitPrice": {
+                              "amount": "0.00",
+                              "currencyCode": "CAD"
+                            },
+                            "unitPriceMeasurement": {
+                              "measuredType": "VOLUME",
+                              "quantityUnit": "ML",
+                              "quantityValue": 5.0,
+                              "referenceUnit": "ML",
+                              "referenceValue": 1
+                            }
                           }
                         }
                       ]
@@ -340,7 +378,15 @@ export default {
                                 "name": "Size",
                                 "value": "small"
                               }
-                            ]
+                            ],
+                            "unitPrice": null,
+                            "unitPriceMeasurement": {
+                              "measuredType": null,
+                              "quantityUnit": null,
+                              "quantityValue": 0.0,
+                              "referenceUnit": null,
+                              "referenceValue": 0
+                            }
                           }
                         },
                         {
@@ -368,7 +414,18 @@ export default {
                                 "name": "Size",
                                 "value": "large"
                               }
-                            ]
+                            ],
+                            "unitPrice": {
+                              "amount": "0.00",
+                              "currencyCode": "CAD"
+                            },
+                            "unitPriceMeasurement": {
+                              "measuredType": "VOLUME",
+                              "quantityUnit": "ML",
+                              "quantityValue": 5.0,
+                              "referenceUnit": "ML",
+                              "referenceValue": 1
+                            }
                           }
                         },
                         {
@@ -396,7 +453,15 @@ export default {
                                 "name": "Size",
                                 "value": "very large"
                               }
-                            ]
+                            ],
+                            "unitPrice": null,
+                            "unitPriceMeasurement": {
+                              "measuredType": null,
+                              "quantityUnit": null,
+                              "quantityValue": 0.0,
+                              "referenceUnit": null,
+                              "referenceValue": 0
+                            }
                           }
                         }
                       ]

--- a/fixtures/query-collections-with-products-fixture.js
+++ b/fixtures/query-collections-with-products-fixture.js
@@ -130,7 +130,18 @@ export default {
                                 "name": "Size",
                                 "value": "Medium"
                               }
-                            ]
+                            ],
+                            "unitPrice": {
+                              "amount": "0.00",
+                              "currencyCode": "CAD"
+                            },
+                            "unitPriceMeasurement": {
+                              "measuredType": "VOLUME",
+                              "quantityUnit": "ML",
+                              "quantityValue": 5.0,
+                              "referenceUnit": "ML",
+                              "referenceValue": 1
+                            }
                           }
                         },
                         {
@@ -162,7 +173,15 @@ export default {
                                 "name": "Size",
                                 "value": "Small"
                               }
-                            ]
+                            ],
+                            "unitPrice": null,
+                            "unitPriceMeasurement": {
+                              "measuredType": null,
+                              "quantityUnit": null,
+                              "quantityValue": 0.0,
+                              "referenceUnit": null,
+                              "referenceValue": 0
+                            }
                           }
                         },
                         {
@@ -194,7 +213,18 @@ export default {
                                 "name": "Size",
                                 "value": "Large"
                               }
-                            ]
+                            ],
+                            "unitPrice": {
+                              "amount": "0.00",
+                              "currencyCode": "CAD"
+                            },
+                            "unitPriceMeasurement": {
+                              "measuredType": "VOLUME",
+                              "quantityUnit": "ML",
+                              "quantityValue": 5.0,
+                              "referenceUnit": "ML",
+                              "referenceValue": 1
+                            }
                           }
                         }
                       ]
@@ -266,7 +296,15 @@ export default {
                                 "name": "Title",
                                 "value": "Default Title"
                               }
-                            ]
+                            ],
+                            "unitPrice": null,
+                            "unitPriceMeasurement": {
+                              "measuredType": null,
+                              "quantityUnit": null,
+                              "quantityValue": 0.0,
+                              "referenceUnit": null,
+                              "referenceValue": 0
+                            }
                           }
                         }
                       ]
@@ -396,7 +434,15 @@ export default {
                                 "name": "Size",
                                 "value": "small"
                               }
-                            ]
+                            ],
+                            "unitPrice": null,
+                            "unitPriceMeasurement": {
+                              "measuredType": null,
+                              "quantityUnit": null,
+                              "quantityValue": 0.0,
+                              "referenceUnit": null,
+                              "referenceValue": 0
+                            }
                           }
                         },
                         {
@@ -424,7 +470,18 @@ export default {
                                 "name": "Size",
                                 "value": "large"
                               }
-                            ]
+                            ],
+                            "unitPrice": {
+                              "amount": "0.00",
+                              "currencyCode": "CAD"
+                            },
+                            "unitPriceMeasurement": {
+                              "measuredType": "VOLUME",
+                              "quantityUnit": "ML",
+                              "quantityValue": 5.0,
+                              "referenceUnit": "ML",
+                              "referenceValue": 1
+                            }
                           }
                         },
                         {
@@ -452,7 +509,15 @@ export default {
                                 "name": "Size",
                                 "value": "very large"
                               }
-                            ]
+                            ],
+                            "unitPrice": null,
+                            "unitPriceMeasurement": {
+                              "measuredType": null,
+                              "quantityUnit": null,
+                              "quantityValue": 0.0,
+                              "referenceUnit": null,
+                              "referenceValue": 0
+                            }
                           }
                         }
                       ]

--- a/fixtures/query-products-fixture.js
+++ b/fixtures/query-products-fixture.js
@@ -89,7 +89,18 @@ export default {
                         "name": "Fur",
                         "value": "Fluffy"
                       }
-                    ]
+                    ],
+                    "unitPrice": {
+                      "amount": "0.00",
+                      "currencyCode": "CAD"
+                    },
+                    "unitPriceMeasurement": {
+                      "measuredType": "VOLUME",
+                      "quantityUnit": "ML",
+                      "quantityValue": 5.0,
+                      "referenceUnit": "ML",
+                      "referenceValue": 1
+                    }
                   }
                 },
                 {
@@ -113,7 +124,15 @@ export default {
                         "name": "Fur",
                         "value": "Extra Fluffy"
                       }
-                    ]
+                    ],
+                    "unitPrice": null,
+                    "unitPriceMeasurement": {
+                      "measuredType": null,
+                      "quantityUnit": null,
+                      "quantityValue": 0.0,
+                      "referenceUnit": null,
+                      "referenceValue": 0
+                    }
                   }
                 },
                 {
@@ -137,7 +156,15 @@ export default {
                         "name": "Fur",
                         "value": "Mega Fluff"
                       }
-                    ]
+                    ],
+                    "unitPrice": null,
+                    "unitPriceMeasurement": {
+                      "measuredType": null,
+                      "quantityUnit": null,
+                      "quantityValue": 0.0,
+                      "referenceUnit": null,
+                      "referenceValue": 0
+                    }
                   }
                 }
               ]
@@ -234,7 +261,15 @@ export default {
                         "name": "Size",
                         "value": "small"
                       }
-                    ]
+                    ],
+                    "unitPrice": null,
+                    "unitPriceMeasurement": {
+                      "measuredType": null,
+                      "quantityUnit": null,
+                      "quantityValue": 0.0,
+                      "referenceUnit": null,
+                      "referenceValue": 0
+                    }
                   }
                 },
                 {
@@ -257,7 +292,15 @@ export default {
                         "name": "Size",
                         "value": "large"
                       }
-                    ]
+                    ],
+                    "unitPrice": null,
+                    "unitPriceMeasurement": {
+                      "measuredType": null,
+                      "quantityUnit": null,
+                      "quantityValue": 0.0,
+                      "referenceUnit": null,
+                      "referenceValue": 0
+                    }
                   }
                 },
                 {
@@ -280,7 +323,15 @@ export default {
                         "name": "Size",
                         "value": "very large"
                       }
-                    ]
+                    ],
+                    "unitPrice": null,
+                    "unitPriceMeasurement": {
+                      "measuredType": null,
+                      "quantityUnit": null,
+                      "quantityValue": 0.0,
+                      "referenceUnit": null,
+                      "referenceValue": 0
+                    }
                   }
                 }
               ]

--- a/schema.json
+++ b/schema.json
@@ -880,12 +880,27 @@
             },
             {
               "kind": "OBJECT",
+              "name": "ExternalVideo",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "MailingAddress",
               "ofType": null
             },
             {
               "kind": "OBJECT",
+              "name": "MediaImage",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "Metafield",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Model3d",
               "ofType": null
             },
             {
@@ -921,6 +936,11 @@
             {
               "kind": "OBJECT",
               "name": "ShopPolicy",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Video",
               "ofType": null
             }
           ]
@@ -3913,7 +3933,7 @@
         {
           "kind": "ENUM",
           "name": "CurrencyCode",
-          "description": "Currency codes",
+          "description": "Currency codes.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -4201,6 +4221,12 @@
               "deprecationReason": null
             },
             {
+              "name": "FKP",
+              "description": "Falkland Islands Pounds (FKP).",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "XPF",
               "description": "CFP Franc (XPF).",
               "isDeprecated": false,
@@ -4209,6 +4235,12 @@
             {
               "name": "FJD",
               "description": "Fijian Dollars (FJD).",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GIP",
+              "description": "Gibraltar Pounds (GIP).",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -4587,6 +4619,12 @@
             {
               "name": "WST",
               "description": "Samoan Tala (WST).",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SHP",
+              "description": "Saint Helena Pounds (SHP).",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -5620,6 +5658,91 @@
               "deprecationReason": null
             },
             {
+              "name": "presentmentUnitPrices",
+              "description": "List of unit prices in the presentment currencies for this shop.",
+              "args": [
+                {
+                  "name": "presentmentCurrencies",
+                  "description": "Specify the currencies in which to return presentment unit prices.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "CurrencyCode",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns up to the first `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "after",
+                  "description": "Returns the elements that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "reverse",
+                  "description": "Reverse the order of the underlying list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MoneyV2Connection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "price",
               "description": "The product variant’s price.",
               "args": [],
@@ -5731,6 +5854,30 @@
                   "name": "String",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "unitPrice",
+              "description": "The unit price value for the variant based on the variant's measurement.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "MoneyV2",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "unitPriceMeasurement",
+              "description": "The unit price measurement for the variant.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "UnitPriceMeasurement",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -6385,6 +6532,73 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "ImageConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "media",
+              "description": "The media associated with the product.",
+              "args": [
+                {
+                  "name": "first",
+                  "description": "Returns up to the first `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "after",
+                  "description": "Returns the elements that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns up to the last `n` elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "reverse",
+                  "description": "Reverse the order of the underlying list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MediaConnection",
                   "ofType": null
                 }
               },
@@ -7830,6 +8044,207 @@
         },
         {
           "kind": "OBJECT",
+          "name": "MediaConnection",
+          "description": null,
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "MediaEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "MediaEdge",
+          "description": null,
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of MediaEdge.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "Media",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "Media",
+          "description": "Represents a media interface.",
+          "fields": [
+            {
+              "name": "alt",
+              "description": "A word or phrase to share the nature or contents of a media.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mediaContentType",
+              "description": "The media content type.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "MediaContentType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "previewImage",
+              "description": "The preview image for the media.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Image",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "ExternalVideo",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "MediaImage",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Model3d",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Video",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "ENUM",
+          "name": "MediaContentType",
+          "description": "The possible content types for a media object.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "EXTERNAL_VIDEO",
+              "description": "An externally hosted video.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "IMAGE",
+              "description": "A Shopify hosted image.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MODEL_3D",
+              "description": "A 3d model.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "VIDEO",
+              "description": "A Shopify hosted video.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "ProductPriceRange",
           "description": "The price range of the product.",
           "fields": [
@@ -8411,6 +8826,291 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "UnitPriceMeasurement",
+          "description": "The measurement used to calculate a unit price for a product variant (e.g. $9.99 / 100ml).\n",
+          "fields": [
+            {
+              "name": "measuredType",
+              "description": "The type of unit of measurement for the unit price measurement.",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "UnitPriceMeasurementMeasuredType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quantityUnit",
+              "description": "The quantity unit for the unit price measurement.",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "UnitPriceMeasurementMeasuredUnit",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quantityValue",
+              "description": "The quantity value for the unit price measurement.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "referenceUnit",
+              "description": "The reference unit for the unit price measurement.",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "UnitPriceMeasurementMeasuredUnit",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "referenceValue",
+              "description": "The reference value for the unit price measurement.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "UnitPriceMeasurementMeasuredType",
+          "description": "The accepted types of unit of measurement.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "VOLUME",
+              "description": "Unit of measurements representing volumes.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "WEIGHT",
+              "description": "Unit of measurements representing weights.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LENGTH",
+              "description": "Unit of measurements representing lengths.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "AREA",
+              "description": "Unit of measurements representing areas.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "UnitPriceMeasurementMeasuredUnit",
+          "description": "The valid units of measurement for a unit price measurement.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "ML",
+              "description": "1000 milliliters equals 1 liter.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CL",
+              "description": "100 centiliters equals 1 liter.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "L",
+              "description": "Metric system unit of volume.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "M3",
+              "description": "1 cubic meter equals 1000 liters.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MG",
+              "description": "1000 milligrams equals 1 gram.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "G",
+              "description": "Metric system unit of weight.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "KG",
+              "description": "1 kilogram equals 1000 grams.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MM",
+              "description": "1000 millimeters equals 1 meter.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CM",
+              "description": "100 centimeters equals 1 meter.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "M",
+              "description": "Metric system unit of length.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "M2",
+              "description": "Metric system unit of area.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "MoneyV2Connection",
+          "description": null,
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "MoneyV2Edge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "MoneyV2Edge",
+          "description": null,
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of MoneyV2Edge.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MoneyV2",
                   "ofType": null
                 }
               },
@@ -14771,6 +15471,12 @@
               "description": "Line item was not found in checkout.",
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "UNABLE_TO_APPLY",
+              "description": "Unable to apply discount.",
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null
@@ -16761,20 +17467,6 @@
               "defaultValue": null
             },
             {
-              "name": "type",
-              "description": "The type of payment token.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
               "name": "paymentData",
               "description": "A simple string or JSON containing the required payment data for the tokenized payment.",
               "type": {
@@ -16805,6 +17497,20 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "type",
+              "description": "The type of payment token.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               },
               "defaultValue": null
             }
@@ -20813,6 +21519,560 @@
               "ofType": null
             }
           ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ExternalVideo",
+          "description": "Represents a video hosted outside of Shopify.",
+          "fields": [
+            {
+              "name": "alt",
+              "description": "A word or phrase to share the nature or contents of a media.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "embeddedUrl",
+              "description": "The URL.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "URL",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "Globally unique identifier.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mediaContentType",
+              "description": "The media content type.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "MediaContentType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "previewImage",
+              "description": "The preview image for the media.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Image",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Media",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "MediaImage",
+          "description": "Represents a Shopify hosted image.",
+          "fields": [
+            {
+              "name": "alt",
+              "description": "A word or phrase to share the nature or contents of a media.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "Globally unique identifier.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "image",
+              "description": "The image for the media.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Image",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mediaContentType",
+              "description": "The media content type.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "MediaContentType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "previewImage",
+              "description": "The preview image for the media.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Image",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Media",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Model3d",
+          "description": "Represents a Shopify hosted 3D model.",
+          "fields": [
+            {
+              "name": "alt",
+              "description": "A word or phrase to share the nature or contents of a media.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "Globally unique identifier.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mediaContentType",
+              "description": "The media content type.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "MediaContentType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "previewImage",
+              "description": "The preview image for the media.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Image",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sources",
+              "description": "The sources for a 3d model.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Model3dSource",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Media",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Model3dSource",
+          "description": "Represents a source for a Shopify hosted 3d model.",
+          "fields": [
+            {
+              "name": "filesize",
+              "description": "The filesize of the 3d model.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "format",
+              "description": "The format of the 3d model.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mimeType",
+              "description": "The MIME type of the 3d model.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": "The URL of the 3d model.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Video",
+          "description": "Represents a Shopify hosted video.",
+          "fields": [
+            {
+              "name": "alt",
+              "description": "A word or phrase to share the nature or contents of a media.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "Globally unique identifier.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mediaContentType",
+              "description": "The media content type.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "MediaContentType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "previewImage",
+              "description": "The preview image for the media.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Image",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sources",
+              "description": "The sources for a video.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "VideoSource",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Media",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "VideoSource",
+          "description": "Represents a source for a Shopify hosted video.",
+          "fields": [
+            {
+              "name": "format",
+              "description": "The format of the video source.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "height",
+              "description": "The height of the video.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mimeType",
+              "description": "The video MIME type.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": "The URL of the video.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "width",
+              "description": "The width of the video.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
         }

--- a/src/graphql/VariantFragment.graphql
+++ b/src/graphql/VariantFragment.graphql
@@ -37,4 +37,15 @@ fragment VariantFragment on ProductVariant {
     name
     value
   }
+  unitPrice {
+    amount
+    currencyCode
+  }
+  unitPriceMeasurement {
+    measuredType
+    quantityUnit
+    quantityValue
+    referenceUnit
+    referenceValue
+  }
 }


### PR DESCRIPTION
* Pull in new `schema.json` by running `yarn run schema:fetch`
* Add `unitPrice` and `unitPriceMeasurement` to the variant fragment, which is used when fetching collections, products, and checkouts
* Added unit pricing fields to fixtures

--- 
To 🎩 verify that unit pricing fields are returned when:
* Fetching a collection with a product that has a variant with unit pricing
* Fetching a product that has a variant with unit pricing
* Fetch a checkout with a line item that has a variant with unit pricing

[Sample testing script](https://codepen.io/spencercanner/pen/MWYrzzV)