### PR TITLE
Bump graphql-js-client to v0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "expect.js": "0.3.1",
     "fetch-mock": "5.12.2",
     "fs-extra": "1.0.0",
-    "graphql-js-client": "0.11.1",
+    "graphql-js-client": "0.12.0",
     "graphql-js-schema": "0.7.1",
     "graphql-js-schema-fetch": "1.1.2",
     "http-server": "0.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3706,10 +3706,10 @@ graphql-js-client-compiler@0.2.0:
     minimist "1.2.0"
     mkdirp "0.5.1"
 
-graphql-js-client@0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/graphql-js-client/-/graphql-js-client-0.11.1.tgz#91e07d7a0ff6d71902ee2f39f29260c9757c7625"
-  integrity sha512-40ig0vPLuYpp6s999IlPiV63om1Fd8PLM9P+ULH7dSZ2NXToZWg+AGi5ok6qODMe+xFBcjodhv3xtLh5t68/KQ==
+graphql-js-client@0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/graphql-js-client/-/graphql-js-client-0.12.0.tgz#2f367cf1425ca17eee98cae7993f19abecf0a458"
+  integrity sha512-d5hPmlzMLq/yZWihd9eaMaRZxcdf+vrFQJxxIep9Tqei+wbesaR1JhkIBU2Czdjz6pCp58msNcyAr1OWTkgZuA==
 
 graphql-js-client@0.7.0:
   version "0.7.0"


### PR DESCRIPTION
This version brings in the following updates:
* Support for directives (https://github.com/Shopify/graphql-js-client/pull/131)
* Resolves an issue where first variables not explicitly named "first" generate an invalid GraphQL query (https://github.com/Shopify/graphql-js-client/pull/134)

To 🎩 : 
* Directives aren't used in js-buy-sdk so this doesn't need to be tested explicitly
  * Every js-buy-sdk call should be sanity checked to verify they still work
* Use run this [code snippet](https://codepen.io/spencercanner/pen/XWWvjNw) against this branch and verify that there are no errors and the second page of products are logged