### PR TITLE
[DOCS] Delete .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: weekly


### PR DESCRIPTION
Delete the extra dependabot.yml that was added by accident