### PR TITLE
Add additional merchandise GraphQL in CartLineFragment fields to closer match VariantFragment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ secrets.json
 
 # VSCode settings
 .vscode
+
+# PHPStorm settings
+.idea

--- a/src/graphql/CartLineFragment.graphql
+++ b/src/graphql/CartLineFragment.graphql
@@ -3,6 +3,33 @@ fragment CartLineFragment on CartLine {
   merchandise {
     ... on ProductVariant {
       id
+      title
+      image {
+        id
+        src: url
+        altText
+        width
+        height
+      }
+      product {
+        id
+        handle
+        title
+      }
+      weight
+      available: availableForSale
+      sku
+      selectedOptions {
+        name
+        value
+      }
+      unitPriceMeasurement {
+        measuredType
+        quantityUnit
+        quantityValue
+        referenceUnit
+        referenceValue
+      }
     }
   }
   quantity


### PR DESCRIPTION
Hello! Not sure on the status of the `sd-cart` branch, but it currently appears to be the only way to continue using js-buy-sdk with support for the Cart API.

I'm working on a migrating a site from using Checkout to Cart, and one thing we rely on is getting back a certain amount of line item data back from our Storefront API calls, including image URL and product title. The Checkout [VariantFragment](https://github.com/Shopify/js-buy-sdk/blob/main/src/graphql/VariantFragment.graphql) in the `main` branch ensured we got the data we needed. With that required data having moved into the `ProductVariant` object AKA the `merchandise` field, the [CartLineFragment](https://github.com/Shopify/js-buy-sdk/blob/sd-cart/src/graphql/CartLineFragment.graphql) is now only returning an ID. I've updated this to include the values originally present in `VariantFragment`.

Perhaps there's another way to retrieve this data using `client.graphQLClient.query` but with `...CartFragment` being the mainstay for all mutation return values, this doesn't seem possible.