### PR TITLE
Remove MoneyFragment

### DIFF
--- a/src/graphql/AppliedGiftCardFragment.graphql
+++ b/src/graphql/AppliedGiftCardFragment.graphql
@@ -1,18 +1,23 @@
 fragment AppliedGiftCardFragment on AppliedGiftCard {
   amountUsed {
-    ...MoneyFragment
+    amount
+    currencyCode
   }
   amountUsedV2: amountUsed {
-    ...MoneyFragment
+    amount
+    currencyCode
   }
   balance {
-    ...MoneyFragment
+    amount
+    currencyCode
   }
   balanceV2: balance {
-    ...MoneyFragment
+    amount
+    currencyCode
   }
   presentmentAmountUsed {
-    ...MoneyFragment
+    amount
+    currencyCode
   }
   id
   lastCharacters

--- a/src/graphql/CheckoutFragment.graphql
+++ b/src/graphql/CheckoutFragment.graphql
@@ -24,10 +24,12 @@ fragment CheckoutFragment on Checkout {
   requiresShipping
   note
   paymentDue {
-    ...MoneyFragment
+    amount
+    currencyCode
   }
   paymentDueV2: paymentDue {
-    ...MoneyFragment
+    amount
+    currencyCode
   }
   webUrl
   orderStatusUrl
@@ -35,25 +37,32 @@ fragment CheckoutFragment on Checkout {
   taxesIncluded
   currencyCode
   totalTax {
-    ...MoneyFragment
+    amount
+    currencyCode
   }
   totalTaxV2: totalTax {
-    ...MoneyFragment
+    amount
+    currencyCode
   }
   lineItemsSubtotalPrice {
-    ...MoneyFragment
+    amount
+    currencyCode
   }
   subtotalPrice {
-    ...MoneyFragment
+    amount
+    currencyCode
   }
   subtotalPriceV2: subtotalPrice {
-    ...MoneyFragment
+    amount
+    currencyCode
   }
   totalPrice {
-    ...MoneyFragment
+    amount
+    currencyCode
   }
   totalPriceV2: totalPrice {
-    ...MoneyFragment
+    amount
+    currencyCode
   }
   completedAt
   createdAt
@@ -79,10 +88,12 @@ fragment CheckoutFragment on Checkout {
   shippingLine {
     handle
     price {
-      ...MoneyFragment
+      amount
+      currencyCode
     }
     priceV2: price {
-      ...MoneyFragment
+      amount
+      currencyCode
     }
     title
   }
@@ -95,35 +106,45 @@ fragment CheckoutFragment on Checkout {
     processedAt
     orderNumber
     subtotalPrice {
-      ...MoneyFragment
+      amount
+      currencyCode
     }
     subtotalPriceV2: subtotalPrice {
-      ...MoneyFragment
+      amount
+      currencyCode
     }
     totalShippingPrice {
-      ...MoneyFragment
+      amount
+      currencyCode
     }
     totalShippingPriceV2: totalShippingPrice {
-      ...MoneyFragment
+      amount
+      currencyCode
     }
     totalTax {
-      ...MoneyFragment
+      amount
+      currencyCode
     }
     totalTaxV2: totalTax {
-      ...MoneyFragment
+      amount
+      currencyCode
     }
     totalPrice {
-      ...MoneyFragment
+      amount
+      currencyCode
     }
     totalPriceV2: totalPrice {
-      ...MoneyFragment
+      amount
+      currencyCode
     }
     currencyCode
     totalRefunded {
-      ...MoneyFragment
+      amount
+      currencyCode
     }
-    totalRefundedV2: totalRefunded {
-      ...MoneyFragment
+    totalRefundedV2: totalRefunded{
+      amount
+      currencyCode
     }
     customerUrl
     shippingAddress {
@@ -170,7 +191,8 @@ fragment CheckoutFragment on Checkout {
         }
         discountAllocations {
           allocatedAmount {
-            ...MoneyFragment
+            amount
+            currencyCode
           }
           discountApplication {
             ...DiscountApplicationFragment

--- a/src/graphql/DiscountApplicationFragment.graphql
+++ b/src/graphql/DiscountApplicationFragment.graphql
@@ -4,7 +4,8 @@ fragment DiscountApplicationFragment on DiscountApplication {
   targetType
   value {
     ... on MoneyV2 {
-      ...MoneyFragment
+      amount
+      currencyCode
     }
     ... on PricingPercentageValue {
       percentage

--- a/src/graphql/MoneyFragment.graphql
+++ b/src/graphql/MoneyFragment.graphql
@@ -1,4 +1,0 @@
-fragment MoneyFragment on MoneyV2 {
-  amount
-  currencyCode
-}

--- a/src/graphql/VariantFragment.graphql
+++ b/src/graphql/VariantFragment.graphql
@@ -3,20 +3,24 @@ fragment VariantFragment on ProductVariant {
   id
   title
   price {
-    ...MoneyFragment
+    amount
+    currencyCode
   }
   priceV2: price {
-    ...MoneyFragment
+    amount
+    currencyCode
   }
   weight
   available: availableForSale
   sku
   compareAtPrice {
-      ...MoneyFragment
-    }
-  compareAtPriceV2: compareAtPrice {
-    ...MoneyFragment
+    amount
+    currencyCode
   }
+  compareAtPriceV2: compareAtPrice {
+  amount
+  currencyCode
+}
   image {
     id
     src: url
@@ -29,8 +33,9 @@ fragment VariantFragment on ProductVariant {
     value
   }
   unitPrice {
-    ...MoneyFragment
-  }
+  amount
+  currencyCode
+}
   unitPriceMeasurement {
     measuredType
     quantityUnit


### PR DESCRIPTION
Currently, `graphql-js-client` will add multiple definitions of the common `MoneyFragment` if the GQL operation contains multiple fragments that uses this common fragment. 

To fix this, we'll remove this common fragment and replace all instances of `MoneyFragment` with the `MoneyV2` object fields.

Fixes #919 and #920