### PR TITLE
Update CartLineFragment to query on BaseCartLine interface

### DIFF
--- a/src/graphql/CartLineFragment.graphql
+++ b/src/graphql/CartLineFragment.graphql
@@ -1,4 +1,4 @@
-fragment CartLineFragment on CartLine {
+fragment CartLineFragment on BaseCartLine {
   id
   merchandise {
     ... on ProductVariant {


### PR DESCRIPTION
Hi there!

While upgrading to `shopify-buy@3` my team noticed that the SDK didn't support [ComponentizableCartLine](https://shopify.dev/docs/api/storefront/2024-07/objects/ComponentizableCartLine) cart line items. 

We created a patched version that modifies `CartLineFragment` to query on the [BaseCartLine](https://shopify.dev/docs/api/storefront/2024-07/interfaces/BaseCartLine) interface to support both `CartLine` and `ComponentizableCartLine`.

`ComponentizableCartLine` does have a `lineComponents` property that's not a part of the `BaseCartLine` interface, but it is not required for our needs. This change aligns with the behaviour of v2.

I thought I'd create a PR just in case this change was desired. We're good on our end, although we would prefer to use the official SDK if possible.