### PR TITLE
add image width and height to variant and product fragments

### DIFF
--- a/src/graphql/ProductFragment.graphql
+++ b/src/graphql/ProductFragment.graphql
@@ -26,6 +26,8 @@ fragment ProductFragment on Product {
         id
         src
         altText
+        width
+        height
       }
     }
   }

--- a/src/graphql/VariantFragment.graphql
+++ b/src/graphql/VariantFragment.graphql
@@ -36,6 +36,8 @@ fragment VariantFragment on ProductVariant {
     id
     src: originalSrc
     altText
+    width
+    height
   }
   selectedOptions {
     name


### PR DESCRIPTION
Created a fresh pull request for https://github.com/Shopify/js-buy-sdk/pull/825 since it was based on an outdated version of the repository. Adds width and height properties to product and variant images.