### PR TITLE
Update accept-language header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ index.*
 # Decrypted secrets
 secrets.json
 .nvmrc
+
+# VSCode settings
+.vscode

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If your store supports multiple languages, Storefront API can return translated 
 ```javascript
 import Client from 'shopify-buy';
 
-// Initializing a client
+// Initializing a client to return content in the store's primary language
 const client = Client.buildClient({
   domain: 'your-shop-name.myshopify.com',
   storefrontAccessToken: 'your-storefront-access-token'

--- a/src/client.js
+++ b/src/client.js
@@ -51,9 +51,9 @@ class Client {
       headers['X-SDK-Variant-Source'] = config.source;
     }
 
-    if (config.language) {
-      headers['Accept-Language'] = config.language;
-    }
+    const languageHeader = config.language ? config.language : '*';
+
+    headers['Accept-Language'] = languageHeader;
 
     if (fetchFunction) {
       headers['Content-Type'] = 'application/json';

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -31,6 +31,7 @@ suite('client-test', () => {
     assert.equal(passedUrl, `https://${config.domain}/api/${config.apiVersion}/graphql`);
     assert.deepEqual(passedFetcherOptions, {
       headers: {
+        'Accept-Language': '*',
         'X-SDK-Variant': 'javascript',
         'X-SDK-Version': version,
         'X-Shopify-Storefront-Access-Token': config.storefrontAccessToken
@@ -61,6 +62,7 @@ suite('client-test', () => {
     assert.equal(passedUrl, `https://${withSourceConfig.domain}/api/${withSourceConfig.apiVersion}/graphql`);
     assert.deepEqual(passedFetcherOptions, {
       headers: {
+        'Accept-Language': '*',
         'X-SDK-Variant': 'javascript',
         'X-SDK-Version': version,
         'X-Shopify-Storefront-Access-Token': withSourceConfig.storefrontAccessToken,
@@ -134,6 +136,7 @@ suite('client-test', () => {
       assert.deepEqual(passedHeaders, {
         'Content-Type': 'application/json',
         Accept: 'application/json',
+        'Accept-Language': '*',
         'X-SDK-Variant': 'javascript',
         'X-SDK-Version': version,
         'X-Shopify-Storefront-Access-Token': config.storefrontAccessToken


### PR DESCRIPTION
Currently, when a user does not set a language configuration during the `client` initialization, the client does not explicitly set the `accept-language` header. This PR updates the client to always set the `accept-language` header for all requests and will set the header to the default value of `*`.  

This default value will result in Storefront API to return content in the shop's primary language.