### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ npm install shopify-buy
 There is a minified UMD build of the latest release available via CDN (see the [Changelog](https://github.com/Shopify/js-buy-sdk/blob/master/CHANGELOG.md) for details about the latest release):
 
 ```html
-<script src="http://sdks.shopifycdn.com/js-buy-sdk/v2/latest/index.umd.min.js"></script>
+<script src="https://sdks.shopifycdn.com/js-buy-sdk/v2/latest/index.umd.min.js"></script>
 ```
 
 If you **don't** want to use the latest version, you can use a specific older release version:


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1oIK7s4OVFkUxAVFcmwdBLQ99IHQoA%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=speXga3)

- Mixed content blocking is to serve all the content as HTTPS instead of HTTP. Network calls were getting blocked due to missing 's'
- CDN URL with v2 had HTTP instead of HTTPS.