### PR TITLE
Add support for ProductVariant.availableForSale

### DIFF
--- a/fixtures/paginated-variants-fixtures.js
+++ b/fixtures/paginated-variants-fixtures.js
@@ -13,6 +13,7 @@ export const secondPageVariantsFixture = {
             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNjA0MH0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc3OTA2NjQ=",
+              "availableForSale": true,
               "title": "Extra Fluffy",
               "price": "0.00",
               "priceV2": {
@@ -62,6 +63,7 @@ export const thirdPageVariantsFixture = {
             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNjEwNH0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4NTk3MjA=",
+              "availableForSale": true,
               "title": "Mega Fluff",
               "price": "0.00",
               "priceV2": {

--- a/fixtures/product-with-paginated-variants-fixture.js
+++ b/fixtures/product-with-paginated-variants-fixture.js
@@ -37,6 +37,7 @@ export default {
             "cursor": "eyJsYXN0X2lkIjoyNTYwMjIzNTk3Nn0=",
             "node": {
               "id": "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0SW1hZ2UvMTgyMTc4MTk0MDA=",
+              "availableForSale": true,
               "price": "0.00",
               "priceV2": {
                 "amount": "0.00",

--- a/src/graphql/VariantFragment.graphql
+++ b/src/graphql/VariantFragment.graphql
@@ -7,6 +7,7 @@ fragment VariantFragment on ProductVariant {
     currencyCode
   }
   weight
+  availableForSale
   available: availableForSale
   sku
   compareAtPrice


### PR DESCRIPTION
Was scratchin' my head as to why [ProductVariant.availableForSale](https://shopify.dev/api/storefront/2021-10/objects/ProductVariant) was returning `undefined`. It's because [it's aliased as `available`](https://github.com/sshaw/js-buy-sdk/blob/55d2e5411ee43a0cbf71b0de650bbc46a43303b6/src/graphql/VariantFragment.graphql#L11). Maybe there's a reason? 

On the testing side given what's currently there not sure what to do. 