### PR TITLE
2 discount bug fixes (multiple discounts + shipping discounts)

### DIFF
--- a/.changeset/cool-swans-wonder.md
+++ b/.changeset/cool-swans-wonder.md
@@ -1,0 +1,5 @@
+---
+"shopify-buy": patch
+---
+
+Fix bug where a shipping discount could appear as if it was a line item discount

--- a/.changeset/tough-phones-sip.md
+++ b/.changeset/tough-phones-sip.md
@@ -1,0 +1,5 @@
+---
+"shopify-buy": patch
+---
+
+Fix bug where adding multiple discount codes to the cart could inadvertently remove some discounts

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ If you migrate to Storefront API Client, there is virtually no use case that can
 | shippingLine     | ⚠️            | Not supported. Defaults to `null`  | Same as above                                                                                                                                                                                                           |
 | taxExempt        | ⚠️            | Not supported. Defaults to `false` | The [Cart API](https://shopify.dev/docs/api/storefront/2025-01/objects/cart) is not tax aware, as taxes are currently handled in the Checkout flow. Remove any existing code depending on this field.               |
 | taxesIncluded    | ⚠️            | Not supported. Defaults to `false` | Same as above                                                                                                                                                                                                           |
+| discountApplications | ✅⚠️          | If a buyer's shipping address is unknown and a shipping discount is applied, shipping discount information is **no longer** returned | In this situation, the [Cart API](https://shopify.dev/docs/api/storefront/2025-01/objects/cart) does not return any information about the value of the shipping discount (eg: whether it's a 100% discount or a $5 off discount)
 
 #### Updated `.checkout` methods
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shopify-buy",
-  "version": "3.0.0",
+  "version": "3.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shopify-buy",
-      "version": "3.0.0",
+      "version": "3.0.6",
       "license": "MIT",
       "devDependencies": {
         "@changesets/cli": "^2.28.1",

--- a/src/utilities/cart-discount-mapping.js
+++ b/src/utilities/cart-discount-mapping.js
@@ -152,43 +152,83 @@ export function discountMapper({cartLineItems, cartDiscountAllocations, cartDisc
     };
   }
 
+  // For each discount allocation, move the code/title field to be inside the discountApplication.
+  // This is because the code/title field is part of the discount allocation for a Cart, but part of
+  // the discount application for a Checkout
+  //
+  // CART EXAMPLE:                                  | CHECKOUT EXAMPLE:
+  // "cart": {                                      | "checkout": {
+  //   "discountAllocations": [                     |   "discountApplications": {
+  //     {                                          |     "nodes": [
+  //       "discountedAmount": {                    |       {
+  //         "amount": "18.0",                      |         "targetSelection": "ALL",
+  //         "currencyCode": "CAD"                  |         "allocationMethod": "EACH",
+  //       },                                       |         "targetType": "SHIPPING_LINE",
+  //       "discountApplication": {                 |         "value": {
+  //         "targetType": "SHIPPING_LINE",         |           "percentage": 100.0
+  //         "allocationMethod": "EACH",            |         },
+  //         "targetSelection": "ALL",              |         "code": "FREESHIPPINGALLCOUNTRIES",
+  //         "value": {                             |         "applicable": true
+  //           "percentage": 100.0                  |       }
+  //         }                                      |     ]
+  //       },                                       |   },
+  //       "code": "FREESHIPPINGALLCOUNTRIES"       | }
+  //     }                                          |
+  //   ]                                            |
+  //   "discountCodes": [                           |
+  //     {                                          |
+  //       "code": "FREESHIPPINGALLCOUNTRIES",      |
+  //       "applicable": true                       |
+  //     }                                          |
+  //   ],                                           |
+  // }                                              |
   convertToCheckoutDiscountApplicationType(cartLineItems, cartDiscountAllocations);
 
+  // While both the Cart and Checkout API return discount allocations for line items and therefore appear similar, they are
+  // substantially different in how they handle order-level discounts.
+  //
+  // The Checkout API ONLY returns discount allocations as a field on line items (for both product-level and order-level discounts).
+  // Shipping discounts are only returned as part of `checkout.discountApplications` (and do NOT have any discount allocations).
+  //
+  // Unlike the Checkout API, the Cart API returns different types of discount allocations in 2 different places:
+  // 1. Discount allocations as a field on line items (for product-level discounts)
+  // 2. Discount allocations as a field on the Cart itself (for order-level discounts and shipping discounts)
+  //
+  // Therefore, to map the Cart API payload to the equivalent Checkout API payload, we need to go through all of the order-level discount
+  // allocations on the *Cart*, and determine which line item the discount is allocated to. But first, we must go through the cart-level
+  // discount allocations to split them into order-level and shipping-level discount allocations.
+  //     - ONLY the order-level discount allocations go onto line items.
+  const [shippingDiscountAllocations, orderLevelDiscountAllocations] = cartDiscountAllocations.reduce((acc, discountAllocation) => {
+    if (discountAllocation.discountApplication.targetType === 'SHIPPING_LINE') {
+      acc[0].push(discountAllocation);
+    } else {
+      acc[1].push(discountAllocation);
+    }
+
+    return acc;
+  }, [[], []]);
   const cartLinesWithAllDiscountAllocations =
     mergeCartOrderLevelDiscountAllocationsToCartLineDiscountAllocations({
       lineItems: cartLineItems,
       orderLevelDiscountAllocationsForLines: findLineIdForEachOrderLevelDiscountAllocation(
         cartLineItems,
-        cartDiscountAllocations
+        orderLevelDiscountAllocations
       )
     });
 
+  // The Cart API and Checkout API have almost identical fields for discount applications, but the `value` field's behaviour (for fixed-amount discounts)
+  // is different.
+  //
+  // With the Checkout API, the `value` field of a discount application is equal to the SUM of all of the `allocatedAmount`s of all of the discount allocations
+  // for that discount.
+  // With the Cart API, the `value` field of a discount application is always equal to the `allocatedAmount` of the discount allocation that the discount
+  // application is inside of. Therefore, to map this to the equivalent Checkout API payload, we need to find all of the discount allocations for the same
+  // discount, and sum up all of the allocated amounts to determine the TOTAL value of the discount.
   const discountIdToDiscountApplicationMap = generateDiscountApplications(
     cartLinesWithAllDiscountAllocations,
+    shippingDiscountAllocations,
     cartDiscountCodes
   );
-
-  cartDiscountCodes.forEach(({code, codeIsApplied}) => {
-    if (!codeIsApplied) { return; }
-
-    // Check if the code exists in the map (case-insensitive)
-    let found = false;
-
-    for (const [key] of discountIdToDiscountApplicationMap) {
-      if (key.toLowerCase() === code.toLowerCase()) {
-        found = true;
-        break;
-      }
-    }
-    if (!found) {
-      throw new Error(
-        `Discount code ${code} not found in discount application map. 
-        Discount application map: ${JSON.stringify(
-          discountIdToDiscountApplicationMap
-        )}`
-      );
-    }
-  });
 
   return {
     discountApplications: Array.from(
@@ -222,7 +262,7 @@ function mergeCartOrderLevelDiscountAllocationsToCartLineDiscountAllocations({
   });
 }
 
-function generateDiscountApplications(cartLinesWithAllDiscountAllocations, discountCodes) {
+function generateDiscountApplications(cartLinesWithAllDiscountAllocations, shippingDiscountAllocations, discountCodes) {
   const discountIdToDiscountApplicationMap = new Map();
 
   if (!cartLinesWithAllDiscountAllocations) { return discountIdToDiscountApplicationMap; }
@@ -233,6 +273,10 @@ function generateDiscountApplications(cartLinesWithAllDiscountAllocations, disco
     discountAllocations.forEach((discountAllocation) => {
       createCheckoutDiscountApplicationFromCartDiscountAllocation(discountAllocation, discountIdToDiscountApplicationMap, discountCodes);
     });
+  });
+
+  shippingDiscountAllocations.forEach((discountAllocation) => {
+    createCheckoutDiscountApplicationFromCartDiscountAllocation(discountAllocation, discountIdToDiscountApplicationMap, discountCodes);
   });
 
   return discountIdToDiscountApplicationMap;


### PR DESCRIPTION
**Nicer diffs if you review commit by commit (and without whitespace diffs!) :)**

1. Fix bug with adding multiple discount codes when not all codes are applicable
    - A discount code can be added to a cart but might not be `applicable`. In that case, the code will appear in the `discountCodes` array, but there won't be any discount allocations.
    - Since we were using discount allocations to determine which discount codes existed, we would end up inadvertently removing discount codes that were added but not `applicable`.
2. Fix bug where a shipping discount could appear as a line item discount (ie: fixes https://github.com/Shopify/js-buy-sdk/issues/1040)
    - Our previous discount mapping logic did not properly map shipping discounts - they were treated the same as order-level discounts, but behave differently. 
    - Unlike order-level discounts (which must get mapped onto line items), shipping discounts should ONLY appear in the `checkout.discountApplications` array.
    - Importantly, if a shipping discount has been added but there is no shipping address known, the Cart APIs behave differently than the Checkout APIs and we therefore have no way of knowing the value, target type, etc. This information was returned by the Checkout APIs in the `checkout.discountApplications` array, but now we cannot return shipping discounts in that array if we don't have a shipping address.