### PR TITLE
Update SDK to use SFAPI v2022-01 and remove unavailable fields

### DIFF
--- a/docs/config.js.html
+++ b/docs/config.js.html
@@ -85,7 +85,7 @@ class Config {
     if (attrs.hasOwnProperty('apiVersion')) {
       this.apiVersion = attrs.apiVersion;
     } else {
-      this.apiVersion = '2021-10';
+      this.apiVersion = '2022-01';
     }
 
     if (attrs.hasOwnProperty('source')) {

--- a/fixtures/checkout-create-fixture.js
+++ b/fixtures/checkout-create-fixture.js
@@ -1,102 +1,85 @@
 export default {
-  "data": {
-    "checkoutCreate": {
-      "checkoutUserErrors": [],
-      "userErrors": [],
-      "checkout": {
-        "id": "Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",
-        "ready": true,
-        "lineItems": {
-          "pageInfo": {
-            "hasNextPage": false,
-            "hasPreviousPage": false
+  data: {
+    checkoutCreate: {
+      checkoutUserErrors: [],
+      userErrors: [],
+      checkout: {
+        id: 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=',
+        ready: true,
+        lineItems: {
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false
           },
-          "edges": [
+          edges: [
             {
-              "cursor": "eyJsYXN0X2lkIjoiZDUyZWU5ZTEwYmQxMWE0NDlkNmQzMWNkMzBhMGFjNzMifQ==",
-              "node": {
-                "title": "Intelligent Granite Table",
-                "variant": {
-                  "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
-                  "title": "Awesome Copper Bench",
-                  "price": "64.99",
-                  "compareAtPrice": null,
-                  "weight": 4.5,
-                  "image": null,
-                  "selectedOptions": [
+              cursor: 'eyJsYXN0X2lkIjoiZDUyZWU5ZTEwYmQxMWE0NDlkNmQzMWNkMzBhMGFjNzMifQ==',
+              node: {
+                title: 'Intelligent Granite Table',
+                variant: {
+                  id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==',
+                  title: 'Awesome Copper Bench',
+                  price: '64.99',
+                  compareAtPrice: null,
+                  weight: 4.5,
+                  image: null,
+                  selectedOptions: [
                     {
-                      "name": "Color or something",
-                      "value": "Awesome Copper Bench"
+                      name: 'Color or something',
+                      value: 'Awesome Copper Bench'
                     }
-                  ],
-                  "presentmentPrices": {
-                    "pageInfo": {
-                      "hasNextPage": false,
-                      "hasPreviousPage": false
-                    },
-                    "edges": [
-                      {
-                        "node": {
-                          "price": {
-                            "amount": "64.99",
-                            "currencyCode": "USD"
-                          },
-                          "compareAtPrice": null
-                        }
-                      }
-                    ]
-                  }
+                  ]
                 },
-                "quantity": 5,
-                "customAttributes": []
+                quantity: 5,
+                customAttributes: []
               }
             }
           ]
         },
-        "shippingAddress": {
-          "address1": "123 Cat Road",
-          "address2": null,
-          "city": "Cat Land",
-          "company": "Catmart",
-          "country": "Canada",
-          "firstName": "Meow",
-          "formatted": [
-            "Catmart",
-            "123 Cat Road",
-            "Cat Land ON M3O 0W1",
-            "Canada"
+        shippingAddress: {
+          address1: '123 Cat Road',
+          address2: null,
+          city: 'Cat Land',
+          company: 'Catmart',
+          country: 'Canada',
+          firstName: 'Meow',
+          formatted: [
+            'Catmart',
+            '123 Cat Road',
+            'Cat Land ON M3O 0W1',
+            'Canada'
           ],
-          "lastName": "Meowington",
-          "latitude": null,
-          "longitude": null,
-          "phone": "4161234566",
-          "province": "Ontario",
-          "zip": "M3O 0W1",
-          "name": "Meow Meowington",
-          "countryCode": "CA",
-          "provinceCode": "ON",
-          "id": "Z2lkOi8vc2hvcGlmeS9QcmdfnAU8nakdWMnAbh890hyOTEwNjA2NDU4NA=="
+          lastName: 'Meowington',
+          latitude: null,
+          longitude: null,
+          phone: '4161234566',
+          province: 'Ontario',
+          zip: 'M3O 0W1',
+          name: 'Meow Meowington',
+          countryCode: 'CA',
+          provinceCode: 'ON',
+          id: 'Z2lkOi8vc2hvcGlmeS9QcmdfnAU8nakdWMnAbh890hyOTEwNjA2NDU4NA=='
         },
-        "shippingLine": null,
-        "requiresShipping": true,
-        "customAttributes": [],
-        "note": null,
-        "paymentDue": "367.19",
-        "webUrl": "https://checkout.myshopify.io/1/checkouts/c4abf4bf036239ab5e3d0bf93c642c96",
-        "orderStatusUrl": null,
-        "taxExempt": false,
-        "taxesIncluded": false,
-        "currencyCode": "CAD",
-        "totalTax": "42.24",
-        "lineItemsSubtotalPrice": {
-          "amount": "324.95",
-          "currencyCode": "CAD"
+        shippingLine: null,
+        requiresShipping: true,
+        customAttributes: [],
+        note: null,
+        paymentDue: '367.19',
+        webUrl: 'https://checkout.myshopify.io/1/checkouts/c4abf4bf036239ab5e3d0bf93c642c96',
+        orderStatusUrl: null,
+        taxExempt: false,
+        taxesIncluded: false,
+        currencyCode: 'CAD',
+        totalTax: '42.24',
+        lineItemsSubtotalPrice: {
+          amount: '324.95',
+          currencyCode: 'CAD'
         },
-        "subtotalPrice": "324.95",
-        "totalPrice": "367.19",
-        "completedAt": null,
-        "createdAt": "2017-03-28T16:58:31Z",
-        "updatedAt": "2017-03-28T16:58:31Z"
+        subtotalPrice: '324.95',
+        totalPrice: '367.19',
+        completedAt: null,
+        createdAt: '2017-03-28T16:58:31Z',
+        updatedAt: '2017-03-28T16:58:31Z'
       }
     }
   }

--- a/fixtures/checkout-create-with-paginated-line-items-fixture.js
+++ b/fixtures/checkout-create-with-paginated-line-items-fixture.js
@@ -1,83 +1,63 @@
 export default {
-  "data": {
-    "checkoutCreate": {
-      "checkoutUserErrors": [],
-      "userErrors": [],
-      "checkout": {
-        "id": "Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",
-        "ready": true,
-        "lineItems": {
-          "pageInfo": {
-            "hasNextPage": true,
-            "hasPreviousPage": false
+  data: {
+    checkoutCreate: {
+      checkoutUserErrors: [],
+      userErrors: [],
+      checkout: {
+        id: 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=',
+        ready: true,
+        lineItems: {
+          pageInfo: {
+            hasNextPage: true,
+            hasPreviousPage: false
           },
-          "edges": [
+          edges: [
             {
-              "cursor": "eyJsYXN0X2lkIjoiZDUyZWU5ZTEwYmQxMWE0NDlkNmQzMWNkMzBhMGFjNzMifQ==",
-              "node": {
-                "title": "Intelligent Granite Table",
-                "variant": {
-                  "id": "gid://shopify/ProductVariant/1",
-                  "title": "Awesome Copper Bench",
-                  "price": "64.99",
-                  "compareAtPrice": "69.99",
-                  "weight": 4.5,
-                  "image": null,
-                  "selectedOptions": [
+              cursor: 'eyJsYXN0X2lkIjoiZDUyZWU5ZTEwYmQxMWE0NDlkNmQzMWNkMzBhMGFjNzMifQ==',
+              node: {
+                title: 'Intelligent Granite Table',
+                variant: {
+                  id: 'gid://shopify/ProductVariant/1',
+                  title: 'Awesome Copper Bench',
+                  price: '64.99',
+                  compareAtPrice: '69.99',
+                  weight: 4.5,
+                  image: null,
+                  selectedOptions: [
                     {
-                      "name": "Color or something",
-                      "value": "Awesome Copper Bench"
+                      name: 'Color or something',
+                      value: 'Awesome Copper Bench'
                     }
-                  ],
-                  "presentmentPrices": {
-                    "pageInfo": {
-                      "hasNextPage": false,
-                      "hasPreviousPage": false
-                    },
-                    "edges": [
-                      {
-                        "node": {
-                          "price": {
-                            "amount": "64.99",
-                            "currencyCode": "USD"
-                          },
-                          "compareAtPrice": {
-                            "amount": "69.99",
-                            "currencyCode": "USD"
-                          }
-                        }
-                      }
-                    ]
-                  }
+                  ]
                 },
-                "quantity": 5,
-                "customAttributes": []
+                quantity: 5,
+                customAttributes: []
               }
             }
           ]
         },
-        "shippingAddress": null,
-        "shippingLine": null,
-        "requiresShipping": true,
-        "customAttributes": [],
-        "note": null,
-        "paymentDue": "367.19",
-        "webUrl": "https://checkout.myshopify.io/1/checkouts/c4abf4bf036239ab5e3d0bf93c642c96",
-        "order": null,
-        "orderStatusUrl": null,
-        "taxExempt": false,
-        "taxesIncluded": false,
-        "currencyCode": "CAD",
-        "totalTax": "42.24",
-        "lineItemsSubtotalPrice": {
-          "amount": "324.95",
-          "currencyCode": "CAD"
+        shippingAddress: null,
+        shippingLine: null,
+        requiresShipping: true,
+        customAttributes: [],
+        note: null,
+        paymentDue: '367.19',
+        webUrl: 'https://checkout.myshopify.io/1/checkouts/c4abf4bf036239ab5e3d0bf93c642c96',
+        order: null,
+        orderStatusUrl: null,
+        taxExempt: false,
+        taxesIncluded: false,
+        currencyCode: 'CAD',
+        totalTax: '42.24',
+        lineItemsSubtotalPrice: {
+          amount: '324.95',
+          currencyCode: 'CAD'
         },
-        "subtotalPrice": "324.95",
-        "totalPrice": "367.19",
-        "completedAt": null,
-        "createdAt": "2017-03-28T16:58:31Z",
-        "updatedAt": "2017-03-28T16:58:31Z"
+        subtotalPrice: '324.95',
+        totalPrice: '367.19',
+        completedAt: null,
+        createdAt: '2017-03-28T16:58:31Z',
+        updatedAt: '2017-03-28T16:58:31Z'
       }
     }
   }

--- a/fixtures/checkout-line-items-update-fixture.js
+++ b/fixtures/checkout-line-items-update-fixture.js
@@ -1,97 +1,77 @@
 export default {
-   "data":{
-      "checkoutLineItemsUpdate":{
-         "userErrors":[],
-         "checkoutUserErrors": [],
-         "checkout":{
-            "id":"Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=",
-            "ready":true,
-            "lineItems":{
-               "pageInfo":{
-                  "hasNextPage":false,
-                  "hasPreviousPage":false
-               },
-               "edges": [
-                  {
-                     "cursor":"eyJsYXN0X2lkIjoiZmI3MTEwMmYwZDM4ZGU0NmUwMzdiMzBmODE3ZTlkYjUifQ==",
-                     "node":{
-                        "id":"zUzNzQ1ZjU0OTVlZjIyYzIxYzVkZj9rZXk9MTlkMjljZDgwYjg3MGMxNmRmNjNjM2JjODUzYjY3MTY=",
-                        "title":"Arena Zip Boot",
-                        "variant":{
-                           "id":"Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==",
-                           "title":"Black / 8",
-                           "price":"188.00",
-                           "compareAtPrice":"190.00",
-                           "weight":0,
-                           "image": {
-                              "id":"Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
-                              "src":"https://cdn.shopify.com/s/files/1/1312/0893/products/003_3e206539-20d3-49c0-8bff-006e449906ca.jpg?v=1491850970",
-                              "altText":null
-                           },
-                           "selectedOptions":[
-                              {
-                                 "name":"Color",
-                                 "value":"Black"
-                              },
-                              {
-                                 "name":"Size",
-                                 "value":"8"
-                              }
-                           ],
-                           "presentmentPrices": {
-                              "pageInfo": {
-                                "hasNextPage": false,
-                                "hasPreviousPage": false
-                              },
-                              "edges": [
-                                {
-                                  "node": {
-                                    "price": {
-                                      "amount": "188.00",
-                                      "currencyCode": "USD"
-                                    },
-                                    "compareAtPrice": {
-                                      "amount": "190.00",
-                                      "currencyCode": "USD"
-                                    }
-                                  }
-                                }
-                              ]
-                            }
-                        },
-                        "quantity":2,
-                        "customAttributes":[
+  data: {
+    checkoutLineItemsUpdate: {
+      userErrors: [],
+      checkoutUserErrors: [],
+      checkout: {
+        id: 'Z2lkOi8vc2hvcGlmeS9DaGVja291dC9lM2JkNzFmNzI0OGM4MDZmMzM3MjVhNTNlMzM5MzFlZj9rZXk9NDcwOTJlNDQ4NTI5MDY4ZDFiZTUyZTUwNTE2MDNhZjg=',
+        ready: true,
+        lineItems: {
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false
+          },
+          edges: [
+            {
+              cursor: 'eyJsYXN0X2lkIjoiZmI3MTEwMmYwZDM4ZGU0NmUwMzdiMzBmODE3ZTlkYjUifQ==',
+              node: {
+                id: 'zUzNzQ1ZjU0OTVlZjIyYzIxYzVkZj9rZXk9MTlkMjljZDgwYjg3MGMxNmRmNjNjM2JjODUzYjY3MTY=',
+                title: 'Arena Zip Boot',
+                variant: {
+                  id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yOTEwNjA2NDU4NA==',
+                  title: 'Black / 8',
+                  price: '188.00',
+                  compareAtPrice: '190.00',
+                  weight: 0,
+                  image: {
+                    id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=',
+                    src: 'https://cdn.shopify.com/s/files/1/1312/0893/products/003_3e206539-20d3-49c0-8bff-006e449906ca.jpg?v=1491850970',
+                    altText: null
+                  },
+                  selectedOptions: [
+                    {
+                      name: 'Color',
+                      value: 'Black'
+                    },
+                    {
+                      name: 'Size',
+                      value: '8'
+                    }
+                  ]
+                },
+                quantity: 2,
+                customAttributes: [
 
-                        ]
-                     }
-                  }
-               ]
-            },
-            "shippingAddress":null,
-            "shippingLine":null,
-            "requiresShipping":true,
-            "customAttributes":[
+                ]
+              }
+            }
+          ]
+        },
+        shippingAddress: null,
+        shippingLine: null,
+        requiresShipping: true,
+        customAttributes: [
 
-            ],
-            "note":null,
-            "paymentDue":"376.00",
-            "webUrl":"https://checkout.shopify.com/13120893/checkouts/e28b55a3205f8d129a9b7223287ec95a?key=191add76e8eba90b93cfe4d5d261c4cb",
-            "order":null,
-            "orderStatusUrl":null,
-            "taxExempt":false,
-            "taxesIncluded":false,
-            "currencyCode":"CAD",
-            "totalTax":"0.00",
-            "lineItemsSubtotalPrice": {
-              "amount": "376.00",
-              "currencyCode": "CAD"
-            },
-            "subtotalPrice":"376.00",
-            "totalPrice":"376.00",
-            "completedAt":null,
-            "createdAt":"2017-04-13T21:54:16Z",
-            "updatedAt":"2017-04-13T21:54:17Z"
-         }
+        ],
+        note: null,
+        paymentDue: '376.00',
+        webUrl: 'https://checkout.shopify.com/13120893/checkouts/e28b55a3205f8d129a9b7223287ec95a?key=191add76e8eba90b93cfe4d5d261c4cb',
+        order: null,
+        orderStatusUrl: null,
+        taxExempt: false,
+        taxesIncluded: false,
+        currencyCode: 'CAD',
+        totalTax: '0.00',
+        lineItemsSubtotalPrice: {
+          amount: '376.00',
+          currencyCode: 'CAD'
+        },
+        subtotalPrice: '376.00',
+        totalPrice: '376.00',
+        completedAt: null,
+        createdAt: '2017-04-13T21:54:16Z',
+        updatedAt: '2017-04-13T21:54:17Z'
       }
-   }
+    }
+  }
 };

--- a/fixtures/shop-info-fixture.js
+++ b/fixtures/shop-info-fixture.js
@@ -1,14 +1,13 @@
 export default {
-  "data": {
-    "shop": {
-      "currencyCode": "CAD",
-      "description": "pls send me cats",
-      "moneyFormat": "${{amount}}",
-      "name": "sendmecats",
-      "primaryDomain": {
-        "host": "sendmecats.myshopify.com",
-        "sslEnabled": true,
-        "url": "https://sendmecats.myshopify.com"
+  data: {
+    shop: {
+      description: 'pls send me cats',
+      moneyFormat: '${{amount}}',
+      name: 'sendmecats',
+      primaryDomain: {
+        host: 'sendmecats.myshopify.com',
+        sslEnabled: true,
+        url: 'https://sendmecats.myshopify.com'
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint --max-warnings 0 -c .eslintrc.json $(yarn run lint:reporter-args 2>&1 >/dev/null) src/ test/",
     "lint:reporter-args": "test -n \"${CI}\" && >&2 echo -o $CIRCLE_TEST_REPORTS/junit/eslint.xml -f junit",
     "print-start-message": "wait-on file:.tmp/test/index.html file:.tmp/test/tests.js tcp:35729 tcp:4200 && echo \"\n\n⚡️⚡️⚡️  Good to go at http://localhost:4200 ⚡️⚡️⚡️\"",
-    "schema:fetch": "graphql-js-schema-fetch --url 'https://graphql.myshopify.com/api/2021-10/graphql' --header 'Authorization: Basic MzUxYzEyMjAxN2QwZjJhOTU3ZDMyYWU3MjhhZDc0OWM=' | jq '.' > schema.json",
+    "schema:fetch": "graphql-js-schema-fetch --url 'https://graphql.myshopify.com/api/2022-01/graphql' --header 'Authorization: Basic MzUxYzEyMjAxN2QwZjJhOTU3ZDMyYWU3MjhhZDc0OWM=' | jq '.' > schema.json",
     "minify-umd:optimized": "babel-minify index.umd.js > index.umd.min.js",
     "minify-umd:unoptimized": "babel-minify index.unoptimized.umd.js > index.unoptimized.umd.min.js"
   },

--- a/schema.json
+++ b/schema.json
@@ -12,7 +12,7 @@
         {
           "kind": "OBJECT",
           "name": "ApiVersion",
-          "description": "A version of the API.",
+          "description": "A version of the API, as defined by [Shopify API versioning](https://shopify.dev/api/usage/versioning).\nVersions are commonly referred to by their handle (for example, `2021-10`).\n",
           "fields": [
             {
               "name": "displayName",
@@ -426,48 +426,7 @@
             {
               "name": "image",
               "description": "The image associated with the article.",
-              "args": [
-                {
-                  "name": "maxWidth",
-                  "description": "Image width in pixels between 1 and 2048. This argument is deprecated: Use `maxWidth` on `Image.transformedSrc` instead.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "maxHeight",
-                  "description": "Image height in pixels between 1 and 2048. This argument is deprecated: Use `maxHeight` on `Image.transformedSrc` instead.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "crop",
-                  "description": "Crops the image according to the specified region. This argument is deprecated: Use `crop` on `Image.transformedSrc` instead.",
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "CropRegion",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "scale",
-                  "description": "Image size multiplier for high-resolution retina displays. Must be between 1 and 3. This argument is deprecated: Use `scale` on `Image.transformedSrc` instead.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": "1"
-                }
-              ],
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "Image",
@@ -591,8 +550,8 @@
                   "ofType": null
                 }
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "The `metafields` field will be removed in the future in favor of using [aliases](https://graphql.org/learn/queries/#aliases) with the `metafield` field.\n"
             },
             {
               "name": "onlineStoreUrl",
@@ -673,22 +632,6 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
-            },
-            {
-              "name": "url",
-              "description": "The url pointing to the article accessible from the web.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "URL",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `onlineStoreUrl` instead"
             }
           ],
           "inputFields": null,
@@ -1266,7 +1209,7 @@
                 },
                 {
                   "name": "query",
-                  "description": "Supported filter parameters:\n - `author`\n - `blog_title`\n - `created_at`\n - `tag`\n - `updated_at`\n\nSee the detailed [search syntax](https://help.shopify.com/api/getting-started/search-syntax)\nfor more information about using filters.\n",
+                  "description": "Supported filter parameters:\n - `author`\n - `blog_title`\n - `created_at`\n - `tag`\n - `tag_not`\n - `updated_at`\n\nSee the detailed [search syntax](https://help.shopify.com/api/getting-started/search-syntax)\nfor more information about using filters.\n",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -1458,8 +1401,8 @@
                   "ofType": null
                 }
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "The `metafields` field will be removed in the future in favor of using [aliases](https://graphql.org/learn/queries/#aliases) with the `metafield` field.\n"
             },
             {
               "name": "onlineStoreUrl",
@@ -1500,22 +1443,6 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
-            },
-            {
-              "name": "url",
-              "description": "The url pointing to the blog accessible from the web.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "URL",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `onlineStoreUrl` instead"
             }
           ],
           "inputFields": null,
@@ -1728,7 +1655,7 @@
         {
           "kind": "OBJECT",
           "name": "Cart",
-          "description": "A cart represents the merchandise that a buyer intends to purchase, and the estimated cost associated with the cart.",
+          "description": "A cart represents the merchandise that a buyer intends to purchase, and the estimated cost associated with the cart. To learn how to interact with a cart during a customer's session, refer to the [Cart guide](https://shopify.dev/custom-storefronts/cart).",
           "fields": [
             {
               "name": "attributes",
@@ -1828,7 +1755,7 @@
             },
             {
               "name": "estimatedCost",
-              "description": "The estimated costs that the buyer will pay at checkout.",
+              "description": "The estimated costs that the buyer will pay at checkout. The estimated costs are subject to change and changes will be reflected at checkout.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -2445,7 +2372,7 @@
         {
           "kind": "ENUM",
           "name": "CartErrorCode",
-          "description": "Possible error codes that could be returned by CartUserError.",
+          "description": "Possible error codes that can be returned by `CartUserError`.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -2690,7 +2617,7 @@
             },
             {
               "name": "estimatedCost",
-              "description": "The estimated cost of the merchandise that the buyer will pay for at checkout.",
+              "description": "The estimated cost of the merchandise that the buyer will pay for at checkout. The estimated costs are subject to change and changes will be reflected at checkout.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -2893,7 +2820,7 @@
             },
             {
               "name": "totalAmount",
-              "description": "The estimated total cost of the merchandise line, without discounts.",
+              "description": "The estimated total cost of the merchandise line.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -3426,18 +3353,6 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
-            },
-            {
-              "name": "customer",
-              "description": "The customer associated with the checkout.",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Customer",
-                "ofType": null
-              },
-              "isDeprecated": true,
-              "deprecationReason": "This field will always return null. If you have an authentication token for the customer, you can use the `customer` field on the query root to retrieve it."
             },
             {
               "name": "discountApplications",
@@ -5583,7 +5498,7 @@
         {
           "kind": "ENUM",
           "name": "CheckoutErrorCode",
-          "description": "Possible error codes that could be returned by CheckoutUserError.",
+          "description": "Possible error codes that can be returned by `CheckoutUserError`.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -7107,48 +7022,7 @@
             {
               "name": "image",
               "description": "Image associated with the collection.",
-              "args": [
-                {
-                  "name": "maxWidth",
-                  "description": "Image width in pixels between 1 and 2048. This argument is deprecated: Use `maxWidth` on `Image.transformedSrc` instead.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "maxHeight",
-                  "description": "Image height in pixels between 1 and 2048. This argument is deprecated: Use `maxHeight` on `Image.transformedSrc` instead.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "crop",
-                  "description": "Crops the image according to the specified region. This argument is deprecated: Use `crop` on `Image.transformedSrc` instead.",
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "CropRegion",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "scale",
-                  "description": "Image size multiplier for high-resolution retina displays. Must be between 1 and 3. This argument is deprecated: Use `scale` on `Image.transformedSrc` instead.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": "1"
-                }
-              ],
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "Image",
@@ -7272,8 +7146,8 @@
                   "ofType": null
                 }
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "The `metafields` field will be removed in the future in favor of using [aliases](https://graphql.org/learn/queries/#aliases) with the `metafield` field.\n"
             },
             {
               "name": "onlineStoreUrl",
@@ -7350,6 +7224,24 @@
                     "ofType": null
                   },
                   "defaultValue": "COLLECTION_DEFAULT"
+                },
+                {
+                  "name": "filters",
+                  "description": "Returns a subset of products matching all product filters.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "ProductFilter",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -9696,7 +9588,7 @@
         {
           "kind": "ENUM",
           "name": "CurrencyCode",
-          "description": "Currency codes.",
+          "description": "The three-letter currency codes that represent the world currencies used in stores. These include standard ISO 4217 codes, legacy codes,\nand non-standard codes.\n",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -10969,8 +10861,8 @@
                   "ofType": null
                 }
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "The `metafields` field will be removed in the future in favor of using [aliases](https://graphql.org/learn/queries/#aliases) with the `metafield` field.\n"
             },
             {
               "name": "orders",
@@ -12047,7 +11939,7 @@
         {
           "kind": "ENUM",
           "name": "CustomerErrorCode",
-          "description": "Possible error codes that could be returned by CustomerUserError.",
+          "description": "Possible error codes that can be returned by `CustomerUserError`.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -12631,7 +12523,7 @@
         {
           "kind": "SCALAR",
           "name": "DateTime",
-          "description": "An ISO-8601 encoded UTC date time string. Example value: `\"2019-07-03T20:47:55Z\"`.",
+          "description": "Represents an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-encoded date and time string.\nFor example, 3:30 pm on September 7, 2019 in the time zone of UTC (Coordinated Universal Time) is\nrepresented as `\"2019-09-07T15:50:00Z`\".\n",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -12641,7 +12533,7 @@
         {
           "kind": "SCALAR",
           "name": "Decimal",
-          "description": "A signed decimal number, which supports arbitrary precision and is serialized as a string. Example value: `\"29.99\"`.",
+          "description": "A signed decimal number, which supports arbitrary precision and is serialized as a string.\n\nExample values: `\"29.99\"`, `\"29.999\"`.\n",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -13267,8 +13159,8 @@
                   "ofType": null
                 }
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "Use `originUrl` instead"
             },
             {
               "name": "host",
@@ -13344,6 +13236,187 @@
               "ofType": null
             }
           ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Filter",
+          "description": "A filter that is supported on the parent field.",
+          "fields": [
+            {
+              "name": "id",
+              "description": "A unique identifier.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "label",
+              "description": "A human-friendly string for this filter.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": "An enumeration that denotes the type of data this filter represents.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "FilterType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "values",
+              "description": "The list of values for this filter.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "FilterValue",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "FilterType",
+          "description": "Denotes the type of data this filter group represents.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "LIST",
+              "description": "A list of selectable values.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PRICE_RANGE",
+              "description": "A range of prices.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FilterValue",
+          "description": "A selectable value within a filter.",
+          "fields": [
+            {
+              "name": "count",
+              "description": "The number of results that match this filter value.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "A unique identifier.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "input",
+              "description": "An input object that can be used to filter by this value on the parent field.\n\nThe value is provided as a helper for building dynamic filtering UI. For example, if you have a list of selected `FilterValue` objects, you can combine their respective `input` values to use in a subsequent query.\n",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "JSON",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "label",
+              "description": "A human-friendly string for this filter value.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -13696,7 +13769,7 @@
         {
           "kind": "SCALAR",
           "name": "HTML",
-          "description": "A string containing HTML code. Example value: `\"<p>Grey cotton knit sweater.</p>\"`.",
+          "description": "A string containing HTML code. Refer to the [HTML spec](https://html.spec.whatwg.org/#elements-3) for a\ncomplete list of HTML elements.\n\nExample value: `\"<p>Grey cotton knit sweater.</p>\"`.\n",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -13823,8 +13896,8 @@
                   "ofType": null
                 }
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "The `metafields` field will be removed in the future in favor of using [aliases](https://graphql.org/learn/queries/#aliases) with the `metafield` field.\n"
             }
           ],
           "inputFields": null,
@@ -13881,7 +13954,7 @@
         {
           "kind": "SCALAR",
           "name": "ID",
-          "description": "Represents a unique identifier, often used to refetch an object or as key for a cache.\nThe ID type appears in a JSON response as a String, but it is not intended to be human-readable.\nWhen expected as an input type, any string (such as \"4\") or integer (such as 4) input value will be accepted as an ID.\n\nAdmin API example value: `\"gid://shopify/Product/10079785100\"`.\n\nStorefront API example value: `\"Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzEwMDc5Nzg1MTAw\"`.\n",
+          "description": "Represents a unique identifier, often used to refetch an object.\nThe ID type appears in a JSON response as a String, but it is not intended to be human-readable.\n\nAdmin API example value: `\"gid://shopify/Product/10079785100\"`.\n\nStorefront API example value: `\"Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzEwMDc5Nzg1MTAw\"`.\n",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -13942,8 +14015,8 @@
                   "ofType": null
                 }
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "Use `url` instead"
             },
             {
               "name": "src",
@@ -13959,7 +14032,7 @@
                 }
               },
               "isDeprecated": true,
-              "deprecationReason": "Previously an image had a single `src` field. This could either return the original image\nlocation or a URL that contained transformations such as sizing or scale.\n\nThese transformations were specified by arguments on the parent field.\n\nNow an image has two distinct URL fields: `originalSrc` and `transformedSrc`.\n\n* `originalSrc` - the original unmodified image URL\n* `transformedSrc` - the image URL with the specified transformations included\n\nTo migrate to the new fields, image transformations should be moved from the parent field to `transformedSrc`.\n\nBefore:\n```graphql\n{\n  shop {\n    productImages(maxWidth: 200, scale: 2) {\n      edges {\n        node {\n          src\n        }\n      }\n    }\n  }\n}\n```\n\nAfter:\n```graphql\n{\n  shop {\n    productImages {\n      edges {\n        node {\n          transformedSrc(maxWidth: 200, scale: 2)\n        }\n      }\n    }\n  }\n}\n```\n"
+              "deprecationReason": "Use `url` instead"
             },
             {
               "name": "transformedSrc",
@@ -14007,10 +14080,37 @@
                 },
                 {
                   "name": "preferredContentType",
-                  "description": "Best effort conversion of image into content type (SVG -> PNG, Anything -> JGP, Anything -> WEBP are supported).",
+                  "description": "Best effort conversion of image into content type (SVG -> PNG, Anything -> JPG, Anything -> WEBP are supported).",
                   "type": {
                     "kind": "ENUM",
                     "name": "ImageContentType",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "URL",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `url(transform:)` instead"
+            },
+            {
+              "name": "url",
+              "description": "The location of the image as a URL.\n\nIf no transform options are specified, then the original image will be preserved including any pre-applied transforms.\n\nAll transformation options are considered \"best-effort\". Any transformation that the original image type doesn't support will be ignored.\n\nIf you need multiple variations of the same image, then you can use [GraphQL field aliases](https://graphql.org/learn/queries/#aliases). For example:\n\n```graphql\n{\n  ... on Image {\n    original: url\n    thumbnail: url(transform: { maxWidth: 80, maxHeight: 80 })\n    retina: url(transform: { scale: 2 })\n  }\n}\n```\n",
+              "args": [
+                {
+                  "name": "transform",
+                  "description": "A set of options to transform the original image.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ImageTransformInput",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -14170,9 +14270,80 @@
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "ImageTransformInput",
+          "description": "The available options for transforming an image.\n\nAll transformation options are considered \"best-effort\". Any transformation that the original image type doesn't support will be ignored.\n",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "crop",
+              "description": "Crop the image according to the specified region.",
+              "type": {
+                "kind": "ENUM",
+                "name": "CropRegion",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "maxWidth",
+              "description": "Image width in pixels between 1 and 5760.\n",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "maxHeight",
+              "description": "Image height in pixels between 1 and 5760.\n",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "scale",
+              "description": "Image size multiplier for high-resolution retina displays. Must be within 1..3.\n",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": "1"
+            },
+            {
+              "name": "preferredContentType",
+              "description": "Convert the source image into the preferred content type.\nSupported conversions: `.svg` to `.png`, any file type to `.jpg`, and any file type to `.webp`.\n",
+              "type": {
+                "kind": "ENUM",
+                "name": "ImageContentType",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "SCALAR",
           "name": "Int",
           "description": "Represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "JSON",
+          "description": "A [JSON](https://www.json.org/json-en.html) object.\n\nExample value:\n`{\n  \"product\": {\n    \"id\": \"gid://shopify/Product/1346443542550\",\n    \"title\": \"White T-shirt\",\n    \"options\": [{\n      \"name\": \"Size\",\n      \"values\": [\"M\", \"L\"]\n    }]\n  }\n}`\n",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -15615,6 +15786,18 @@
               "deprecationReason": null
             },
             {
+              "name": "reference",
+              "description": "Returns a reference object if the metafield definition's type is a resource reference.",
+              "args": [],
+              "type": {
+                "kind": "UNION",
+                "name": "MetafieldReference",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "type",
               "description": "The type name of the metafield.\nSee the list of [supported types](https://shopify.dev/apps/metafields/definitions/types).\n",
               "args": [],
@@ -15661,22 +15844,6 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
-            },
-            {
-              "name": "valueType",
-              "description": "Represents the metafield value type.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "MetafieldValueType",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "`valueType` is deprecated and replaced by `type` in API version 2021-07."
             }
           ],
           "inputFields": null,
@@ -15785,6 +15952,59 @@
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "MetafieldFilter",
+          "description": "A filter used to view a subset of products in a collection matching a specific metafield value.\n\nOnly the following metafield types are currently supported:\n- `number_integer`\n- `number_decimal`\n- `single_line_text_field`\n",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "namespace",
+              "description": "The namespace of the metafield to filter on.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "key",
+              "description": "The key of the metafield to filter on.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "value",
+              "description": "The value of the metafield.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "UNION",
           "name": "MetafieldParentResource",
           "description": "A resource that the metafield belongs to.",
@@ -15841,33 +16061,35 @@
           ]
         },
         {
-          "kind": "ENUM",
-          "name": "MetafieldValueType",
-          "description": "Metafield value types.",
+          "kind": "UNION",
+          "name": "MetafieldReference",
+          "description": "Returns the resource which is being referred to by a metafield.\n",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "enumValues": [
+          "enumValues": null,
+          "possibleTypes": [
             {
-              "name": "STRING",
-              "description": "A string metafield.",
-              "isDeprecated": false,
-              "deprecationReason": null
+              "kind": "OBJECT",
+              "name": "MediaImage",
+              "ofType": null
             },
             {
-              "name": "INTEGER",
-              "description": "An integer metafield.",
-              "isDeprecated": false,
-              "deprecationReason": null
+              "kind": "OBJECT",
+              "name": "Page",
+              "ofType": null
             },
             {
-              "name": "JSON_STRING",
-              "description": "A json string metafield.",
-              "isDeprecated": false,
-              "deprecationReason": null
+              "kind": "OBJECT",
+              "name": "Product",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "ProductVariant",
+              "ofType": null
             }
-          ],
-          "possibleTypes": null
+          ]
         },
         {
           "kind": "OBJECT",
@@ -16049,7 +16271,7 @@
         {
           "kind": "SCALAR",
           "name": "Money",
-          "description": "A monetary value string. Example value: `\"100.57\"`.",
+          "description": "A monetary value string without a currency symbol or code. Example value: `\"100.57\"`.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -16126,100 +16348,6 @@
                 "ofType": {
                   "kind": "ENUM",
                   "name": "CurrencyCode",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "MoneyV2Connection",
-          "description": "An auto-generated type for paginating through multiple MoneyV2s.\n",
-          "fields": [
-            {
-              "name": "edges",
-              "description": "A list of edges.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "MoneyV2Edge",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "pageInfo",
-              "description": "Information to aid in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PageInfo",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "MoneyV2Edge",
-          "description": "An auto-generated type which holds one MoneyV2 and a cursor during pagination.\n",
-          "fields": [
-            {
-              "name": "cursor",
-              "description": "A cursor for use in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "node",
-              "description": "The item at the end of MoneyV2Edge.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "MoneyV2",
                   "ofType": null
                 }
               },
@@ -18302,7 +18430,7 @@
         {
           "kind": "INTERFACE",
           "name": "Node",
-          "description": "An object with an ID to support global identification.",
+          "description": "An object with an ID field to support global identification, in accordance with the\n[Relay specification](https://relay.dev/graphql/objectidentification.htm#sec-Node-Interface).\nThis interface is used by the [node](https://shopify.dev/api/admin-graphql/unstable/queries/node)\nand [nodes](https://shopify.dev/api/admin-graphql/unstable/queries/nodes) queries.\n",
           "fields": [
             {
               "name": "id",
@@ -18941,8 +19069,8 @@
                   "ofType": null
                 }
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "The `metafields` field will be removed in the future in favor of using [aliases](https://graphql.org/learn/queries/#aliases) with the `metafield` field.\n"
             },
             {
               "name": "name",
@@ -19467,62 +19595,62 @@
         {
           "kind": "ENUM",
           "name": "OrderFulfillmentStatus",
-          "description": "Represents the order's current fulfillment status.",
+          "description": "Represents the order's aggregated fulfillment status for display purposes.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
           "enumValues": [
             {
               "name": "UNFULFILLED",
-              "description": "Displayed as **Unfulfilled**.",
+              "description": "Displayed as **Unfulfilled**. None of the items in the order have been fulfilled.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "PARTIALLY_FULFILLED",
-              "description": "Displayed as **Partially fulfilled**.",
+              "description": "Displayed as **Partially fulfilled**. Some of the items in the order have been fulfilled.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "FULFILLED",
-              "description": "Displayed as **Fulfilled**.",
+              "description": "Displayed as **Fulfilled**. All of the items in the order have been fulfilled.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "RESTOCKED",
-              "description": "Displayed as **Restocked**.",
+              "description": "Displayed as **Restocked**. All of the items in the order have been restocked. Replaced by \"UNFULFILLED\" status.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "PENDING_FULFILLMENT",
-              "description": "Displayed as **Pending fulfillment**.",
+              "description": "Displayed as **Pending fulfillment**. A request for fulfillment of some items awaits a response from the fulfillment service. Replaced by \"IN_PROGRESS\" status.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "OPEN",
-              "description": "Displayed as **Open**.",
+              "description": "Displayed as **Open**. None of the items in the order have been fulfilled. Replaced by \"UNFULFILLED\" status.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "IN_PROGRESS",
-              "description": "Displayed as **In progress**.",
+              "description": "Displayed as **In progress**. Some of the items in the order have been fulfilled, or a request for fulfillment has been sent to the fulfillment service.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ON_HOLD",
-              "description": "Displayed as **On hold**.",
+              "description": "Displayed as **On hold**. All of the unfulfilled items in this order are on hold.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "SCHEDULED",
-              "description": "Displayed as **Scheduled**.",
+              "description": "Displayed as **Scheduled**. All of the unfulfilled items in this order are scheduled for fulfillment at later time.",
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -20009,8 +20137,8 @@
                   "ofType": null
                 }
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "The `metafields` field will be removed in the future in favor of using [aliases](https://graphql.org/learn/queries/#aliases) with the `metafield` field.\n"
             },
             {
               "name": "onlineStoreUrl",
@@ -20067,22 +20195,6 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
-            },
-            {
-              "name": "url",
-              "description": "The url pointing to the page accessible from the web.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "URL",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `onlineStoreUrl` instead"
             }
           ],
           "inputFields": null,
@@ -20203,11 +20315,11 @@
         {
           "kind": "OBJECT",
           "name": "PageInfo",
-          "description": "Information about pagination in a connection.",
+          "description": "Returns information about pagination in a connection, in accordance with the\n[Relay specification](https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo).\n",
           "fields": [
             {
               "name": "hasNextPage",
-              "description": "Indicates if there are more pages to fetch.",
+              "description": "Whether there are more pages to fetch following the current page.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -20223,7 +20335,7 @@
             },
             {
               "name": "hasPreviousPage",
-              "description": "Indicates if there are any pages prior to the current page.",
+              "description": "Whether there are any pages prior to the current page.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -20637,8 +20749,45 @@
               "description": "Google Pay token type.",
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "STRIPE_VAULT_TOKEN",
+              "description": "Stripe token type.",
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "PriceRangeFilter",
+          "description": "A filter used to view a subset of products in a collection matching a specific price range.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "min",
+              "description": "The minimum price in the range. Defaults to zero.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": "0.0"
+            },
+            {
+              "name": "max",
+              "description": "The maximum price in the range. Empty indicates no max price.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
           "possibleTypes": null
         },
         {
@@ -20853,6 +21002,18 @@
               "deprecationReason": null
             },
             {
+              "name": "featuredImage",
+              "description": "The featured image for the product.\n\nThis field is functionally equivalent to `images(first: 1)`.\n",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Image",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "handle",
               "description": "A human-friendly unique string for the Product automatically generated from its title.\nThey are used by the Liquid templating language to refer to objects.\n",
               "args": [],
@@ -20947,46 +21108,6 @@
                     "ofType": null
                   },
                   "defaultValue": "POSITION"
-                },
-                {
-                  "name": "maxWidth",
-                  "description": "Image width in pixels between 1 and 2048. This argument is deprecated: Use `maxWidth` on `Image.transformedSrc` instead.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "maxHeight",
-                  "description": "Image height in pixels between 1 and 2048. This argument is deprecated: Use `maxHeight` on `Image.transformedSrc` instead.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "crop",
-                  "description": "Crops the image according to the specified region. This argument is deprecated: Use `crop` on `Image.transformedSrc` instead.",
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "CropRegion",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "scale",
-                  "description": "Image size multiplier for high-resolution retina displays. Must be between 1 and 3. This argument is deprecated: Use `scale` on `Image.transformedSrc` instead.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": "1"
                 }
               ],
               "type": {
@@ -21193,8 +21314,8 @@
                   "ofType": null
                 }
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "The `metafields` field will be removed in the future in favor of using [aliases](https://graphql.org/learn/queries/#aliases) with the `metafield` field.\n"
             },
             {
               "name": "onlineStoreUrl",
@@ -21242,91 +21363,6 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
-            },
-            {
-              "name": "presentmentPriceRanges",
-              "description": "List of price ranges in the presentment currencies for this shop.",
-              "args": [
-                {
-                  "name": "presentmentCurrencies",
-                  "description": "Specifies the presentment currencies to return a price range in.",
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "ENUM",
-                        "name": "CurrencyCode",
-                        "ofType": null
-                      }
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "first",
-                  "description": "Returns up to the first `n` elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "after",
-                  "description": "Returns the elements that come after the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "last",
-                  "description": "Returns up to the last `n` elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "before",
-                  "description": "Returns the elements that come before the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "reverse",
-                  "description": "Reverse the order of the underlying list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  },
-                  "defaultValue": "false"
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "ProductPriceRangeConnection",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `@inContext` instead."
             },
             {
               "name": "priceRange",
@@ -21782,6 +21818,30 @@
               "deprecationReason": null
             },
             {
+              "name": "filters",
+              "description": "A list of available filters.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Filter",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "pageInfo",
               "description": "Information to aid in pagination.",
               "args": [],
@@ -21843,6 +21903,87 @@
           ],
           "inputFields": null,
           "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ProductFilter",
+          "description": "A filter used to view a subset of products in a collection.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "available",
+              "description": "Filter on if the product is available for sale.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "variantOption",
+              "description": "A variant option to filter on.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "VariantOptionFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "productType",
+              "description": "The product type to filter on.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "productVendor",
+              "description": "The product vendor to filter on.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "price",
+              "description": "A range of prices to filter with-in.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "PriceRangeFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "productMetafield",
+              "description": "A product metafield to filter on.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "MetafieldFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "variantMetafield",
+              "description": "A variant metafield to filter on.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "MetafieldFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -22027,100 +22168,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "ProductPriceRangeConnection",
-          "description": "An auto-generated type for paginating through multiple ProductPriceRanges.\n",
-          "fields": [
-            {
-              "name": "edges",
-              "description": "A list of edges.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "ProductPriceRangeEdge",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "pageInfo",
-              "description": "Information to aid in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PageInfo",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "ProductPriceRangeEdge",
-          "description": "An auto-generated type which holds one ProductPriceRange and a cursor during pagination.\n",
-          "fields": [
-            {
-              "name": "cursor",
-              "description": "A cursor for use in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "node",
-              "description": "The item at the end of ProductPriceRangeEdge.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "ProductPriceRange",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "ENUM",
           "name": "ProductSortKeys",
           "description": "The set of valid sort keys for the Product query.",
@@ -22191,18 +22238,6 @@
           "description": "A product variant represents a different version of a product, such as differing sizes or differing colors.",
           "fields": [
             {
-              "name": "available",
-              "description": "Indicates if the product variant is in stock.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `availableForSale` instead"
-            },
-            {
               "name": "availableForSale",
               "description": "Indicates if the product variant is available for sale.",
               "args": [],
@@ -22214,6 +22249,18 @@
                   "name": "Boolean",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "barcode",
+              "description": "The barcode (for example, ISBN, UPC, or GTIN) associated with the variant.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -22276,49 +22323,8 @@
             },
             {
               "name": "image",
-              "description": "Image associated with the product variant. This field falls back to the product image if no image is available.",
-              "args": [
-                {
-                  "name": "maxWidth",
-                  "description": "Image width in pixels between 1 and 2048. This argument is deprecated: Use `maxWidth` on `Image.transformedSrc` instead.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "maxHeight",
-                  "description": "Image height in pixels between 1 and 2048. This argument is deprecated: Use `maxHeight` on `Image.transformedSrc` instead.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "crop",
-                  "description": "Crops the image according to the specified region. This argument is deprecated: Use `crop` on `Image.transformedSrc` instead.",
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "CropRegion",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "scale",
-                  "description": "Image size multiplier for high-resolution retina displays. Must be between 1 and 3. This argument is deprecated: Use `scale` on `Image.transformedSrc` instead.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": "1"
-                }
-              ],
+              "description": "Image associated with the product variant. This field falls back to the product image if no image is available.\n",
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "Image",
@@ -22442,178 +22448,8 @@
                   "ofType": null
                 }
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "presentmentPrices",
-              "description": "List of prices and compare-at prices in the presentment currencies for this shop.",
-              "args": [
-                {
-                  "name": "presentmentCurrencies",
-                  "description": "The presentment currencies prices should return in.",
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "ENUM",
-                        "name": "CurrencyCode",
-                        "ofType": null
-                      }
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "first",
-                  "description": "Returns up to the first `n` elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "after",
-                  "description": "Returns the elements that come after the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "last",
-                  "description": "Returns up to the last `n` elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "before",
-                  "description": "Returns the elements that come before the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "reverse",
-                  "description": "Reverse the order of the underlying list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  },
-                  "defaultValue": "false"
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "ProductVariantPricePairConnection",
-                  "ofType": null
-                }
-              },
               "isDeprecated": true,
-              "deprecationReason": "Use `@inContext` instead."
-            },
-            {
-              "name": "presentmentUnitPrices",
-              "description": "List of unit prices in the presentment currencies for this shop.",
-              "args": [
-                {
-                  "name": "presentmentCurrencies",
-                  "description": "Specify the currencies in which to return presentment unit prices.",
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "ENUM",
-                        "name": "CurrencyCode",
-                        "ofType": null
-                      }
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "first",
-                  "description": "Returns up to the first `n` elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "after",
-                  "description": "Returns the elements that come after the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "last",
-                  "description": "Returns up to the last `n` elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "before",
-                  "description": "Returns the elements that come before the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "reverse",
-                  "description": "Reverse the order of the underlying list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  },
-                  "defaultValue": "false"
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "MoneyV2Connection",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `@inContext` instead."
+              "deprecationReason": "The `metafields` field will be removed in the future in favor of using [aliases](https://graphql.org/learn/queries/#aliases) with the `metafield` field.\n"
             },
             {
               "name": "price",
@@ -23041,139 +22877,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "ProductVariantPricePair",
-          "description": "The compare-at price and price of a variant sharing a currency.\n",
-          "fields": [
-            {
-              "name": "compareAtPrice",
-              "description": "The compare-at price of the variant with associated currency.",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "MoneyV2",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "price",
-              "description": "The price of the variant with associated currency.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "MoneyV2",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "ProductVariantPricePairConnection",
-          "description": "An auto-generated type for paginating through multiple ProductVariantPricePairs.\n",
-          "fields": [
-            {
-              "name": "edges",
-              "description": "A list of edges.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "ProductVariantPricePairEdge",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "pageInfo",
-              "description": "Information to aid in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PageInfo",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "ProductVariantPricePairEdge",
-          "description": "An auto-generated type which holds one ProductVariantPricePair and a cursor during pagination.\n",
-          "fields": [
-            {
-              "name": "cursor",
-              "description": "A cursor for use in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "node",
-              "description": "The item at the end of ProductVariantPricePairEdge.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "ProductVariantPricePair",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "ENUM",
           "name": "ProductVariantSortKeys",
           "description": "The set of valid sort keys for the ProductVariant query.",
@@ -23285,7 +22988,7 @@
                 },
                 {
                   "name": "query",
-                  "description": "Supported filter parameters:\n - `author`\n - `blog_title`\n - `created_at`\n - `tag`\n - `updated_at`\n\nSee the detailed [search syntax](https://help.shopify.com/api/getting-started/search-syntax)\nfor more information about using filters.\n",
+                  "description": "Supported filter parameters:\n - `author`\n - `blog_title`\n - `created_at`\n - `tag`\n - `tag_not`\n - `updated_at`\n\nSee the detailed [search syntax](https://help.shopify.com/api/getting-started/search-syntax)\nfor more information about using filters.\n",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -24197,7 +23900,7 @@
                 },
                 {
                   "name": "query",
-                  "description": "Supported filter parameters:\n - `available_for_sale`\n - `created_at`\n - `product_type`\n - `tag`\n - `title`\n - `updated_at`\n - `variants.price`\n - `vendor`\n\nSee the detailed [search syntax](https://help.shopify.com/api/getting-started/search-syntax)\nfor more information about using filters.\n",
+                  "description": "Supported filter parameters:\n - `available_for_sale`\n - `created_at`\n - `product_type`\n - `tag`\n - `tag_not`\n - `title`\n - `updated_at`\n - `variants.price`\n - `vendor`\n\nSee the detailed [search syntax](https://help.shopify.com/api/getting-started/search-syntax)\nfor more information about using filters.\n",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -24319,22 +24022,6 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
-            },
-            {
-              "name": "description",
-              "description": "The description of the application as defined by the Script.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `title` instead"
             },
             {
               "name": "targetSelection",
@@ -25460,310 +25147,6 @@
           "description": "Shop represents a collection of the general settings and information about the shop.",
           "fields": [
             {
-              "name": "articles",
-              "description": "List of the shop' articles.",
-              "args": [
-                {
-                  "name": "first",
-                  "description": "Returns up to the first `n` elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "after",
-                  "description": "Returns the elements that come after the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "last",
-                  "description": "Returns up to the last `n` elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "before",
-                  "description": "Returns the elements that come before the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "reverse",
-                  "description": "Reverse the order of the underlying list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  },
-                  "defaultValue": "false"
-                },
-                {
-                  "name": "sortKey",
-                  "description": "Sort the underlying list by the given key.",
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "ArticleSortKeys",
-                    "ofType": null
-                  },
-                  "defaultValue": "ID"
-                },
-                {
-                  "name": "query",
-                  "description": "Supported filter parameters:\n - `author`\n - `blog_title`\n - `created_at`\n - `tag`\n - `updated_at`\n\nSee the detailed [search syntax](https://help.shopify.com/api/getting-started/search-syntax)\nfor more information about using filters.\n",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "ArticleConnection",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `QueryRoot.articles` instead."
-            },
-            {
-              "name": "blogs",
-              "description": "List of the shop' blogs.",
-              "args": [
-                {
-                  "name": "first",
-                  "description": "Returns up to the first `n` elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "after",
-                  "description": "Returns the elements that come after the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "last",
-                  "description": "Returns up to the last `n` elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "before",
-                  "description": "Returns the elements that come before the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "reverse",
-                  "description": "Reverse the order of the underlying list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  },
-                  "defaultValue": "false"
-                },
-                {
-                  "name": "sortKey",
-                  "description": "Sort the underlying list by the given key.",
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "BlogSortKeys",
-                    "ofType": null
-                  },
-                  "defaultValue": "ID"
-                },
-                {
-                  "name": "query",
-                  "description": "Supported filter parameters:\n - `created_at`\n - `handle`\n - `title`\n - `updated_at`\n\nSee the detailed [search syntax](https://help.shopify.com/api/getting-started/search-syntax)\nfor more information about using filters.\n",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "BlogConnection",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `QueryRoot.blogs` instead."
-            },
-            {
-              "name": "collectionByHandle",
-              "description": "Find a collection by its handle.",
-              "args": [
-                {
-                  "name": "handle",
-                  "description": "The handle of the collection.",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Collection",
-                "ofType": null
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `QueryRoot.collectionByHandle` instead."
-            },
-            {
-              "name": "collections",
-              "description": "List of the shop’s collections.",
-              "args": [
-                {
-                  "name": "first",
-                  "description": "Returns up to the first `n` elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "after",
-                  "description": "Returns the elements that come after the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "last",
-                  "description": "Returns up to the last `n` elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "before",
-                  "description": "Returns the elements that come before the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "reverse",
-                  "description": "Reverse the order of the underlying list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  },
-                  "defaultValue": "false"
-                },
-                {
-                  "name": "sortKey",
-                  "description": "Sort the underlying list by the given key.",
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "CollectionSortKeys",
-                    "ofType": null
-                  },
-                  "defaultValue": "ID"
-                },
-                {
-                  "name": "query",
-                  "description": "Supported filter parameters:\n - `collection_type`\n - `title`\n - `updated_at`\n\nSee the detailed [search syntax](https://help.shopify.com/api/getting-started/search-syntax)\nfor more information about using filters.\n",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "CollectionConnection",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `QueryRoot.collections` instead."
-            },
-            {
-              "name": "currencyCode",
-              "description": "The three-letter code for the currency that the shop accepts.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "CurrencyCode",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `paymentSettings` instead"
-            },
-            {
               "name": "description",
               "description": "A description of the shop.",
               "args": [],
@@ -25890,8 +25273,8 @@
                   "ofType": null
                 }
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "The `metafields` field will be removed in the future in favor of using [aliases](https://graphql.org/learn/queries/#aliases) with the `metafield` field.\n"
             },
             {
               "name": "moneyFormat",
@@ -25970,182 +25353,6 @@
               "deprecationReason": null
             },
             {
-              "name": "productByHandle",
-              "description": "Find a product by its handle.",
-              "args": [
-                {
-                  "name": "handle",
-                  "description": "The handle of the product.",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Product",
-                "ofType": null
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `QueryRoot.productByHandle` instead."
-            },
-            {
-              "name": "productTags",
-              "description": "A list of tags that have been added to products.\nAdditional access scope required: unauthenticated_read_product_tags.\n",
-              "args": [
-                {
-                  "name": "first",
-                  "description": "Returns up to the first `n` elements from the list.",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "StringConnection",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `QueryRoot.productTags` instead."
-            },
-            {
-              "name": "productTypes",
-              "description": "List of the shop’s product types.",
-              "args": [
-                {
-                  "name": "first",
-                  "description": "Returns up to the first `n` elements from the list.",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "StringConnection",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `QueryRoot.productTypes` instead."
-            },
-            {
-              "name": "products",
-              "description": "List of the shop’s products.",
-              "args": [
-                {
-                  "name": "first",
-                  "description": "Returns up to the first `n` elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "after",
-                  "description": "Returns the elements that come after the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "last",
-                  "description": "Returns up to the last `n` elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "before",
-                  "description": "Returns the elements that come before the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "reverse",
-                  "description": "Reverse the order of the underlying list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  },
-                  "defaultValue": "false"
-                },
-                {
-                  "name": "sortKey",
-                  "description": "Sort the underlying list by the given key.",
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "ProductSortKeys",
-                    "ofType": null
-                  },
-                  "defaultValue": "ID"
-                },
-                {
-                  "name": "query",
-                  "description": "Supported filter parameters:\n - `available_for_sale`\n - `created_at`\n - `product_type`\n - `tag`\n - `title`\n - `updated_at`\n - `variants.price`\n - `vendor`\n\nSee the detailed [search syntax](https://help.shopify.com/api/getting-started/search-syntax)\nfor more information about using filters.\n",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "ProductConnection",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `QueryRoot.products` instead."
-            },
-            {
               "name": "refundPolicy",
               "description": "The shop’s refund policy.",
               "args": [],
@@ -26194,16 +25401,16 @@
               "deprecationReason": null
             },
             {
-              "name": "shopifyPaymentsAccountId",
-              "description": "The shop’s Shopify Payments account id.",
+              "name": "subscriptionPolicy",
+              "description": "The shop’s subscription policy.",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "OBJECT",
+                "name": "ShopPolicyWithDefault",
                 "ofType": null
               },
-              "isDeprecated": true,
-              "deprecationReason": "Use `paymentSettings` instead"
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
               "name": "termsOfService",
@@ -26328,8 +25535,95 @@
         },
         {
           "kind": "OBJECT",
+          "name": "ShopPolicyWithDefault",
+          "description": "A policy for the store that comes with a default value, such as a subscription policy.\nIf the merchant hasn't configured a policy for their store, then the policy will return the default value.\nOtherwise, the policy will return the merchant-configured value.\n",
+          "fields": [
+            {
+              "name": "body",
+              "description": "The text of the policy. Maximum size: 64KB.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "handle",
+              "description": "The handle of the policy.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "The unique identifier of the policy. A default policy doesn't have an ID.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "The title of the policy.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": "Public URL to the policy.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "URL",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "StoreAvailability",
-          "description": "Describes the availability of a product variant at a particular location.",
+          "description": "The availability of a product variant at a particular location.\nLocal pick-up must be enabled in the  store's shipping settings, otherwise this will return an empty result.\n",
           "fields": [
             {
               "name": "available",
@@ -26492,7 +25786,7 @@
         {
           "kind": "OBJECT",
           "name": "StringConnection",
-          "description": "An auto-generated type for paginating through multiple Strings.\n",
+          "description": "An auto-generated type for paginating through a list of Strings.\n",
           "fields": [
             {
               "name": "edges",
@@ -27068,7 +26362,7 @@
         {
           "kind": "SCALAR",
           "name": "URL",
-          "description": "An RFC 3986 and RFC 3987 compliant URI string.\n\nExample value: `\"https://johns-apparel.myshopify.com\"`.\n",
+          "description": "Represents an [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) and\n[RFC 3987](https://datatracker.ietf.org/doc/html/rfc3987)-compliant URI string.\n\nFor example, `\"https://johns-apparel.myshopify.com\"` is a valid URL. It includes a scheme (`https`) and a host\n(`johns-apparel.myshopify.com`).\n",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -27339,6 +26633,45 @@
               "ofType": null
             }
           ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "VariantOptionFilter",
+          "description": "A filter used to view a subset of products in a collection matching a specific variant option.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "name",
+              "description": "The name of the variant option to filter on.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "value",
+              "description": "The value of the variant option to filter on.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -28657,7 +27990,7 @@
         },
         {
           "name": "inContext",
-          "description": "Contextualizes data based on the additional information provided by the directive. For example, you can use the `@inContext(country: CA)` directive to query the price of a product in a storefront within the context of Canada.",
+          "description": "Contextualizes data based on the additional information provided by the directive. For example, you can use the `@inContext(country: CA)` directive to [query a product's price](https://shopify.dev/custom-storefronts/products/international-pricing#query-product-prices) in a storefront within the context of Canada.",
           "locations": [
             "QUERY",
             "MUTATION"

--- a/src/config.js
+++ b/src/config.js
@@ -57,7 +57,7 @@ class Config {
     if (attrs.hasOwnProperty('apiVersion')) {
       this.apiVersion = attrs.apiVersion;
     } else {
-      this.apiVersion = '2021-10';
+      this.apiVersion = '2022-01';
     }
 
     if (attrs.hasOwnProperty('source')) {

--- a/src/graphql/DiscountApplicationFragment.graphql
+++ b/src/graphql/DiscountApplicationFragment.graphql
@@ -20,7 +20,7 @@ fragment DiscountApplicationFragment on DiscountApplication {
     applicable
   }
   ... on ScriptDiscountApplication {
-    description
+    title
   }
   ... on AutomaticDiscountApplication {
     title

--- a/src/graphql/VariantFragment.graphql
+++ b/src/graphql/VariantFragment.graphql
@@ -6,24 +6,6 @@ fragment VariantFragment on ProductVariant {
     amount
     currencyCode
   }
-  presentmentPrices(first: 20) {
-    pageInfo {
-      hasNextPage
-      hasPreviousPage
-    }
-    edges {
-      node {
-        price {
-          amount
-          currencyCode
-        }
-        compareAtPrice {
-          amount
-          currencyCode
-        }
-      }
-    }
-  }
   weight
   available: availableForSale
   sku

--- a/src/graphql/shopQuery.graphql
+++ b/src/graphql/shopQuery.graphql
@@ -1,6 +1,5 @@
 query {
   shop {
-    currencyCode
     paymentSettings {
       enabledPresentmentCurrencies
     }

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -9,7 +9,7 @@ suite('client-test', () => {
   const config = {
     domain: 'sendmecats.myshopify.com',
     storefrontAccessToken: 'abc123',
-    apiVersion: '2021-10'
+    apiVersion: '2022-01'
   };
 
   test('it instantiates a GraphQL client with the given config', () => {

--- a/test/product-helpers-test.js
+++ b/test/product-helpers-test.js
@@ -6,7 +6,7 @@ import singleProductFixture from '../fixtures/product-fixture';
 import types from '../schema.json';
 
 suite('product-helpers-test', () => {
-  const graphQLClient = new GraphQLJSClient(types, {url: 'https://sendmecats.myshopify.com/api/2021-10/graphql'});
+  const graphQLClient = new GraphQLJSClient(types, {url: 'https://sendmecats.myshopify.com/api/2022-01/graphql'});
   const query = productNodeQuery(graphQLClient)
     .definitions
     .find((definition) => definition.operationType === 'query');


### PR DESCRIPTION
Update the SDK to use `Storefront API v2022-01`. Also removed old deprecated fields from the predefined graphQL queries that are now unavailable in the `2022-01` API.

Fields that were changed are:
* Replaced `description` with `title` in `ScriptDiscountApplication` typed `value` object in discount application fragment
* Remove `currencyCode` from shop fragment
* Remove `presentmentPrices` from product variant fragment